### PR TITLE
qualify strtoull/strtoll with std namespace

### DIFF
--- a/src/backends/oracle/standard-into-type.cpp
+++ b/src/backends/oracle/standard-into-type.cpp
@@ -185,7 +185,7 @@ void oracle_standard_into_type_backend::post_fetch(
             if (indOCIHolder_ != -1)
             {
                 long long *v = static_cast<long long *>(data_);
-                *v = strtoll(buf_, NULL, 10);
+                *v = std::strtoll(buf_, NULL, 10);
             }
         }
         else if (type_ == x_unsigned_long_long)
@@ -193,7 +193,7 @@ void oracle_standard_into_type_backend::post_fetch(
             if (indOCIHolder_ != -1)
             {
                 unsigned long long *v = static_cast<unsigned long long *>(data_);
-                *v = strtoull(buf_, NULL, 10);
+                *v = std::strtoull(buf_, NULL, 10);
             }
         }
         else if (type_ == x_stdtm)

--- a/src/backends/oracle/standard-use-type.cpp
+++ b/src/backends/oracle/standard-use-type.cpp
@@ -343,7 +343,7 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
             if (readOnly_)
             {
                 long long const original = *static_cast<long long *>(data_);
-                long long const bound = strtoll(buf_, NULL, 10);
+                long long const bound = std::strtoll(buf_, NULL, 10);
 
                 if (original != bound)
                 {
@@ -355,7 +355,7 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
             if (readOnly_)
             {
                 unsigned long long const original = *static_cast<unsigned long long *>(data_);
-                unsigned long long const bound = strtoull(buf_, NULL, 10);
+                unsigned long long const bound = std::strtoull(buf_, NULL, 10);
 
                 if (original != bound)
                 {

--- a/src/backends/oracle/vector-into-type.cpp
+++ b/src/backends/oracle/vector-into-type.cpp
@@ -213,7 +213,7 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             {
                 if (indOCIHolderVec_[i] != -1)
                 {
-                    v[i] = strtoll(pos, NULL, 10);
+                    v[i] = std::strtoll(pos, NULL, 10);
                 }
                 pos += colSize_;
             }
@@ -231,7 +231,7 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             {
                 if (indOCIHolderVec_[i] != -1)
                 {
-                    v[i] = strtoull(pos, NULL, 10);
+                    v[i] = std::strtoull(pos, NULL, 10);
                 }
                 pos += colSize_;
             }

--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -451,7 +451,7 @@ long long postgresql_statement_backend::get_affected_rows()
 {
     const char * resultStr = PQcmdTuples(result_);
     char * end;
-    long long result = strtoll(resultStr, &end, 0);
+    long long result = std::strtoll(resultStr, &end, 0);
     if (end != resultStr)
     {
         return result;

--- a/src/backends/sqlite3/standard-into-type.cpp
+++ b/src/backends/sqlite3/standard-into-type.cpp
@@ -107,7 +107,7 @@ void sqlite3_standard_into_type_backend::post_fetch(bool gotData,
         case x_long_long:
             {
                 long long* dest = static_cast<long long*>(data_);
-                *dest = strtoll(buf, NULL, 10);
+                *dest = std::strtoll(buf, NULL, 10);
             }
             break;
         case x_unsigned_long_long:
@@ -136,7 +136,7 @@ void sqlite3_standard_into_type_backend::post_fetch(bool gotData,
 
                 rowid *rid = static_cast<rowid *>(data_);
                 sqlite3_rowid_backend *rbe = static_cast<sqlite3_rowid_backend *>(rid->get_backend());
-                long long val = strtoll(buf, NULL, 10);
+                long long val = std::strtoll(buf, NULL, 10);
                 rbe->value_ = static_cast<unsigned long>(val);
             }
             break;


### PR DESCRIPTION
The included header is cstdlib, not stdlib.h, so global/C versions
can be visible only as a side effect, but it is better to use
proper versions in std::.

This caused a problem at least on FreeBSD.
