### PR TITLE
Two enhancements for SOCI 3.2.3 hotfix, PostgreSQL UUID column support and SQLITE3 error code in exception

### DIFF
--- a/doc/backends/postgresql.html
+++ b/doc/backends/postgresql.html
@@ -33,6 +33,9 @@
 </div>
   <a href="#native">Accessing the Native Database API</a><br />
   <a href="#extensions">Backend-specific Extensions</a><br />
+  <div class="navigation-indented">
+      <a href="#uuid">UUID Data Type</a><br />
+  </div>
   <a href="#options">Configuration options</a><br />
 </div>
 
@@ -213,7 +216,10 @@ sql &lt;&lt; "insert into t(x, y) values($1, $2)", use(i), use(j);
 
 <h3 id="extensions">Backend-specific extensions</h3>
 
-<p>None.</p>
+<h4 id="uuid">uuid Data Type</h4>
+
+<p>The PostgreSQL backend supports working with data stored in columns of type UUID via simple string operations. All string representations of UUID supported by PostgreSQL are accepted on input, the backend will return the standard
+format of UUID on output. See the test <code>test_uuid_column_type_support</code> for usage examples.</p>
 
 <h3 id="options">Configuration options</h3>
 

--- a/doc/backends/sqlite3.html
+++ b/doc/backends/sqlite3.html
@@ -33,6 +33,9 @@
 </div>
   <a href="#native">Accessing the Native Database API</a><br />
   <a href="#extensions">Backend-specific Extensions</a><br />
+  <div class="navigation-indented">
+    <a href="#result">SQLite3 result code support</a><br />
+  </div>
   <a href="#options">Configuration options</a><br />
 </div>
 
@@ -196,7 +199,11 @@ sql &lt;&lt; "insert into t(x, y) values(?, ?)", use(i), use(j);
 
 <h3 id="extensions">Backend-specific extensions</h3>
 
-<p>None.</p>
+<h4 id="result">SQLite3 result code support</h4>
+
+<p>SQLite3 result code is provided via the backend specific <code>sqlite3_soci_error</code>
+class. Catching the backend specific error yields the value of SQLite3 result code via the
+<code>result()</code> method.</p>
 
 <h3 id="options">Configuration options</h3>
 

--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -512,6 +512,7 @@ void postgresql_statement_backend::describe_column(int colNum, data_type & type,
     case 142: // xml
     case 114:  // json
     case 17: // bytea
+    case 2950: // uuid
         type = dt_string;
         break;
 

--- a/src/backends/sqlite3/Makefile.basic
+++ b/src/backends/sqlite3/Makefile.basic
@@ -11,7 +11,7 @@ CXXFLAGSSO = ${CXXFLAGS} -fPIC
 INCLUDEDIRS = -I../../core ${SQLITE3INCLUDEDIR}
 
 
-OBJECTS = blob.o factory.o row-id.o session.o standard-into-type.o \
+OBJECTS = blob.o error.o factory.o row-id.o session.o standard-into-type.o \
 	standard-use-type.o statement.o vector-into-type.o vector-use-type.o \
 	common.o
 
@@ -27,6 +27,9 @@ libsoci_sqlite3.a : ${OBJECTS}
 
 
 blob.o : blob.cpp
+	${COMPILER} -c $? ${CXXFLAGS} ${INCLUDEDIRS}
+
+error.o : error.cpp
 	${COMPILER} -c $? ${CXXFLAGS} ${INCLUDEDIRS}
 
 common.o : common.cpp
@@ -63,6 +66,9 @@ shared : ${OBJECTSSO}
 
 blob-s.o : blob.cpp
 	${COMPILER} -c -o $@ $? ${CXXFLAGSSO} ${INCLUDEDIRS}
+
+error-s.o : error.cpp
+	${COMPILER} -c -o $@ $? ${CXXFLAGS} ${INCLUDEDIRS}
 
 common-s.o : common.cpp
 	${COMPILER} -c -o $@ $? ${CXXFLAGSSO} ${INCLUDEDIRS}

--- a/src/backends/sqlite3/error.cpp
+++ b/src/backends/sqlite3/error.cpp
@@ -1,0 +1,25 @@
+//
+// Copyright 2014 SimpliVT Corporation
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#define SOCI_SQLITE3_SOURCE
+#include "soci-sqlite3.h"
+#include "error.h"
+#include <cstring>
+#include <cassert>
+
+using namespace soci;
+
+sqlite3_soci_error::sqlite3_soci_error(
+    std::string const & msg, int result)
+    : soci_error(msg), result_(result)
+{
+}
+
+int sqlite3_soci_error::result() const
+{
+    return result_;
+}

--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -34,7 +34,7 @@ void execude_hardcoded(sqlite_api::sqlite3* conn, char const* const query, char 
         std::ostringstream ss;
         ss << errMsg << " " << zErrMsg;
         sqlite3_free(zErrMsg);
-        throw soci_error(ss.str());
+        throw sqlite3_soci_error(ss.str(), res);
     }
 }
 
