### PR TITLE
For Visual C++, defined std::strtoll in terms of _strtoi64()

### DIFF
--- a/src/core/soci-platform.h
+++ b/src/core/soci-platform.h
@@ -10,6 +10,7 @@
 
 // Portability hacks for Microsoft Visual C++ compiler
 #ifdef _MSC_VER
+#include <stdlib.h>
 
 // Define if you have the vsnprintf variants.
 #if _MSC_VER < 1500
@@ -24,12 +25,16 @@
 // Define if you have the strtoll variants.
 #if _MSC_VER >= 1300
 # define HAVE_STRTOLL 1
-# define strtoll(nptr, endptr, base) _strtoi64(nptr, endptr, base)
+namespace std {
+    inline long long strtoll(char const* str, char** str_end, int base)
+    {
+        return _strtoi64(str, str_end, base);
+    }
+}
 #else
 # undef HAVE_STRTOLL
 # error "Visual C++ versions prior 1300 don't support strtoi64"
 #endif // _MSC_VER >= 1300
-
 #endif // _MSC_VER
 
 #endif // SOCI_PLATFORM_H_INCLUDED


### PR DESCRIPTION
...sue #27 and related to pull request #37.
