### PR TITLE
In Unix System cmake could not find ORACLE_NNZ_LIBRARY for Oracle 12g.li...

### DIFF
--- a/src/cmake/modules/FindOracle.cmake
+++ b/src/cmake/modules/FindOracle.cmake
@@ -38,7 +38,7 @@ if(DEFINED ENV{ORACLE_HOME})
 
   set(ORACLE_OCI_NAMES clntsh libclntsh oci) # Dirty trick might help on OSX, see issues/89
   set(ORACLE_OCCI_NAMES libocci occi oraocci10 oraocci11)
-  set(ORACLE_NNZ_NAMES nnz10 libnnz10 nnz11 libnnz11 ociw32)
+  set(ORACLE_NNZ_NAMES nnz10 libnnz10 nnz11 libnnz11 nnz12 libnnz12 ociw32)
 
   set(ORACLE_LIB_DIR
     ${ORACLE_HOME}


### PR DESCRIPTION
...bnnz12 and nnz12 are added for Oracle 12g backends for finding path correctly.
