### PR TITLE
Fix int and long mismatch for vector in ODBC

### DIFF
--- a/src/backends/odbc/standard-into-type.cpp
+++ b/src/backends/odbc/standard-into-type.cpp
@@ -53,7 +53,7 @@ void odbc_standard_into_type_backend::define_by_pos(
         break;
     case x_integer:
         odbcType_ = SQL_C_SLONG;
-        size = sizeof(long);
+        size = sizeof(int);
         break;
     case x_long_long:
         if (use_string_for_bigint())

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -181,9 +181,10 @@ statement_backend::exec_fetch_result
 odbc_statement_backend::fetch(int number)
 {
     numRowsFetched_ = 0;
+    SQLULEN const row_array_size = static_cast<SQLULEN>(number);
 
     SQLSetStmtAttr(hstmt_, SQL_ATTR_ROW_BIND_TYPE, SQL_BIND_BY_COLUMN, 0);
-    SQLSetStmtAttr(hstmt_, SQL_ATTR_ROW_ARRAY_SIZE, (SQLPOINTER)number, 0);
+    SQLSetStmtAttr(hstmt_, SQL_ATTR_ROW_ARRAY_SIZE, (SQLPOINTER)row_array_size, 0);
     SQLSetStmtAttr(hstmt_, SQL_ATTR_ROWS_FETCHED_PTR, &numRowsFetched_, 0);
 
     SQLRETURN rc = SQLFetch(hstmt_);

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -7,6 +7,7 @@
 
 #define SOCI_ODBC_SOURCE
 #include "soci-odbc.h"
+#include <cassert>
 #include <cctype>
 #include <cstdio>
 #include <cstring>
@@ -55,7 +56,8 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
         {
             sqlType = SQL_INTEGER;
             cType = SQL_C_SLONG;
-            size = sizeof(int);
+            size = sizeof(SQLINTEGER);
+            assert(sizeof(SQLINTEGER) == sizeof(int));
             std::vector<int> *vp = static_cast<std::vector<int> *>(data);
             std::vector<int> &v(*vp);
             prepare_indicators(v.size());
@@ -171,7 +173,7 @@ void odbc_vector_use_type_backend::bind_helper(int &position, void *data, exchan
 
     prepare_for_bind(data, size, sqlType, cType);
 
-    SQLINTEGER arraySize = (SQLINTEGER)indHolderVec_.size();
+    SQLULEN const arraySize = static_cast<SQLULEN>(indHolderVec_.size());
     SQLSetStmtAttr(statement_.hstmt_, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)arraySize, 0);
 
     SQLRETURN rc = SQLBindParameter(statement_.hstmt_, static_cast<SQLUSMALLINT>(position++),

--- a/src/core/test/common-tests.h
+++ b/src/core/test/common-tests.h
@@ -741,7 +741,7 @@ void test3()
             }
         }
 
-        // repeated fetch and bulk fetch of int
+        // repeated fetch and bulk fetch of int (4-bytes)
         {
             // create and populate the test table
             auto_table_creator tableCreator(tc_.table_creator_1(sql));
@@ -800,7 +800,6 @@ void test3()
                 {
                     for (std::size_t i = 0; i != vec.size(); ++i)
                     {
-                        std::clog << i2 << " -> " << vec[i] << std::endl;
                         assert(i2 == vec[i]);
                         ++i2;
                     }
@@ -811,13 +810,13 @@ void test3()
             }
         }
 
-        // repeated fetch and bulk fetch of unsigned long
+        // repeated fetch and bulk fetch of unsigned int (4-bytes)
         {
             // create and populate the test table
             auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
-            unsigned long const rowsToTest = 100;
-            unsigned long ul;
+            unsigned int const rowsToTest = 100;
+            unsigned int ul;
             for (ul = 0; ul != rowsToTest; ++ul)
             {
                 sql << "insert into soci_test(ul) values(" << ul << ")";
@@ -828,7 +827,7 @@ void test3()
             assert(count == static_cast<int>(rowsToTest));
 
             {
-                unsigned long ul2 = 0;
+                unsigned int ul2 = 0;
 
                 statement st = (sql.prepare <<
                     "select ul from soci_test order by ul", into(ul));
@@ -842,9 +841,9 @@ void test3()
                 assert(ul2 == rowsToTest);
             }
             {
-                unsigned long ul2 = 0;
+                unsigned int ul2 = 0;
 
-                std::vector<unsigned long> vec(8);
+                std::vector<unsigned int> vec(8);
                 statement st = (sql.prepare <<
                     "select ul from soci_test order by ul", into(vec));
                 st.execute();
@@ -1573,11 +1572,11 @@ void test8()
             assert(v2[3] == 2000000000);
         }
 
-        // test for unsigned long
+        // test for unsigned int
         {
             auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
-            std::vector<unsigned long> v;
+            std::vector<unsigned int> v;
             v.push_back(0);
             v.push_back(1);
             v.push_back(123);
@@ -1585,7 +1584,7 @@ void test8()
 
             sql << "insert into soci_test(ul) values(:ul)", use(v);
 
-            std::vector<unsigned long> v2(4);
+            std::vector<unsigned int> v2(4);
 
             sql << "select ul from soci_test order by ul", into(v2);
             assert(v2.size() == 4);


### PR DESCRIPTION
## Analysis

This is attempt to investigate and solve problems with failing **ODBC** tests after Travis CI switched to Linux VMs from 32-bit to **64-bit** (see Travis CI [build 231](https://travis-ci.org/SOCI/soci/builds/5397230) for details).

Apparently, there is mismatch of C++ types `vector<int>` and `vector<long>` with `use()` and `into()`.

ODBC backend relies on C++ `sizeof` and casting, so mixing 4-byte int with 8-byte long on Linux 64-bit is asking for troubles. AFAIK, ODBC C type `SQL_C_SLONG` is derived from `SQL_INTEGER` which is 4 bytes long. So, defining 8-byte long output with `into()` was corrupting data in memory.
## Calling for review

This commit _may be incomplete_ and serves purpose of illustration of the problem, needs to be reviewed and improved if needed. As the `common-tests.h` have been changed, it is necessary to verify those changes against other backends as well.

---

(Problems of this sort prove that sorting out strong requirements regarding [C++ integer type support](https://github.com/SOCI/soci/wiki/RFC1) is a must. Let's do it in SOCI 4.0.0!)
