### PR TITLE
Update common.h

### DIFF
--- a/src/backends/postgresql/common.h
+++ b/src/backends/postgresql/common.h
@@ -15,6 +15,9 @@
 #include <ctime>
 #include <vector>
 
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
 namespace soci
 {
 
@@ -30,7 +33,7 @@ T string_to_integer(char const * buf)
 {
     long long t(0);
     int n(0);
-    int const converted = std::sscanf(buf, "%lld%n", &t, &n);
+    int const converted = std::sscanf(buf, "%" SCNd64 "%n", &t, &n);
     if (converted == 1 && static_cast<std::size_t>(n) == std::strlen(buf))
     {
         // successfully converted to long long
@@ -75,7 +78,7 @@ T string_to_unsigned_integer(char const * buf)
 {
     unsigned long long t(0);
     int n(0);
-    int const converted = std::sscanf(buf, "%llu%n", &t, &n);
+    int const converted = std::sscanf(buf, "%" SCNu64 "%n", &t, &n);
     if (converted == 1 && static_cast<std::size_t>(n) == std::strlen(buf))
     {
         // successfully converted to unsigned long long


### PR DESCRIPTION
Changed the format argument for function sscanf (using the macros defined in 'inttypes.h') since it was showing a warning when compiled with mingw: (warning: unknown conversion type character 'l' in format too many arguments for format). According to this http://sourceforge.net/p/tdm-gcc/bugs/62/ using lld/llu would not work with 64bit numbers?
This still gives a warning in mingw: (warning: ISO C++ does not support the 'I64' ms_scanf length modifier [-Wformat]). Using the -Wno-pedantic-ms-format flag removes these warnings (http://gcc.gnu.org/bugzilla/show_bug.cgi?id=25502)
Also I get a warning about flag -fPIC: warning: -fPIC ignored for target (all code is position independent) [enabled by default].
