### PR TITLE
numeric handling in odbc_statement_backend::describe_column fixed

### DIFF
--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -291,7 +291,7 @@ void odbc_statement_backend::describe_column(int colNum, data_type & type,
         type = dt_date;
         break;
     case SQL_NUMERIC:
-    {
+    { //
         if (decDigits > 0)
         {
             type = dt_double;
@@ -328,24 +328,6 @@ void odbc_statement_backend::describe_column(int colNum, data_type & type,
         break;
     }
 }
-
-    case SQLT_NUM:
-        if (scale > 0)
-        {
-            if (session_.get_option_decimals_as_strings())
-                type = dt_string;
-            else
-                type = dt_double;
-        }
-        else if (precision <= std::numeric_limits<int>::digits10)
-        {
-            type = dt_integer;
-        }
-        else
-        {
-            type = dt_long_long;
-        }
-        break;
 
 std::size_t odbc_statement_backend::column_size(int colNum)
 {


### PR DESCRIPTION
The SQL_NUMERIC type was not handled correctly in the odbc-backend (everything was double). I merged the changes from the oracle-backend to handle the SQL_NUMERIC as integer, long_long or double. 
