### PR TITLE
fixed link error for msvc 64 bit

### DIFF
--- a/src/cmake/modules/FindODBC.cmake
+++ b/src/cmake/modules/FindODBC.cmake
@@ -1,13 +1,13 @@
-# 
+#
 # Find the ODBC driver manager includes and library.
-# 
+#
 # ODBC is an open standard for connecting to different databases in a
 # semi-vendor-independent fashion.  First you install the ODBC driver
 # manager.  Then you need a driver for each separate database you want
 # to connect to (unless a generic one works).  VTK includes neither
 # the driver manager nor the vendor-specific drivers: you have to find
 # those yourself.
-#  
+#
 # This module defines
 # ODBC_INCLUDE_DIR, where to find sql.h
 # ODBC_LIBRARIES, the libraries to link against to use ODBC
@@ -27,26 +27,31 @@ find_path(ODBC_INCLUDE_DIR sql.h
   "C:/Program Files (x86)/Windows Kits/8.0/include/um"
   "C:/Program Files (x86)/Microsoft SDKs/Windows/v7.0A/Include"
   "C:/Program Files/ODBC/include"
-  "C:/Program Files/Microsoft SDKs/Windows/v7.0/include" 
-  "C:/Program Files/Microsoft SDKs/Windows/v6.0a/include" 
+  "C:/Program Files/Microsoft SDKs/Windows/v7.0/include"
+  "C:/Program Files/Microsoft SDKs/Windows/v6.0a/include"
   "C:/ODBC/include"
   DOC "Specify the directory containing sql.h."
 )
 
-find_library(ODBC_LIBRARY 
-  NAMES iodbc odbc odbcinst odbc32
-  PATHS
-  /usr/lib
-  /usr/lib/odbc
-  /usr/local/lib
-  /usr/local/lib/odbc
-  /usr/local/odbc/lib
-  "C:/Program Files (x86)/Windows Kits/8.0/Lib/win8/um/x86/"
-  "C:/Program Files (x86)/Microsoft SDKs/Windows/v7.0A/Lib"
-  "C:/Program Files/ODBC/lib"
-  "C:/ODBC/lib/debug"
-  DOC "Specify the ODBC driver manager library here."
-)
+if(MSVC)
+    # msvc knows where to find sdk libs
+    set(ODBC_LIBRARY odbc32)
+else()
+    find_library(ODBC_LIBRARY
+      NAMES iodbc odbc odbcinst odbc32
+      PATHS
+          /usr/lib
+          /usr/lib/odbc
+          /usr/local/lib
+          /usr/local/lib/odbc
+          /usr/local/odbc/lib
+          "C:/Program Files (x86)/Windows Kits/8.0/Lib/win8/um/x86/"
+          "C:/Program Files (x86)/Microsoft SDKs/Windows/v7.0A/Lib"
+          "C:/Program Files/ODBC/lib"
+          "C:/ODBC/lib/debug"
+      DOC "Specify the ODBC driver manager library here."
+    )
+endif()
 
 if(ODBC_LIBRARY)
   if(ODBC_INCLUDE_DIR)


### PR DESCRIPTION
How to reproduce:
- Generate solution or ninja build with x86_64 target for master branch
- cmake .. -G"Visual Studio 11 Win64"
- cmake .. --build . --config Release

Error:

All ODBC targets are failed to link

Log:

4>Build started 16.10.2013 19:40:14.
2>Link:
2>     Creating library C:/WORK/GITHUB/soci/src/build.x86_64/lib/Release/soci_od
bc_3_2.lib and object C:/WORK/GITHUB/soci/src/build.x86_64/lib/Release/soci_odbc
_3_2.exp
4>InitializeBuildStatus:
4>  Touching "soci_odbc_test_mssql_static.dir\Release\soci_odbc_test_mssql_stati
c.unsuccessfulbuild".
4>CustomBuild:
4>  All outputs are up-to-date.
2>vector-use-type.obj : error LNK2001: unresolved external symbol SQLGetDiagRecA

... 

Cause:
FindODBC.cmake done wrong assumption about lib location, while MSVC compiler perfectly knows where to search for odbc32.lib .
