### PR TITLE
FindODBC.cmake: rename ODBC_INCLUDE_DIRECTORIES to ODBC_INCLUDE_DIR

### DIFF
--- a/doc/installation.html
+++ b/doc/installation.html
@@ -140,7 +140,7 @@
   <td>Should CMake try to detect ODBC libraries. On Unix systems, CMake tries to find <a href="http://www.unixodbc.org/">unixODBC</a> or <a href="http://www.iodbc.org/">iODBC</a> implementations.</td>
 </tr>
 <tr>
-  <td class="variable-name">ODBC_INCLUDE_DIRECTORIES</td>
+  <td class="variable-name">ODBC_INCLUDE_DIR</td>
   <td class="variable-type">string</td>
   <td>Path to ODBC implementation include directories where CMake should look for sql.h header.</td>
 </tr>

--- a/src/cmake/modules/FindODBC.cmake
+++ b/src/cmake/modules/FindODBC.cmake
@@ -9,7 +9,7 @@
 # those yourself.
 #  
 # This module defines
-# ODBC_INCLUDE_DIRECTORIES, where to find sql.h
+# ODBC_INCLUDE_DIR, where to find sql.h
 # ODBC_LIBRARIES, the libraries to link against to use ODBC
 # ODBC_FOUND.  If false, you cannot build anything that requires MySQL.
 
@@ -18,7 +18,7 @@
 
 set(ODBC_FOUND FALSE)
 
-find_path(ODBC_INCLUDE_DIRECTORIES sql.h
+find_path(ODBC_INCLUDE_DIR sql.h
   /usr/include
   /usr/include/odbc
   /usr/local/include
@@ -46,12 +46,12 @@ find_library(ODBC_LIBRARY
 )
 
 if(ODBC_LIBRARY)
-  if(ODBC_INCLUDE_DIRECTORIES)
+  if(ODBC_INCLUDE_DIR)
     set( ODBC_FOUND 1 )
   endif()
 endif()
 
 set(ODBC_LIBRARIES ${ODBC_LIBRARY})
 
-mark_as_advanced(ODBC_FOUND ODBC_LIBRARY ODBC_EXTRA_LIBRARIES ODBC_INCLUDE_DIRECTORIES)
+mark_as_advanced(ODBC_FOUND ODBC_LIBRARY ODBC_EXTRA_LIBRARIES ODBC_INCLUDE_DIR)
 


### PR DESCRIPTION
This matches the convention used by all other FindXXX modules and is
compatible with soci_backend() macro.

Resolves issue #32.