@@ -45,7 +45,7 @@ void check_sqlite_err(sqlite_api::sqlite3* conn, int res, char const* const errM
         const char *zErrMsg = sqlite3_errmsg(conn);
         std::ostringstream ss;
         ss << errMsg << zErrMsg;
-        throw soci_error(ss.str());
+        throw sqlite3_soci_error(ss.str(), res);
     }
 }
 

--- a/src/backends/sqlite3/soci-sqlite3.h
+++ b/src/backends/sqlite3/soci-sqlite3.h
@@ -56,6 +56,17 @@ typedef void (*sqlite3_destructor_type)(void*);
 namespace soci
 {
 
+class sqlite3_soci_error : public soci_error
+{
+public:
+    sqlite3_soci_error(std::string const & msg, int result);
+
+    int result() const;
+
+private:
+    int result_;
+};
+
 struct sqlite3_statement_backend;
 struct sqlite3_standard_into_type_backend : details::standard_into_type_backend
 {

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -66,7 +66,7 @@ void sqlite3_statement_backend::prepare(std::string const & query,
         std::ostringstream ss;
         ss << "sqlite3_statement_backend::prepare: "
            << zErrMsg;
-        throw soci_error(ss.str());
+        throw sqlite3_soci_error(ss.str(), res);
     }
     databaseReady_ = true;
 }
@@ -145,7 +145,7 @@ sqlite3_statement_backend::load_rowset(int totalRows)
                 std::ostringstream ss;
                 ss << "sqlite3_statement_backend::loadRS: "
                    << zErrMsg;
-                throw soci_error(ss.str());
+                throw sqlite3_soci_error(ss.str(), res);
             }
         }
     }
@@ -180,7 +180,7 @@ sqlite3_statement_backend::load_one()
         std::ostringstream ss;
         ss << "sqlite3_statement_backend::loadOne: "
            << zErrMsg;
-        throw soci_error(ss.str());
+        throw sqlite3_soci_error(ss.str(), res);
     }
 
     return retVal;
@@ -227,7 +227,7 @@ sqlite3_statement_backend::bind_and_execute(int number)
             {
                 // preserve the number of rows affected so far.
                 rowsAffectedBulk_ = rowsAffectedBulkTemp;
-                throw soci_error("Failure to bind on bulk operations");
+                throw sqlite3_soci_error("Failure to bind on bulk operations", bindRes);
             }
         }
 

--- a/src/backends/sqlite3/test/test-sqlite3.cpp
+++ b/src/backends/sqlite3/test/test-sqlite3.cpp
@@ -258,6 +258,38 @@ void test5()
     std::cout << "test 5 passed" << std::endl;
 }
 
+struct test6_table_creator : table_creator_base
+{
+    test6_table_creator(session & sql) : table_creator_base(sql)
+    {
+        sql << "create table soci_test (id INTEGER PRIMARY KEY, name char)";
+    }
+};
+
+void test6()
+{
+    {
+        session sql(backEnd, connectString);
+
+        test6_table_creator tableCreator(sql);
+
+        sql << "insert into soci_test(id, name) values(1, 'john')";
+
+        {
+            try
+            {
+                // using same primary key causes constraint violation error
+                sql << "insert into soci_test(id, name) values(1, 'jack')";
+            }
+            catch (sqlite3_soci_error const& e)
+            {
+                assert(SQLITE_CONSTRAINT == (0xFF & e.result()));
+            }
+        }
+    }
+    std::cout << "test 6 passed" << std::endl;
+}
+
 // DDL Creation objects for common tests
 struct table_creator_one : public table_creator_base
 {
@@ -377,6 +409,7 @@ int main(int argc, char** argv)
         test3();
         test4();
         test5();
+        test6();
 
         std::cout << "\nOK, all tests passed.\n\n";
 


### PR DESCRIPTION
Greetings, I submit the following two enhancements for inclusion in the 3.2.3 hotfix or later. 

The first one adds support for PostgreSQL UUID columns in the backend.  Includes unit test to show correctness.

The second is a simple sqlite3_soci_error exception that exposes the SQLITE result code as part of the exception data.

Regards,
Alex Volanis