### PR TITLE
Update version.h

### DIFF
--- a/src/core/version.h
+++ b/src/core/version.h
@@ -20,7 +20,7 @@
 //  SOCI_VERSION / 100 % 1000 is the minor version
 //  SOCI_VERSION / 100000 is the major version
 
-#define SOCI_VERSION 300201
+#define SOCI_VERSION 300202
 
 //
 //  SOCI_LIB_VERSION must be defined to be the same as SOCI_VERSION


### PR DESCRIPTION
SOCI_VERSION and SOCI_LIB_VERSION are expected to reflect the same SOCI version, more specifically 3.2.2 here. So, I guess that it was a typo.