### PR TITLE
Fix compilation of ODBC-specific SOCI header with new include paths.

### DIFF
--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -24,9 +24,9 @@
 #endif
 
 #include <vector>
-#include <soci-backend.h>
+#include "../soci-backend.h"
 #if defined(_MSC_VER) || defined(__MINGW32__)
-#include <soci-platform.h>
+#include "../soci-platform.h"
 #include <windows.h>
 #endif
 #include <sqlext.h> // ODBC


### PR DESCRIPTION
If only soci/include directory is in the compiler include path, including
<soci-backend.h> doesn't compile, as it should be included as
<soci/soci-backend.h> or, as this patch does, "../soci-backend.h", which is
uglier but simpler as it doesn't require changing any SOCI makefiles.
