### PR TITLE
Add helper cstring_to_double() and use it in PostgreSQL backend.

### DIFF
--- a/include/private/soci-cstrtod.h
+++ b/include/private/soci-cstrtod.h
@@ -1,0 +1,51 @@
+//
+// Copyright (C) 2014 Vadim Zeitlin.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_PRIVATE_SOCI_CSTRTOD_H_INCLUDED
+#define SOCI_PRIVATE_SOCI_CSTRTOD_H_INCLUDED
+
+#include "error.h"
+
+#include <locale>
+#include <sstream>
+
+namespace soci
+{
+
+namespace details
+{
+
+// Locale-independent, i.e. always using "C" locale, function for converting
+// strings to numbers.
+//
+// The string must contain a floating point number in "C" locale, i.e. using
+// point as decimal separator, and nothing but it. If it does, the converted
+// number is returned, otherwise an exception is thrown.
+inline
+double cstring_to_double(std::string const & str)
+{
+    using namespace std;
+
+    double d;
+    istringstream is(str);
+    is.imbue(locale::classic());
+    is >> d;
+
+    if (!is || !is.eof())
+    {
+      throw soci_error(string("Cannot convert data: string \"") + str + "\" "
+                       "is not a number.");
+    }
+
+    return d;
+}
+
+} // namespace details
+
+} // namespace soci
+
+#endif // SOCI_PRIVATE_SOCI_CSTRTOD_H_INCLUDED

--- a/src/backends/postgresql/common.cpp
+++ b/src/backends/postgresql/common.cpp
@@ -91,21 +91,3 @@ void soci::details::postgresql::parse_std_tm(char const * buf, std::tm & t)
 
     std::mktime(&t);
 }
-
-double soci::details::postgresql::string_to_double(char const * buf)
-{
-    double t;
-    int n;
-    int const converted = sscanf(buf, "%lf%n", &t, &n);
-    if (converted == 1 && static_cast<std::size_t>(n) == strlen(buf))
-    {
-        // successfully converted to double
-        // and no other characters were found in the buffer
-
-        return t;
-    }
-    else
-    {
-        throw soci_error("Cannot convert data.");
-    }
-}

--- a/src/backends/postgresql/common.h
+++ b/src/backends/postgresql/common.h
@@ -112,9 +112,6 @@ T string_to_unsigned_integer(char const * buf)
     }
 }
 
-// helper function for parsing doubles
-double string_to_double(char const * buf);
-
 // helper function for parsing datetime values
 void parse_std_tm(char const * buf, std::tm & t);
 

--- a/src/backends/postgresql/standard-into-type.cpp
+++ b/src/backends/postgresql/standard-into-type.cpp
@@ -8,6 +8,7 @@
 #define SOCI_POSTGRESQL_SOURCE
 #include <soci-platform.h>
 #include "soci-postgresql.h"
+#include "soci-cstrtod.h"
 #include "common.h"
 #include "rowid.h"
 #include "blob.h"
@@ -125,7 +126,7 @@ void postgresql_standard_into_type_backend::post_fetch(
         case x_double:
             {
                 double * dest = static_cast<double *>(data_);
-                *dest = string_to_double(buf);
+                *dest = cstring_to_double(buf);
             }
             break;
         case x_stdtm:

--- a/src/backends/postgresql/vector-into-type.cpp
+++ b/src/backends/postgresql/vector-into-type.cpp
@@ -8,6 +8,7 @@
 #define SOCI_POSTGRESQL_SOURCE
 #include <soci-platform.h>
 #include "soci-postgresql.h"
+#include "soci-cstrtod.h"
 #include "common.h"
 #include <libpq/libpq-fs.h> // libpq
 #include <cassert>
@@ -131,7 +132,7 @@ void postgresql_vector_into_type_backend::post_fetch(bool gotData, indicator * i
                 break;
             case x_double:
                 {
-                    double const val = string_to_double(buf);
+                    double const val = cstring_to_double(buf);
                     set_invector_(data_, i, val);
                 }
                 break;

--- a/tests/assert/postgresql/test-postgresql.cpp
+++ b/tests/assert/postgresql/test-postgresql.cpp
@@ -406,7 +406,8 @@ void test7()
         }
         catch (soci_error const & e)
         {
-            assert(e.what() == std::string("Cannot convert data."));
+            char const * expectedPrefix = "Cannot convert data";
+            assert(strncmp(e.what(), expectedPrefix, strlen(expectedPrefix)) == 0);
         }
     }
 


### PR DESCRIPTION
Replace PostgreSQL-specific and incorrect string_to_double() function with a
common (i.e. reusable) cstring_to_double() which always interprets the string
as being in "C" locale as this is what the actual strings, retrieved from the
database, use.

---

This should finally fix the problem last discussed 5 years ago in [this thread](https://sourceforge.net/p/soci/mailman/message/22659188/) except that it does it for PostgreSQL and not SQLite. If there are no objections, I'm going to update the patch to also do it for SQLite and MySQL (although I won't be able to test the latter).
