### PR TITLE
Fix the issue #136 across all backends.

### DIFF
--- a/src/backends/db2/factory.cpp
+++ b/src/backends/db2/factory.cpp
@@ -15,10 +15,9 @@ using namespace soci::details;
 
 
 // concrete factory for ODBC concrete strategies
-db2_session_backend * db2_backend_factory::make_session(
-     connection_parameters const & parameters) const
+db2_session_backend * db2_backend_factory::make_session() const
 {
-     return new db2_session_backend(parameters);
+     return new db2_session_backend();
 }
 
 db2_backend_factory const soci::db2;

--- a/src/backends/db2/session.cpp
+++ b/src/backends/db2/session.cpp
@@ -77,9 +77,18 @@ void db2_session_backend::parseConnectString(std::string const &  connectString)
     }   
 }
 
-db2_session_backend::db2_session_backend(
-    connection_parameters const & parameters) :
-        in_transaction(false)
+db2_session_backend::db2_session_backend() :
+    autocommit(false), in_transaction(false), hEnv(NULL), hDbc(NULL)
+{
+}
+
+bool db2_session_backend::opened() const
+{
+    return (hDbc != NULL);
+}
+
+void db2_session_backend::open(
+    connection_parameters const & parameters)
 {
     parseConnectString(parameters.get_connect_string());
     SQLRETURN cliRC = SQL_SUCCESS;
@@ -199,6 +208,8 @@ void db2_session_backend::clean_up()
     SQLDisconnect(hDbc);
     SQLFreeHandle(SQL_HANDLE_DBC,hDbc);
     SQLFreeHandle(SQL_HANDLE_ENV,hEnv);
+    hDbc = NULL;
+    hEnv = NULL;
 }
 
 db2_statement_backend * db2_session_backend::make_statement_backend()

