### PR TITLE
SQLite database path may contain spaces if enclosed in quotes.

### DIFF
--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -51,6 +51,25 @@ sqlite3_session_backend::sqlite3_session_backend(
         std::string key, val;
         std::getline(ssconn, key, '=');
         std::getline(ssconn, val, ' ');
+
+        if (val.size()>0 && val[0]=='\"')
+        {
+            std::string quotedVal = val.erase(0, 1);
+
+            if (quotedVal[quotedVal.size()-1] ==  '\"')
+            {
+                quotedVal.erase(val.size()-1);
+            }
+            else // space inside value string
+            {
+                std::getline(ssconn, val, '\"');
+                quotedVal = quotedVal + " " + val;
+                std::getline(ssconn, std::string(), ' ');
+            }     
+
+            val = quotedVal;
+        }
+
         if ("dbname" == key || "db" == key)
         {
             dbname = val;


### PR DESCRIPTION
I ran into a problem with openning a connection to SQLite database if database path contains spaces and another option e.g. timeout is set.
It tuned out that problem has to do with parsing connection string parameters which is splitted by spaces.
So if database path contains spaces parsing failes.
This patch fixes this problem.
