### PR TITLE
Fix harmless warning about signed/unsigned comparison.

### DIFF
--- a/src/backends/postgresql/vector-into-type.cpp
+++ b/src/backends/postgresql/vector-into-type.cpp
@@ -169,7 +169,7 @@ void resizevector_(void * p, std::size_t sz)
 
 void postgresql_vector_into_type_backend::resize(std::size_t sz)
 {
-    assert(sz < 10*std::numeric_limits<unsigned short>::max()); // Not a strong constraint, for debugging only. Notice my fix is even worse
+    assert(sz < 10u*std::numeric_limits<unsigned short>::max()); // Not a strong constraint, for debugging only. Notice my fix is even worse
 
     switch (type_)
     {


### PR DESCRIPTION
MSVC (and probably other compilers too) gave a warning about comparing size_t
argument of postgresql_vector_into_type_backend::resize() with the expression
that became integer after the change of 29cb6c7e, so make this expression
unsigned again.
