### PR TITLE
fixed bug with get_affected_rows() and user defined types

### DIFF
--- a/src/backends/mysql/statement.cpp
+++ b/src/backends/mysql/statement.cpp
@@ -155,7 +155,7 @@ mysql_statement_backend::execute(int number)
                     "Binding for use elements must be either by position "
                     "or by name.");
             }
-            long long rowsAffectedBulkTemp = 0;
+            long long rowsAffectedBulkTemp = -1;
             for (int i = 0; i != numberOfExecutions; ++i)
             {
                 std::vector<char *> paramValues;
@@ -233,6 +233,10 @@ mysql_statement_backend::execute(int number)
                     }
                     else
                     {
+			if(rowsAffectedBulkTemp == -1)
+			{
+				rowsAffectedBulkTemp = 0;
+			}
                         rowsAffectedBulkTemp += static_cast<long long>(mysql_affected_rows(session_.conn_));
                     }
                     if (mysql_field_count(session_.conn_) != 0)

--- a/src/backends/mysql/test/test-mysql.cpp
+++ b/src/backends/mysql/test/test-mysql.cpp
@@ -530,6 +530,12 @@ void test7()
         st2.execute(false);
 
         assert(st2.get_affected_rows() == 5);
+
+        MyInt mi(11);
+        statement st3 = (sql.prepare <<
+            "insert into soci_test(val) values(:val)", use(mi));
+        st3.execute();
+        assert(st3.get_affected_rows() == 1);
     }
 
     std::cout << "test 7 passed" << std::endl;


### PR DESCRIPTION
If an user defined type is used get_affected_rows() returns wrong values. See modified test7() in MySQL backend for this bug.