### PR TITLE
Avoid final_action() call during stack unwinding

### DIFF
--- a/src/core/ref-counted-statement.h
+++ b/src/core/ref-counted-statement.h
@@ -35,16 +35,18 @@ public:
     {
         if (--refCount_ == 0)
         {
-            try
+            if (!std::uncaught_exception())
             {
-                final_action();
+                try
+                {
+                    final_action();
+                }
+                catch (...)
+                {
+                    delete this;
+                    throw;
+                }
             }
-            catch (...)
-            {
-                delete this;
-                throw;
-            }
-
             delete this;
         }
     }


### PR DESCRIPTION
Should fix #256