### PR TITLE
Bumped version number to 3.2.0

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@ colormsg(_HIBLUE_ "Configuring SOCI:")
 #################################################################################
 include(SociVersion)
 
-soci_version(MAJOR 3 MINOR 1 PATCH 0)
+soci_version(MAJOR 3 MINOR 2 PATCH 0)
 
 #################################################################################
 # Build features and variants


### PR DESCRIPTION
Preparing for SOCI 3.2.0 release, #39 cleared.
