### PR TITLE
Implement session::get_next_sequence_value() for PostgreSQL backend.

### DIFF
--- a/src/backends/postgresql/session.cpp
+++ b/src/backends/postgresql/session.cpp
@@ -8,6 +8,7 @@
 #define SOCI_POSTGRESQL_SOURCE
 #include "soci-postgresql.h"
 #include "error.h"
+#include "session.h"
 #include <connection-parameters.h>
 #include <libpq/libpq-fs.h> // libpq
 #include <cctype>
@@ -102,6 +103,14 @@ void postgresql_session_backend::deallocate_prepared_statement(
 
     hard_exec(conn_, query.c_str(),
         "Cannot deallocate prepared statement.");
+}
+
+bool postgresql_session_backend::get_next_sequence_value(
+    session & s, std::string const & sequence, long & value)
+{
+    s << "select nextval('" + sequence + "')", into(value);
+
+    return true;
 }
 
 void postgresql_session_backend::clean_up()

--- a/src/backends/postgresql/soci-postgresql.h
+++ b/src/backends/postgresql/soci-postgresql.h
@@ -239,6 +239,9 @@ struct postgresql_session_backend : details::session_backend
 
     void deallocate_prepared_statement(const std::string & statementName);
 
+    virtual bool get_next_sequence_value(session & s,
+        std::string const & sequence, long & value);
+
     virtual std::string get_backend_name() const { return "postgresql"; }
 
     void clean_up();


### PR DESCRIPTION
Use the same actual implementation as for the ODBC backend when using
PostgreSQL driver, i.e. "select nextval(sequence-name)".
