### PR TITLE
Explicitly include stdarg.h pulled in by namespace-protected sqlite.h.

### DIFF
--- a/src/backends/sqlite3/soci-sqlite3.h
+++ b/src/backends/sqlite3/soci-sqlite3.h
@@ -23,6 +23,7 @@
 # define SOCI_SQLITE3_DECL
 #endif
 
+#include <stdarg.h>
 #include <vector>
 #include "soci-backend.h"
 


### PR DESCRIPTION
The namespace wrapper around sqlite.h forces the va_list type definition into the same namespace. A latter include of <cstdarg> may therefore break as seen with libc++.
