### PR TITLE
Set noData_ to false while calling execute

### DIFF
--- a/src/backends/oracle/statement.cpp
+++ b/src/backends/oracle/statement.cpp
@@ -76,6 +76,7 @@ statement_backend::exec_fetch_result oracle_statement_backend::execute(int numbe
 
     if (res == OCI_SUCCESS || res == OCI_SUCCESS_WITH_INFO)
     {
+        noData_ = false;
         return ef_success;
     }
     else if (res == OCI_NO_DATA)


### PR DESCRIPTION
fetch sets noData_ to true when OCIStmtFetch returns OCI_NO_DATA, so subsequent
calls to fetch returns ef_no_data immediately. But noData_ is not set to
false again anywhere other than the constructor.

noData_ should be set to false if OCIStmtExecute returns with success.