--- a/src/backends/db2/soci-db2.h
+++ b/src/backends/db2/soci-db2.h
@@ -230,9 +230,12 @@ struct db2_blob_backend : details::blob_backend
 
 struct db2_session_backend : details::session_backend
 {
-    db2_session_backend(connection_parameters const& parameters);
+    db2_session_backend();
 
     ~db2_session_backend();
+
+    virtual bool opened() const;
+    virtual void open(connection_parameters const& parameters);
 
     void begin();
     void commit();
@@ -240,7 +243,7 @@ struct db2_session_backend : details::session_backend
 
     std::string get_backend_name() const { return "DB2"; }
 
-    void clean_up();
+    virtual void clean_up();
 
     db2_statement_backend* make_statement_backend();
     db2_rowid_backend* make_rowid_backend();
@@ -262,8 +265,7 @@ struct db2_session_backend : details::session_backend
 struct SOCI_DB2_DECL db2_backend_factory : backend_factory
 {
 	db2_backend_factory() {}
-    db2_session_backend* make_session(
-        connection_parameters const & parameters) const;
+    db2_session_backend* make_session() const;
 };
 
 extern SOCI_DB2_DECL db2_backend_factory const db2;

--- a/src/backends/db2/statement.cpp
+++ b/src/backends/db2/statement.cpp
@@ -35,12 +35,7 @@ void db2_statement_backend::alloc()
 
 void db2_statement_backend::clean_up()
 {
-    SQLRETURN cliRC = SQL_SUCCESS;
-
-    cliRC=SQLFreeHandle(SQL_HANDLE_STMT,hStmt);
-    if (cliRC != SQL_SUCCESS) {
-        throw db2_soci_error(db2_soci_error::sqlState("Statement handle clean-up error",SQL_HANDLE_STMT,hStmt),cliRC);
-    }
+    SQLFreeHandle(SQL_HANDLE_STMT,hStmt);
 }
 
 void db2_statement_backend::prepare(std::string const &  query ,

--- a/src/backends/empty/factory.cpp
+++ b/src/backends/empty/factory.cpp
@@ -17,10 +17,9 @@ using namespace soci;
 using namespace soci::details;
 
 // concrete factory for Empty concrete strategies
-empty_session_backend* empty_backend_factory::make_session(
-     connection_parameters const& parameters) const
+empty_session_backend* empty_backend_factory::make_session() const
 {
-     return new empty_session_backend(parameters);
+     return new empty_session_backend();
 }
 
 empty_backend_factory const soci::empty;

--- a/src/backends/empty/session.cpp
+++ b/src/backends/empty/session.cpp
@@ -16,10 +16,21 @@ using namespace soci;
 using namespace soci::details;
 
 
-empty_session_backend::empty_session_backend(
+empty_session_backend::empty_session_backend()
+    : connected_(false)
+{
+}
+
+bool empty_session_backend::opened() const
+{
+    return connected_;
+}
+
+void empty_session_backend::open(
     connection_parameters const & /* parameters */)
 {
     // ...
+    connected_ = true;
 }
 
 empty_session_backend::~empty_session_backend()
@@ -45,6 +56,7 @@ void empty_session_backend::rollback()
 void empty_session_backend::clean_up()
 {
     // ...
+    connected_ = false;
 }
 
 empty_statement_backend * empty_session_backend::make_statement_backend()

--- a/src/backends/empty/soci-empty.h
+++ b/src/backends/empty/soci-empty.h
@@ -154,9 +154,12 @@ struct empty_blob_backend : details::blob_backend
 
 struct empty_session_backend : details::session_backend
 {
-    empty_session_backend(connection_parameters const& parameters);
+    empty_session_backend();
 
     ~empty_session_backend();
+
+    virtual bool opened() const;
+    virtual void open(connection_parameters const& parameters);
 
     void begin();
     void commit();
@@ -164,17 +167,20 @@ struct empty_session_backend : details::session_backend
 
     std::string get_backend_name() const { return "empty"; }
 
-    void clean_up();
+    virtual void clean_up();
 
     empty_statement_backend* make_statement_backend();
     empty_rowid_backend* make_rowid_backend();
     empty_blob_backend* make_blob_backend();
+
+    // Simulate reconnection
+    bool connected_;
 };
 
 struct SOCI_EMPTY_DECL empty_backend_factory : backend_factory
 {
     empty_backend_factory() {}
-    empty_session_backend* make_session(connection_parameters const& parameters) const;
+    empty_session_backend* make_session() const;
 };
 
 extern SOCI_EMPTY_DECL empty_backend_factory const empty;

--- a/src/backends/firebird/factory.cpp
+++ b/src/backends/firebird/factory.cpp
@@ -11,10 +11,9 @@
 
 using namespace soci;
 
-firebird_session_backend * firebird_backend_factory::make_session(
-    connection_parameters const & parameters) const
+firebird_session_backend * firebird_backend_factory::make_session() const
 {
-    return new firebird_session_backend(parameters);
+    return new firebird_session_backend();
 }
 
 firebird_backend_factory const soci::firebird;

--- a/src/backends/firebird/soci-firebird.h
+++ b/src/backends/firebird/soci-firebird.h
@@ -291,9 +291,12 @@ protected:
 
 struct firebird_session_backend : details::session_backend
 {
-    firebird_session_backend(connection_parameters const & parameters);
+    firebird_session_backend();
 
     ~firebird_session_backend();
+
+    virtual bool opened() const;
+    virtual void open(connection_parameters const& parameters);
 
     virtual void begin();
     virtual void commit();
@@ -304,7 +307,7 @@ struct firebird_session_backend : details::session_backend
 
     virtual std::string get_backend_name() const { return "firebird"; }
 
-    void cleanUp();
+    virtual void clean_up();
 
     virtual firebird_statement_backend * make_statement_backend();
     virtual firebird_rowid_backend * make_rowid_backend();
@@ -323,8 +326,7 @@ struct firebird_session_backend : details::session_backend
 struct firebird_backend_factory : backend_factory
 {
     firebird_backend_factory() {}
-    virtual firebird_session_backend * make_session(
-        connection_parameters const & parameters) const;
+    virtual firebird_session_backend * make_session() const;
 };
 
 extern SOCI_FIREBIRD_DECL firebird_backend_factory const firebird;

--- a/src/backends/firebird/test/test-firebird.cpp
+++ b/src/backends/firebird/test/test-firebird.cpp
@@ -21,7 +21,7 @@
 using namespace soci;
 
 std::string connectString;
-soci::backend_factory const &backEnd = firebird;
+soci::backend_factory const &backEnd = *soci::factory_firebird();
 
 // fundamental tests - transactions in Firebird
 void test1()

--- a/src/backends/mysql/factory.cpp
+++ b/src/backends/mysql/factory.cpp
@@ -20,10 +20,9 @@ using namespace soci::details;
 
 
 // concrete factory for MySQL concrete strategies
-mysql_session_backend * mysql_backend_factory::make_session(
-     connection_parameters const & parameters) const
+mysql_session_backend * mysql_backend_factory::make_session() const
 {
-     return new mysql_session_backend(parameters);
+     return new mysql_session_backend();
 }
 
 mysql_backend_factory const soci::mysql;

--- a/src/backends/mysql/session.cpp
+++ b/src/backends/mysql/session.cpp
@@ -272,7 +272,17 @@ void parse_connect_string(const string & connectString,
 
 } // namespace anonymous
 
-mysql_session_backend::mysql_session_backend(
+mysql_session_backend::mysql_session_backend()
+    : conn_(NULL)
+{
+}
+
+bool mysql_session_backend::opened() const
+{
+    return (conn_ != NULL);
+}
+
+void mysql_session_backend::open(
     connection_parameters const & parameters)
 {
     string host, user, password, db, unix_socket, ssl_ca, ssl_cert, ssl_key,

--- a/src/backends/mysql/soci-mysql.h
+++ b/src/backends/mysql/soci-mysql.h
@@ -228,9 +228,12 @@ struct mysql_blob_backend : details::blob_backend
 
 struct mysql_session_backend : details::session_backend
 {
-    mysql_session_backend(connection_parameters const & parameters);
+    mysql_session_backend();
 
     ~mysql_session_backend();
+
+    virtual bool opened() const;
+    virtual void open(connection_parameters const& parameters);
 
     virtual void begin();
     virtual void commit();
@@ -238,7 +241,7 @@ struct mysql_session_backend : details::session_backend
 
     virtual std::string get_backend_name() const { return "mysql"; }
 
-    void clean_up();
+    virtual void clean_up();
 
     virtual mysql_statement_backend * make_statement_backend();
     virtual mysql_rowid_backend * make_rowid_backend();
@@ -251,8 +254,7 @@ struct mysql_session_backend : details::session_backend
 struct mysql_backend_factory : backend_factory
 {
     mysql_backend_factory() {}
-    virtual mysql_session_backend * make_session(
-        connection_parameters const & parameters) const;
+    virtual mysql_session_backend * make_session() const;
 };
 
 extern SOCI_MYSQL_DECL mysql_backend_factory const mysql;

--- a/src/backends/odbc/factory.cpp
+++ b/src/backends/odbc/factory.cpp
@@ -14,10 +14,9 @@ using namespace soci::details;
 
 
 // concrete factory for ODBC concrete strategies
-odbc_session_backend * odbc_backend_factory::make_session(
-     connection_parameters const & parameters) const
+odbc_session_backend * odbc_backend_factory::make_session() const
 {
-     return new odbc_session_backend(parameters);
+     return new odbc_session_backend();
 }
 
 odbc_backend_factory const soci::odbc;

--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -16,9 +16,18 @@ using namespace soci::details;
 
 char const * soci::odbc_option_driver_complete = "odbc.driver_complete";
 
-odbc_session_backend::odbc_session_backend(
+odbc_session_backend::odbc_session_backend()
+    : henv_(NULL), hdbc_(NULL), product_(prod_uninitialized)
+{
+}
+
+bool odbc_session_backend::opened() const
+{
+    return (hdbc_ != NULL);
+}
+
+void odbc_session_backend::open(
     connection_parameters const & parameters)
-    : henv_(0), hdbc_(0), product_(prod_uninitialized)
 {
     SQLRETURN rc;
 
@@ -244,6 +253,9 @@ void odbc_session_backend::clean_up()
         throw odbc_soci_error(SQL_HANDLE_ENV, henv_,
                             "SQLFreeHandle ENV");
     }
+    henv_ = NULL;
+    hdbc_ = NULL;
+    product_ = prod_uninitialized;
 }
 
 odbc_statement_backend * odbc_session_backend::make_statement_backend()

--- a/src/backends/odbc/soci-odbc.h
+++ b/src/backends/odbc/soci-odbc.h
@@ -265,9 +265,12 @@ struct odbc_blob_backend : details::blob_backend
 
 struct odbc_session_backend : details::session_backend
 {
-    odbc_session_backend(connection_parameters const & parameters);
+    odbc_session_backend();
 
     ~odbc_session_backend();
+
+    virtual bool opened() const;
+    virtual void open(connection_parameters const& parameters);
 
     virtual void begin();
     virtual void commit();
@@ -282,7 +285,7 @@ struct odbc_session_backend : details::session_backend
 
     void reset_transaction();
 
-    void clean_up();
+    virtual void clean_up();
 
     virtual odbc_statement_backend * make_statement_backend();
     virtual odbc_rowid_backend * make_rowid_backend();
@@ -410,8 +413,7 @@ inline bool odbc_standard_type_backend_base::use_string_for_bigint() const
 struct odbc_backend_factory : backend_factory
 {
     odbc_backend_factory() {}
-    virtual odbc_session_backend * make_session(
-        connection_parameters const & parameters) const;
+    virtual odbc_session_backend * make_session() const;
 };
 
 extern SOCI_ODBC_DECL odbc_backend_factory const odbc;

--- a/src/backends/oracle/factory.cpp
+++ b/src/backends/oracle/factory.cpp
@@ -22,102 +22,10 @@
 using namespace soci;
 using namespace soci::details;
 
-// retrieves service name, user name and password from the
-// uniform connect string
-void chop_connect_string(std::string const & connectString,
-    std::string & serviceName, std::string & userName,
-    std::string & password, int & mode, bool & decimals_as_strings)
-{
-    // transform the connect string into a sequence of tokens
-    // separated by spaces, this is done by replacing each first '='
-    // in each original token with space
-    // note: each original token is a key=value pair and only the first
-    // '=' there is replaced with space, so that potential '=' signs
-    // in the value part are left intact
-
-    std::string tmp;
-    bool in_value = false;
-    for (std::string::const_iterator i = connectString.begin(),
-             end = connectString.end(); i != end; ++i)
-    {
-        if (*i == '=' && in_value == false)
-        {
-            // this is the first '=' in the key=value pair
-            tmp += ' ';
-            in_value = true;
-        }
-        else
-        {
-            tmp += *i;
-            if (*i == ' ' || *i == '\t')
-            {
-                // follow with the next key=value pair
-                in_value = false;
-            }
-        }
-    }
-
-    serviceName.clear();
-    userName.clear();
-    password.clear();
-    mode = OCI_DEFAULT;
-    decimals_as_strings = false;
-
-    std::istringstream iss(tmp);
-    std::string key, value;
-    while (iss >> key >> value)
-    {
-        if (key == "service")
-        {
-            serviceName = value;
-        }
-        else if (key == "user")
-        {
-            userName = value;
-        }
-        else if (key == "password")
-        {
-            password = value;
-        }
-        else if (key == "mode")
-        {
-            if (value == "sysdba")
-            {
-                mode = OCI_SYSDBA;
-            }
-            else if (value == "sysoper")
-            {
-                mode = OCI_SYSOPER;
-            }
-            else if (value == "default")
-            {
-                mode = OCI_DEFAULT;
-            }
-            else
-            {
-                throw soci_error("Invalid connection mode.");
-            }
-        }
-        else if (key == "decimals_as_strings")
-        {
-            decimals_as_strings = value == "1" || value == "Y" || value == "y";
-        }
-    }
-}
-
 // concrete factory for Empty concrete strategies
-oracle_session_backend * oracle_backend_factory::make_session(
-     connection_parameters const & parameters) const
+oracle_session_backend * oracle_backend_factory::make_session() const
 {
-    std::string serviceName, userName, password;
-    int mode;
-    bool decimals_as_strings;
-
-    chop_connect_string(parameters.get_connect_string(), serviceName, userName, password,
-            mode, decimals_as_strings);
-
-    return new oracle_session_backend(serviceName, userName, password,
-            mode, decimals_as_strings);
+    return new oracle_session_backend();
 }
 
 oracle_backend_factory const soci::oracle;

--- a/src/backends/oracle/session.cpp
+++ b/src/backends/oracle/session.cpp
@@ -8,6 +8,7 @@
 #define SOCI_ORACLE_SOURCE
 #include "soci-oracle.h"
 #include "error.h"
+#include <connection-parameters.h>
 #include <cctype>
 #include <cstdio>
 #include <cstring>
@@ -22,12 +23,112 @@ using namespace soci;
 using namespace soci::details;
 using namespace soci::details::oracle;
 
-oracle_session_backend::oracle_session_backend(std::string const & serviceName,
-    std::string const & userName, std::string const & password, int mode,
-    bool decimals_as_strings)
-    : envhp_(NULL), srvhp_(NULL), errhp_(NULL), svchp_(NULL), usrhp_(NULL)
-      , decimals_as_strings_(decimals_as_strings)
+// retrieves service name, user name and password from the
+// uniform connect string
+void chop_connect_string(std::string const & connectString,
+    std::string & serviceName, std::string & userName,
+    std::string & password, int & mode, bool & decimals_as_strings)
 {
+    // transform the connect string into a sequence of tokens
+    // separated by spaces, this is done by replacing each first '='
+    // in each original token with space
+    // note: each original token is a key=value pair and only the first
+    // '=' there is replaced with space, so that potential '=' signs
+    // in the value part are left intact
+
+    std::string tmp;
+    bool in_value = false;
+    for (std::string::const_iterator i = connectString.begin(),
+             end = connectString.end(); i != end; ++i)
+    {
+        if (*i == '=' && in_value == false)
+        {
+            // this is the first '=' in the key=value pair
+            tmp += ' ';
+            in_value = true;
+        }
+        else
+        {
+            tmp += *i;
+            if (*i == ' ' || *i == '\t')
+            {
+                // follow with the next key=value pair
+                in_value = false;
+            }
+        }
+    }
+
+    serviceName.clear();
+    userName.clear();
+    password.clear();
+    mode = OCI_DEFAULT;
+    decimals_as_strings = false;
+
+    std::istringstream iss(tmp);
+    std::string key, value;
+    while (iss >> key >> value)
+    {
+        if (key == "service")
+        {
+            serviceName = value;
+        }
+        else if (key == "user")
+        {
+            userName = value;
+        }
+        else if (key == "password")
+        {
+            password = value;
+        }
+        else if (key == "mode")
+        {
+            if (value == "sysdba")
+            {
+                mode = OCI_SYSDBA;
+            }
+            else if (value == "sysoper")
+            {
+                mode = OCI_SYSOPER;
+            }
+            else if (value == "default")
+            {
+                mode = OCI_DEFAULT;
+            }
+            else
+            {
+                throw soci_error("Invalid connection mode.");
+            }
+        }
+        else if (key == "decimals_as_strings")
+        {
+            decimals_as_strings = value == "1" || value == "Y" || value == "y";
+        }
+    }
+}
+
+
+oracle_session_backend::oracle_session_backend()
+    : envhp_(NULL), srvhp_(NULL), errhp_(NULL), svchp_(NULL), usrhp_(NULL)
+    , decimals_as_strings_(false)
+{
+}
+
+bool oracle_session_backend::opened() const
+{
+    return (envhp_ != NULL);
+}
+
+void oracle_session_backend::open(
+    connection_parameters const& parameters)
+{
+    std::string serviceName;
+    std::string userName;
+    std::string password;
+    int mode = 0;
+
+    chop_connect_string(parameters.get_connect_string(), serviceName, userName, password,
+            mode, decimals_as_strings_);
+
     sword res;
 
     // create the environment
@@ -198,6 +299,13 @@ void oracle_session_backend::clean_up()
     }
     if (errhp_) { OCIHandleFree(errhp_, OCI_HTYPE_ERROR); }
     if (envhp_) { OCIHandleFree(envhp_, OCI_HTYPE_ENV);   }
+
+    envhp_ = NULL;
+    srvhp_ = NULL;
+    errhp_ = NULL;
+    svchp_ = NULL;
+    usrhp_ = NULL;
+    decimals_as_strings_ = false;
 }
 
 oracle_statement_backend * oracle_session_backend::make_statement_backend()

--- a/src/backends/oracle/soci-oracle.h
+++ b/src/backends/oracle/soci-oracle.h
@@ -242,13 +242,12 @@ struct oracle_blob_backend : details::blob_backend
 
 struct oracle_session_backend : details::session_backend
 {
-    oracle_session_backend(std::string const & serviceName,
-        std::string const & userName,
-        std::string const & password,
-        int mode,
-        bool decimals_as_strings = false);
+    oracle_session_backend();
 
     ~oracle_session_backend();
+
+    virtual bool opened() const;
+    virtual void open(connection_parameters const& parameters);
 
     virtual void begin();
     virtual void commit();
@@ -256,7 +255,7 @@ struct oracle_session_backend : details::session_backend
 
     virtual std::string get_backend_name() const { return "oracle"; }
 
-    void clean_up();
+    virtual void clean_up();
 
     virtual oracle_statement_backend * make_statement_backend();
     virtual oracle_rowid_backend * make_rowid_backend();
@@ -275,8 +274,7 @@ struct oracle_session_backend : details::session_backend
 struct oracle_backend_factory : backend_factory
 {
 	  oracle_backend_factory() {}
-    virtual oracle_session_backend * make_session(
-        connection_parameters const & parameters) const;
+    virtual oracle_session_backend * make_session() const;
 };
 
 extern SOCI_ORACLE_DECL oracle_backend_factory const oracle;

--- a/src/backends/postgresql/factory.cpp
+++ b/src/backends/postgresql/factory.cpp
@@ -24,10 +24,9 @@ using namespace soci;
 using namespace soci::details;
 
 // concrete factory for Empty concrete strategies
-postgresql_session_backend * postgresql_backend_factory::make_session(
-     connection_parameters const & parameters) const
+postgresql_session_backend * postgresql_backend_factory::make_session() const
 {
-     return new postgresql_session_backend(parameters);
+     return new postgresql_session_backend();
 }
 
 postgresql_backend_factory const soci::postgresql;

--- a/src/backends/postgresql/session.cpp
+++ b/src/backends/postgresql/session.cpp
@@ -30,9 +30,18 @@ using namespace soci;
 using namespace soci::details;
 using namespace soci::details::postgresql;
 
-postgresql_session_backend::postgresql_session_backend(
+postgresql_session_backend::postgresql_session_backend()
+    : statementCount_(0), conn_(NULL)
+{
+}
+
+bool postgresql_session_backend::opened() const
+{
+    return (conn_ != NULL);
+}
+
+void postgresql_session_backend::open(
     connection_parameters const& parameters)
-    : statementCount_(0)
 {
     PGconn* conn = PQconnectdb(parameters.get_connect_string().c_str());
     if (0 == conn || CONNECTION_OK != PQstatus(conn))

--- a/src/backends/postgresql/soci-postgresql.h
+++ b/src/backends/postgresql/soci-postgresql.h
@@ -229,9 +229,12 @@ struct postgresql_blob_backend : details::blob_backend
 
 struct postgresql_session_backend : details::session_backend
 {
-    postgresql_session_backend(connection_parameters const & parameters);
+    postgresql_session_backend();
 
     ~postgresql_session_backend();
+
+    virtual bool opened() const;
+    virtual void open(connection_parameters const& parameters);
 
     virtual void begin();
     virtual void commit();
@@ -241,7 +244,7 @@ struct postgresql_session_backend : details::session_backend
 
     virtual std::string get_backend_name() const { return "postgresql"; }
 
-    void clean_up();
+    virtual void clean_up();
 
     virtual postgresql_statement_backend * make_statement_backend();
     virtual postgresql_rowid_backend * make_rowid_backend();
@@ -257,8 +260,7 @@ struct postgresql_session_backend : details::session_backend
 struct postgresql_backend_factory : backend_factory
 {
     postgresql_backend_factory() {}
-    virtual postgresql_session_backend * make_session(
-        connection_parameters const & parameters) const;
+    virtual postgresql_session_backend * make_session() const;
 };
 
 extern SOCI_POSTGRESQL_DECL postgresql_backend_factory const postgresql;

--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -73,7 +73,8 @@ void postgresql_statement_backend::prepare(std::string const & query,
 
     std::string name;
     int position = 1;
-
+    // Be sure to start a new query
+    query_.clear();
     for (std::string::const_iterator it = query.begin(), end = query.end();
          it != end; ++it)
     {
@@ -170,8 +171,6 @@ void postgresql_statement_backend::prepare(std::string const & query,
 
     if (stType == st_repeatable_query)
     {
-        assert(statementName_.empty());
-
         // Holding the name temporarily in this var because
         // if it fails to prepare it we can't DEALLOCATE it. 
         std::string statementName = session_.get_next_statement_name();

--- a/src/backends/sqlite3/factory.cpp
+++ b/src/backends/sqlite3/factory.cpp
@@ -17,10 +17,9 @@ using namespace soci;
 using namespace soci::details;
 
 // concrete factory for Empty concrete strategies
-sqlite3_session_backend * sqlite3_backend_factory::make_session(
-     connection_parameters const & parameters) const
+sqlite3_session_backend * sqlite3_backend_factory::make_session() const
 {
-     return new sqlite3_session_backend(parameters);
+     return new sqlite3_session_backend();
 }
 
 sqlite3_backend_factory const soci::sqlite3;

--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -41,7 +41,17 @@ void execude_hardcoded(sqlite_api::sqlite3* conn, char const* const query, char 
 } // namespace anonymous
 
 
-sqlite3_session_backend::sqlite3_session_backend(
+sqlite3_session_backend::sqlite3_session_backend()
+	: conn_(NULL)
+{
+}
+
+bool sqlite3_session_backend::opened() const
+{
+    return (conn_ != NULL);
+}
+
+void sqlite3_session_backend::open(
     connection_parameters const & parameters)
 {
     int timeout = 0;
@@ -138,6 +148,7 @@ void sqlite3_session_backend::rollback()
 void sqlite3_session_backend::clean_up()
 {
     sqlite3_close(conn_);
+    conn_ = NULL;
 }
 
 sqlite3_statement_backend * sqlite3_session_backend::make_statement_backend()

--- a/src/backends/sqlite3/soci-sqlite3.h
+++ b/src/backends/sqlite3/soci-sqlite3.h
@@ -234,9 +234,12 @@ private:
 
 struct sqlite3_session_backend : details::session_backend
 {
-    sqlite3_session_backend(connection_parameters const & parameters);
+    sqlite3_session_backend();
 
     ~sqlite3_session_backend();
+
+    virtual bool opened() const;
+    virtual void open(connection_parameters const& parameters);
 
     virtual void begin();
     virtual void commit();
@@ -244,7 +247,7 @@ struct sqlite3_session_backend : details::session_backend
 
     virtual std::string get_backend_name() const { return "sqlite3"; }
 
-    void clean_up();
+    virtual void clean_up();
 
     virtual sqlite3_statement_backend * make_statement_backend();
     virtual sqlite3_rowid_backend * make_rowid_backend();
@@ -256,8 +259,7 @@ struct sqlite3_session_backend : details::session_backend
 struct sqlite3_backend_factory : backend_factory
 {
     sqlite3_backend_factory() {}
-    virtual sqlite3_session_backend * make_session(
-        connection_parameters const & parameters) const;
+    virtual sqlite3_session_backend * make_session() const;
 };
 
 extern SOCI_SQLITE3_DECL sqlite3_backend_factory const sqlite3;

--- a/src/core/soci-backend.h
+++ b/src/core/soci-backend.h
@@ -28,6 +28,7 @@ enum data_type
 enum indicator { i_ok, i_null, i_truncated };
 
 class session;
+class connection_parameters;
 
 namespace details
 {
@@ -225,6 +226,10 @@ public:
     session_backend() {}
     virtual ~session_backend() {}
 
+    virtual bool opened() const = 0;
+    virtual void open(connection_parameters const& parameters) = 0;
+    virtual void clean_up() = 0;
+
     virtual void begin() = 0;
     virtual void commit() = 0;
     virtual void rollback() = 0;
@@ -268,8 +273,7 @@ public:
     backend_factory() {}
     virtual ~backend_factory() {}
 
-    virtual details::session_backend* make_session(
-        connection_parameters const& parameters) const = 0;
+    virtual details::session_backend* make_session() const = 0;
 };
 
 } // namespace soci

--- a/src/core/test/common-tests.h
+++ b/src/core/test/common-tests.h
@@ -3140,6 +3140,7 @@ void test27()
         try
         {
             sql.reconnect();
+            statement st(sql);
             assert(false);
         }
         catch (soci_error const &e)
@@ -3148,9 +3149,12 @@ void test27()
                        "Cannot reconnect without previous connection."));
         }
 
-        // open from empty session
-        sql.open(backEndFactory_, connectString_);
-        sql.close();
+        {
+            // open from empty session
+            sql.open(backEndFactory_, connectString_);
+            statement st(sql);
+            sql.close();
+        }
 
         // reconnecting from closed session
         sql.reconnect();
@@ -3159,6 +3163,7 @@ void test27()
         try
         {
             sql.open(backEndFactory_, connectString_);
+            statement st(sql);
             assert(false);
         }
         catch (soci_error const &e)
@@ -3168,12 +3173,15 @@ void test27()
         }
 
         sql.close();
+        {
+            // open from closed
+            sql.open(backEndFactory_, connectString_);
+            statement st1(sql);
 
-        // open from closed
-        sql.open(backEndFactory_, connectString_);
-
-        // reconnect from already connected session
-        sql.reconnect();
+            // reconnect from already connected session
+            sql.reconnect();
+            statement st2(sql);
+        }
     }
 
     {
@@ -3840,7 +3848,7 @@ void test_issue67()
         }
     }
 
-}; // class common_tests
+}
 
 }; // class common_tests
 


### PR DESCRIPTION
See issue #136

The issue is cause because the session backend gets deleted during reconnect.
This solution simply don't do that.
With this fix session backends gained support for open connections and close them (via clean_up).
Also, it's possible to check if session backend is opened though in very simplistic way that just works. That can be improved in later versions.

No public API was changed and I tried to be conservative as possible with the backend objects.

This is a reasonable complex issue, so reviews are welcome.

I'm targeting soci 3.2.2 with fix pull request.

Please note DB2 backend depend (lightly) on #146 to work properly.
Other small DB2 fix is included in this request.
