### PR TITLE
Improve fixes in pull #5

### DIFF
--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -224,16 +224,22 @@ void session::reconnect()
 
 void session::begin()
 {
+    ensureConnected(backEnd_);
+
     backEnd_->begin();
 }
 
 void session::commit()
 {
+    ensureConnected(backEnd_);
+
     backEnd_->commit();
 }
 
 void session::rollback()
 {
+    ensureConnected(backEnd_);
+
     backEnd_->rollback();
 }
 
@@ -366,6 +372,8 @@ bool session::get_last_insert_id(std::string const & sequence, long & value)
 
 std::string session::get_backend_name() const
 {
+    ensureConnected(backEnd_);
+
     return backEnd_->get_backend_name();
 }
 


### PR DESCRIPTION
- Ensure connection is established and backend set for session (thanks
  to @kzeslaf for reporting this)
- Add test_pull5 to ensure no crash occurs (see Krzysztof's example in
  pull #5 comments)
- Add test0 testing connection ensured
- Add test31 with basic use of connection_pool (no multiple threads,
  sequential use only)
