### PR TITLE
Spelling fix Comiting -> Comitting (Fixes #260)

### DIFF
--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -112,7 +112,7 @@ void odbc_session_backend::commit()
     if (is_odbc_error(rc))
     {
         throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_,
-                         "Commiting");
+                         "Committing");
     }
     reset_transaction();
 }


### PR DESCRIPTION
See issue #260
