### PR TITLE
sqlite3: Give error if sqlite3 is already included

### DIFF
--- a/src/backends/sqlite3/soci-sqlite3.h
+++ b/src/backends/sqlite3/soci-sqlite3.h
@@ -42,6 +42,10 @@ namespace sqlite_api
 typedef void (*sqlite3_destructor_type)(void*);
 #endif
 
+#ifdef _SQLITE3_H_
+#error "sqlite3 is already included. You should remove any reference you have to sqlite3 and let SOCI handle the library includes"
+#endif
+
 #include <sqlite3.h>
 
 } // namespace sqlite_api


### PR DESCRIPTION
If <sqlite3.h> is included before soci-sqlite3.h all sqlite3
functions will be in an incorrect namespace (according to soci).
Compilation will fail with very cryptic error messages about
undefined functions. This fix gives a better error message so
the user knows how to fix the issue.
