### PR TITLE
Don't allow exceptions escape from postgresql_statement_backend dtor.

### DIFF
--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -43,7 +43,19 @@ postgresql_statement_backend::postgresql_statement_backend(
 postgresql_statement_backend::~postgresql_statement_backend()
 {
     if (statementName_.empty() == false)
-        session_.deallocate_prepared_statement(statementName_);
+    {
+        try
+        {
+            session_.deallocate_prepared_statement(statementName_);
+        }
+        catch (...)
+        {
+            // Don't allow exceptions to escape from dtor. Suppressing them is
+            // not ideal, but terminating the program, as would happen if we're
+            // already unwinding the stack because of a previous exception,
+            // would be even worse.
+        }
+    }
 }
 
 void postgresql_statement_backend::alloc()


### PR DESCRIPTION
I'm not totally sure about this one, there may (must?) be a better way of dealing with this, perhaps by remembering if we're inside a transaction and not deallocating the statement if an error happens in this case (or maybe there is some better way at PG API level? Unfortunately I just don't know it well enough...). But OTOH letting the exceptions escape from the dtor remains a very bad idea (unfortunately this is not the only place where this happens in SOCI...) because aborting the entire application just because of an integrity violation at the database level is not acceptable. So this is probably a good thing to do anyhow.

Commit message:

---

This fixes abnormal program termination if an error happened while executing a
prepared statement: it was then destroyed during stack unwinding and if
deallocating it failed as well, resulting in a call to terminate().

In practice, deallocation seems to always fail with SQL state 25P02 ("current
transaction is aborted, commands ignored until end of transaction block") when
it is executed inside a transaction.
