### PR TITLE
Fixes the compilation of the firebird tests with the backend as a DLL.

### DIFF
--- a/src/backends/firebird/soci-firebird.h
+++ b/src/backends/firebird/soci-firebird.h
@@ -15,9 +15,10 @@
 #   define SOCI_FIREBIRD_DECL __declspec(dllexport)
 #  else
 #   define SOCI_FIREBIRD_DECL __declspec(dllimport)
-#  endif // SOCI_FIREBIRD_SOURCE
-# endif // SOCI_DLL
+#  endif // SOCI_DLL
+# endif // SOCI_FIREBIRD_SOURCE
 #endif // _WIN32
+
 //
 // If SOCI_FIREBIRD_DECL isn't defined yet define it now
 #ifndef SOCI_FIREBIRD_DECL

--- a/src/backends/firebird/test/test-firebird.cpp
+++ b/src/backends/firebird/test/test-firebird.cpp
@@ -21,7 +21,7 @@
 using namespace soci;
 
 std::string connectString;
-soci::backend_factory const &backEnd = firebird;
+soci::backend_factory const &backEnd = *factory_firebird();
 
 // fundamental tests - transactions in Firebird
 void test1()


### PR DESCRIPTION
The global variable for the backend factory can't be accessed directly.
Fixes it by using the function designed for this purpose as other backends do.
