### PR TITLE
Fixed a compile error in FreeBSD 8.2, using the lates GCC version 4.2.1

### DIFF
--- a/src/cmake/SociConfig.cmake
+++ b/src/cmake/SociConfig.cmake
@@ -35,7 +35,11 @@ else()
         
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC ${SOCI_GCC_CLANG_COMMON_FLAGS}")
     if (CMAKE_COMPILER_IS_GNUCXX)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
+        if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++98")
+        else()
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
+        endif()
     endif()
 
   elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER}" MATCHES "clang")


### PR DESCRIPTION
While working with SOCI, encountered the the following compilation error

> backends/postgresql/CMakeFiles/soci_postgresql.dir/statement.cpp.o
> /usr/local/CN/src/soci/src/backends/postgresql/statement.cpp: In member
> function 'virtual long long int
> soci::postgresql_statement_backend::get_affected_rows()':
> /usr/local/CN/src/soci/src/backends/postgresql/statement.cpp:448:
> error:
> 'strtoll' was not declared in this scope

The solution was to remove '--std=c++98' and replace it with '--std=gnu++98'
