### PR TITLE
cmake: FindSQLite3 - add handling of SQLITE_ROOT_DIR

### DIFF
--- a/src/cmake/modules/FindSQLite3.cmake
+++ b/src/cmake/modules/FindSQLite3.cmake
@@ -31,7 +31,7 @@ find_path(SQLITE3_INCLUDE_DIR
   ${SQLITE_ROOT_DIR}/include
   $ENV{OSGEO4W_ROOT}/include)
 
-set(SQLITE3_NAMES sqlite3)
+set(SQLITE3_NAMES sqlite3_i sqlite3)
 find_library(SQLITE3_LIBRARY
   NAMES ${SQLITE3_NAMES}
   PATHS


### PR DESCRIPTION
- removed special WIN32 case
- added searching in ENV{SQLITE_ROOT} and SQLITE_ROOT_DIR (for -DSQLITE_ROOT_DIR=<path>)
