### PR TITLE
fixed sqlite3 test // issue #15

### DIFF
--- a/src/backends/sqlite3/test/test-sqlite3.cpp
+++ b/src/backends/sqlite3/test/test-sqlite3.cpp
@@ -273,8 +273,6 @@ struct table_creator_for_test6 : table_creator_base
 
 void test6()
 {
-    std::cout << "test 6 skipped (see issue #15)" << std::endl;
-#if 0
     {
         session sql(backEnd, connectString);
 
@@ -287,25 +285,24 @@ void test6()
 
         statement st1 = (sql.prepare <<
             "update soci_test set val = val + 1");
-        st1.execute(false);
+        st1.execute(true);
 
         assert(st1.get_affected_rows() == 10);
 
         statement st2 = (sql.prepare <<
             "delete from soci_test where val <= 5");
-        st2.execute(false);
+        st2.execute(true);
 
         assert(st2.get_affected_rows() == 5);
 
         statement st3 = (sql.prepare <<
             "update soci_test set val = val + 1");
-        st3.execute(true); // true or false shoudl make no difference, both should lead to load_one()
+        st3.execute(true);
 
         assert(st3.get_affected_rows() == 5);
     }
 
     std::cout << "test 6 passed" << std::endl;
-#endif
 }
 
 


### PR DESCRIPTION
Here the patch for https://github.com/SOCI/soci/issues/15

The issue is follows:

We have 3 code path's of SQLite statement.cpp execute(withDataExchange = false)
1. With false
2. With true
3. Either with false or true but with rows destination not empty

Execute(false) and empty destination will not really execute the statement, but prepare for subsequent fetch() requests.

Execute(true) and empty destination will call back-end execute.

3rd one will call bulk fetch to destination regardless of withDataExchange param.
