### PR TITLE
Fix in soci::oracle to allow spaces in the params

### DIFF
--- a/src/backends/oracle/factory.cpp
+++ b/src/backends/oracle/factory.cpp
@@ -22,51 +22,70 @@
 using namespace soci;
 using namespace soci::details;
 
+// iterates the string pointed by i, searching for pairs of key value.
+// it returns the position after the value
+std::string::const_iterator get_key_value(std::string::const_iterator & i,
+                                          std::string::const_iterator const & end,
+                                          std::string & key,
+                                          std::string & value)
+{
+    bool in_value = false;
+    bool quoted = false;
+
+    key.clear();
+    value.clear();
+
+    while (i != end)
+    {
+        if (in_value == false)
+        {
+            if (*i == '=')
+            {
+                in_value = true;
+                if (i != end && *(i + 1) == '"')
+                {
+                    quoted = true;
+                    ++i; // jump over the quote
+                }
+            }
+            else if (!isspace(*i))
+            {
+                key += *i;
+            }
+        }
+        else
+        {
+            if ((quoted == true && *i == '"') || (quoted == false && isspace(*i)))
+            {
+                return ++i;
+            }
+            else
+            {
+                value += *i;
+            }
+        }
+        ++i;
+    }
+    return i;
+}
+
 // retrieves service name, user name and password from the
 // uniform connect string
 void chop_connect_string(std::string const & connectString,
     std::string & serviceName, std::string & userName,
     std::string & password, int & mode, bool & decimals_as_strings)
 {
-    // transform the connect string into a sequence of tokens
-    // separated by spaces, this is done by replacing each first '='
-    // in each original token with space
-    // note: each original token is a key=value pair and only the first
-    // '=' there is replaced with space, so that potential '=' signs
-    // in the value part are left intact
-
-    std::string tmp;
-    bool in_value = false;
-    for (std::string::const_iterator i = connectString.begin(),
-             end = connectString.end(); i != end; ++i)
-    {
-        if (*i == '=' && in_value == false)
-        {
-            // this is the first '=' in the key=value pair
-            tmp += ' ';
-            in_value = true;
-        }
-        else
-        {
-            tmp += *i;
-            if (*i == ' ' || *i == '\t')
-            {
-                // follow with the next key=value pair
-                in_value = false;
-            }
-        }
-    }
-
     serviceName.clear();
     userName.clear();
     password.clear();
     mode = OCI_DEFAULT;
     decimals_as_strings = false;
 
-    std::istringstream iss(tmp);
     std::string key, value;
-    while (iss >> key >> value)
+    std::string::const_iterator i = connectString.begin();
+    while (i != connectString.end())
     {
+        i = get_key_value(i, connectString.end(), key, value);
         if (key == "service")
         {
             serviceName = value;


### PR DESCRIPTION
chop_connect_string didn't accept parameters containing spaces inside.
Now, spaces can be used encapsulating the value between quotes.

user=oracle-user password=oracle-password service="(DESCRIPTION = ( ADDRESS= .... ) )"