### PR TITLE
Replace sqlite3_prepare with sqlite3_prepare_v2

### DIFF
--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -51,7 +51,7 @@ void sqlite3_statement_backend::prepare(std::string const & query,
     clean_up();
 
     char const* tail = 0; // unused;
-    int const res = sqlite3_prepare(session_.conn_,
+    int const res = sqlite3_prepare_v2(session_.conn_,
                               query.c_str(),
                               static_cast<int>(query.size()),
                               &stmt_,


### PR DESCRIPTION
SQLite3 manual suggests: the sqlite3_prepare_v2() and sqlite3_prepare16_v2() interfaces are recommended for all new programs.
Fixes #188
