### PR TITLE
Add logger class to allow customizing SOCI logging operations.

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,6 +1,9 @@
 # Logging
 
-SOCI provides a very basic logging facility.
+SOCI provides a flexible, but requiring some effort to use, way to log all
+queries done by the library and a more limited but very simple way to do it.
+
+## Simple logging
 
 The following members of the `session` class support the basic logging functionality:
 
@@ -24,3 +27,34 @@ Each statement logs its query string before the preparation step (whether explic
 Note that each prepared query is logged only once, independent on how many times it is executed.
 
 The `get_last_query` function allows to retrieve the last used query.
+
+
+## Flexible logging using custom loggers
+
+If the above is not enough, it is also possible to log the queries in exactly
+the way you want by deriving your own `my_log_impl` class from
+`soci::logger_impl` and implementing its pure virtual `start_query()` and
+`do_clone()` methods:
+
+    class my_log_impl : public soci::logger_impl
+    {
+    public:
+        virtual void start_query(std::string const & query)
+        {
+            ... log the given query ...
+        }
+
+    private:
+        virtual logger_impl* do_clone() const
+        {
+            return new my_log_impl(...);
+        }
+    };
+
+Then simply pass a new, heap-allocated instance of this class to the `session`
+object:
+
+    soci::session sql(...);
+    sql.set_logger(new my_log_impl(...));
+
+and `start_query()` method of the logger will be called for all queries.

--- a/include/soci/logger.h
+++ b/include/soci/logger.h
@@ -1,0 +1,82 @@
+//
+// Copyright (C) 2014 Vadim Zeitlin
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_LOGGER_H_INCLUDED
+#define SOCI_LOGGER_H_INCLUDED
+
+#include "soci/soci-platform.h"
+
+#include <ostream>
+
+namespace soci
+{
+
+// Allows to customize the logging of database operations performed by SOCI.
+//
+// To do it, derive your own class from logger_impl and override its pure
+// virtual start_query() and do_clone() methods (overriding the other methods
+// is optional), then call session::set_logger() with a logger object using
+// your implementation.
+class SOCI_DECL logger_impl
+{
+public:
+    logger_impl() {}
+    virtual ~logger_impl();
+
+    // Called to indicate that a new query is about to be executed.
+    virtual void start_query(std::string const & query) = 0;
+
+    logger_impl * clone() const;
+
+    // These methods are for compatibility only as they're used to implement
+    // session basic logging support, you should only override them if you want
+    // to use session::set_stream() and similar methods with your custom logger.
+    virtual void set_stream(std::ostream * s);
+    virtual std::ostream * get_stream() const;
+    virtual std::string get_last_query() const;
+
+private:
+    // Override to return a new heap-allocated copy of this object.
+    virtual logger_impl * do_clone() const = 0;
+
+    // Non-copyable
+    logger_impl(logger_impl const &);
+    logger_impl & operator=(logger_impl const &);
+};
+
+
+// A wrapper class representing a logger.
+//
+// Unlike logger_impl, this class has value semantics and can be manipulated
+// easily without any danger of memory leaks or dereferencing a NULL pointer.
+class SOCI_DECL logger
+{
+public:
+    // No default constructor, must always have an associated logger_impl.
+
+    // Create a logger using the provided non-NULL implementation (an exception
+    // is thrown if the pointer is NULL). The logger object takes ownership of
+    // the pointer and will delete it.
+    logger(logger_impl * impl);
+    logger(logger const & other);
+    logger& operator=(logger const & other);
+    ~logger();
+
+    void start_query(std::string const & query) { m_impl->start_query(query); }
+
+    // Methods used for the implementation of session basic logging support.
+    void set_stream(std::ostream * s) { m_impl->set_stream(s); }
+    std::ostream * get_stream() const { return m_impl->get_stream(); }
+    std::string get_last_query() const { return m_impl->get_last_query(); }
+
+private:
+    logger_impl * m_impl;
+};
+
+} // namespace soci
+
+#endif // SOCI_LOGGER_H_INCLUDED

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -12,6 +12,7 @@
 #include "soci/once-temp-type.h"
 #include "soci/query_transformation.h"
 #include "soci/connection-parameters.h"
+#include "soci/logger.h"
 
 // std
 #include <cstddef>
@@ -86,7 +87,17 @@ public:
         set_query_transformation_(qtf);
     }
 
-    // support for basic logging
+    // Support for custom logging of database operations.
+
+    // Set the custom logger to use.
+    void set_logger(logger const & logger);
+
+    // Return the currently used logger, by default, this is an instance of a
+    // standard SOCI logger.
+    logger const & get_logger() const;
+
+
+    // support for basic logging (use set_logger() for more control).
     void set_log_stream(std::ostream * s);
     std::ostream * get_log_stream() const;
 
@@ -182,8 +193,7 @@ private:
     std::ostringstream query_stream_;
     details::query_transformation_function* query_transformation_;
 
-    std::ostream * logStream_;
-    std::string lastQuery_;
+    logger logger_;
 
     connection_parameters lastConnectParameters_;
 

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -1,0 +1,88 @@
+//
+// Copyright (C) 2014 Vadim Zeitlin
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#define SOCI_SOURCE
+#include "soci/logger.h"
+#include "soci/error.h"
+
+using namespace soci;
+
+namespace // anonymous
+{
+
+// Helper to throw from not implemented logger_impl methods.
+void throw_not_supported()
+{
+    throw soci_error("Legacy method not supported by this logger.");
+}
+
+} // namespace anonymous
+
+
+logger_impl * logger_impl::clone() const
+{
+    logger_impl * const impl = do_clone();
+    if (!impl)
+    {
+        throw soci_error("Cloning a logger implementation must work.");
+    }
+
+    return impl;
+}
+
+logger_impl::~logger_impl()
+{
+}
+
+void logger_impl::set_stream(std::ostream * s)
+{
+    throw_not_supported();
+}
+
+std::ostream * logger_impl::get_stream() const
+{
+    throw_not_supported();
+
+    return NULL;
+}
+
+std::string logger_impl::get_last_query() const
+{
+    throw_not_supported();
+
+    return std::string();
+}
+
+
+
+logger::logger(logger_impl * impl)
+    : m_impl(impl)
+{
+    if (!m_impl)
+    {
+        throw soci_error("Null logger implementation not allowed.");
+    }
+}
+
+logger::logger(logger const & other)
+    : m_impl(other.m_impl->clone())
+{
+}
+
+logger& logger::operator=(logger const & other)
+{
+    logger_impl * const implOld = m_impl;
+    m_impl = other.m_impl->clone();
+    delete implOld;
+
+    return *this;
+}
+
+logger::~logger()
+{
+    delete m_impl;
+}

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -38,7 +38,7 @@ logger_impl::~logger_impl()
 {
 }
 
-void logger_impl::set_stream(std::ostream * s)
+void logger_impl::set_stream(std::ostream *)
 {
     throw_not_supported();
 }


### PR DESCRIPTION
No big changes yet, but it is now possible to use a custom logger object which
may do something else than just write the query string passed to it to a
stream.

The old behaviour is preserved by using the standard SOCI logger by default
which does write the query to the stream.

---

This is the first step in addressing #138. This approach should be less disruptive (full backwards compatibility is preserved) than the patch currently there and, eventually, more powerful.
