### PR TITLE
backends/oracle: support working in multithreaded programs

### DIFF
--- a/src/backends/oracle/session.cpp
+++ b/src/backends/oracle/session.cpp
@@ -29,7 +29,8 @@ oracle_session_backend::oracle_session_backend(std::string const & serviceName,
     sword res;
 
     // create the environment
-    res = OCIEnvCreate(&envhp_, OCI_DEFAULT, 0, 0, 0, 0, 0, 0);
+    res = OCIEnvCreate(&envhp_, OCI_THREADED | OCI_ENV_NO_MUTEX,
+        0, 0, 0, 0, 0, 0);
     if (res != OCI_SUCCESS)
     {
         throw soci_error("Cannot create environment");


### PR DESCRIPTION
OCI_THREADED ensures that shared OCI data is properly protected.

OCI_ENV_NO_MUTEX avoids using mutexes when there are no concurrent
accesses to a session, which is the multithreading model that SOCI
employs.

More details:
http://docs.oracle.com/cd/B10501_01/appdev.920/a96584/oci15re4.htm
