### PR TITLE
Specify once_temp_type dtor with noexcept(false)

### DIFF
--- a/src/core/once-temp-type.cpp
+++ b/src/core/once-temp-type.cpp
@@ -35,7 +35,7 @@ once_temp_type & once_temp_type::operator=(once_temp_type const & o)
     return *this;
 }
 
-once_temp_type::~once_temp_type()
+once_temp_type::~once_temp_type() SOCI_ONCE_TEMP_TYPE_NOEXCEPT
 {
     rcst_->dec_ref();
 }

--- a/src/core/once-temp-type.h
+++ b/src/core/once-temp-type.h
@@ -11,6 +11,12 @@
 #include "ref-counted-statement.h"
 #include "prepare-temp-type.h"
 
+#if __cplusplus >= 201103L
+#define SOCI_ONCE_TEMP_TYPE_NOEXCEPT noexcept(false)
+#else
+#define SOCI_ONCE_TEMP_TYPE_NOEXCEPT
+#endif
+
 namespace soci
 {
 
@@ -29,8 +35,8 @@ public:
     once_temp_type(session & s);
     once_temp_type(once_temp_type const & o);
     once_temp_type & operator=(once_temp_type const & o);
-
-    ~once_temp_type();
+    
+    ~once_temp_type() SOCI_ONCE_TEMP_TYPE_NOEXCEPT;
 
     template <typename T>
     once_temp_type & operator<<(T const & t)


### PR DESCRIPTION
This addresses issues due to C++11 changes pointed some time ago by Roger Orr (http://sourceforge.net/mailarchive/message.php?msg_id=26451676).
Fixes #181.
