### PR TITLE
Nested transaction support

### DIFF
--- a/src/backends/db2/session.cpp
+++ b/src/backends/db2/session.cpp
@@ -127,7 +127,7 @@ db2_session_backend::~db2_session_backend()
     clean_up();
 }
 
-void db2_session_backend::begin()
+void db2_session_backend::begin(const char* /*beginTx*/)
 {
     // In DB2, transations begin implicitly; however, autocommit must be disabled for the duration of the transaction
     if(autocommit)
@@ -145,7 +145,7 @@ void db2_session_backend::begin()
     in_transaction = true;
 }
 
-void db2_session_backend::commit()
+void db2_session_backend::commit(const char* /*commitTx*/)
 {
     if (!autocommit || in_transaction) {
         in_transaction = false;
@@ -168,7 +168,7 @@ void db2_session_backend::commit()
     }
 }
 
-void db2_session_backend::rollback()
+void db2_session_backend::rollback(const char* /*rollbackTx*/)
 {
     if (!autocommit || in_transaction) {
         in_transaction = false;

--- a/src/backends/db2/soci-db2.h
+++ b/src/backends/db2/soci-db2.h
@@ -234,9 +234,9 @@ struct db2_session_backend : details::session_backend
 
     ~db2_session_backend();
 
-    void begin();
-    void commit();
-    void rollback();
+    virtual void begin(const char* beginTx);
+    virtual void commit(const char* commitTx);
+    virtual void rollback(const char* rollbackTx);
 
     std::string get_backend_name() const { return "DB2"; }
 

--- a/src/backends/db2/test/test-db2.cpp
+++ b/src/backends/db2/test/test-db2.cpp
@@ -96,6 +96,17 @@ public:
     {
         return "to_date('" + pi_datdt_string + "', 'YYYY-MM-DD HH24:MI:SS')";
     }
+
+    bool supportsTransactions() const
+    {
+        return true;
+    }
+
+    bool supportsNestedTransactions() const
+    {
+        return false;
+    }
+
 };
 
 
@@ -107,6 +118,7 @@ void test1()
 {
     {
         session sql(backEnd, connectString);
+        transaction tr(sql);
 
         sql << "SELECT CURRENT TIMESTAMP FROM SYSIBM.SYSDUMMY1";
         sql << "SELECT " << 123 << " FROM SYSIBM.SYSDUMMY1";
@@ -284,7 +296,7 @@ void test1()
 
         sql<<"DROP TABLE DB2INST1.SOCI_TEST";
 
-        sql.commit();
+        tr.commit();
     }
 
     std::cout << "test 1 passed" << std::endl;
@@ -293,6 +305,7 @@ void test1()
 void test2() {
     {
         session sql(backEnd, connectString);
+        transaction tr(sql);
 
         std::string query = "CREATE TABLE DB2INST1.SOCI_TEST (ID BIGINT,DATA VARCHAR(8),DT TIMESTAMP)";
         sql << query;
@@ -330,7 +343,7 @@ void test2() {
         }
         
         sql<<"DROP TABLE DB2INST1.SOCI_TEST";
-        sql.commit();
+        tr.commit();
     }
 
     std::cout << "test 2 passed" << std::endl;
@@ -339,6 +352,7 @@ void test2() {
 void test3() {
     {
         session sql(backEnd, connectString);
+        transaction tr(sql);
         int i;
 
         std::string query = "CREATE TABLE DB2INST1.SOCI_TEST (ID BIGINT,DATA VARCHAR(8),DT TIMESTAMP)";
@@ -384,7 +398,7 @@ void test3() {
         }
         
         sql<<"DROP TABLE DB2INST1.SOCI_TEST";
-        sql.commit();
+        tr.commit();
     }
 
     std::cout << "test 3 passed" << std::endl;

--- a/src/backends/empty/session.cpp
+++ b/src/backends/empty/session.cpp
@@ -27,17 +27,17 @@ empty_session_backend::~empty_session_backend()
     clean_up();
 }
 
-void empty_session_backend::begin()
+void empty_session_backend::begin(const char* /*beginTx*/)
 {
     // ...
 }
 
-void empty_session_backend::commit()
+void empty_session_backend::commit(const char* /*commitTx*/)
 {
     // ...
 }
 
-void empty_session_backend::rollback()
+void empty_session_backend::rollback(const char* /*rollbackTx*/)
 {
     // ...
 }

--- a/src/backends/empty/soci-empty.h
+++ b/src/backends/empty/soci-empty.h
@@ -158,9 +158,9 @@ struct empty_session_backend : details::session_backend
 
     ~empty_session_backend();
 
-    void begin();
-    void commit();
-    void rollback();
+    virtual void begin(const char* beginTx);
+    virtual void commit(const char* commitTx);
+    virtual void rollback(const char* rollbackTx);
 
     std::string get_backend_name() const { return "empty"; }
 

--- a/src/backends/firebird/session.cpp
+++ b/src/backends/firebird/session.cpp
@@ -248,11 +248,11 @@ firebird_session_backend::firebird_session_backend(
         decimals_as_strings_ = param == "1" || param == "Y" || param == "y";
     }
     // starting transaction
-    begin();
+    begin("BEGIN");
 }
 
 
-void firebird_session_backend::begin()
+void firebird_session_backend::begin(const char * /*beginTx*/)
 {
     // Transaction is always started in ctor, because Firebird can't work
     // without active transaction.
@@ -286,7 +286,7 @@ void firebird_session_backend::setDPBOption(int const option, std::string const 
     dpb_.append(value);
 }
 
-void firebird_session_backend::commit()
+void firebird_session_backend::commit(const char * /*commitTx*/)
 {
     ISC_STATUS stat[stat_size];
 
@@ -301,12 +301,12 @@ void firebird_session_backend::commit()
     }
 
 #ifndef SOCI_FIREBIRD_NORESTARTTRANSACTION
-    begin();
+    begin("BEGIN");
 #endif
 
 }
 
-void firebird_session_backend::rollback()
+void firebird_session_backend::rollback(const char * /*rollbackTx*/)
 {
     ISC_STATUS stat[stat_size];
 
@@ -321,7 +321,7 @@ void firebird_session_backend::rollback()
     }
 
 #ifndef SOCI_FIREBIRD_NORESTARTTRANSACTION
-    begin();
+    begin("BEGIN");
 #endif
 
 }

--- a/src/backends/firebird/soci-firebird.h
+++ b/src/backends/firebird/soci-firebird.h
@@ -301,9 +301,9 @@ struct firebird_session_backend : details::session_backend
 
     ~firebird_session_backend();
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    virtual void begin(const char* beginTx);
+    virtual void commit(const char* commitTx);
+    virtual void rollback(const char* rollbackTx);
 
     virtual bool get_next_sequence_value(session & s,
         std::string const & sequence, long & value);

--- a/src/backends/firebird/test/test-firebird.cpp
+++ b/src/backends/firebird/test/test-firebird.cpp
@@ -30,11 +30,11 @@ void test1()
         session sql(backEnd, connectString);
 
         // In Firebird transaction is always required and is started
-        // automatically when session is opened. There is no need to
-        // call session::begin(); it will do nothing if there is active
-        // transaction.
+        // automatically when session is opened.
+        // while begin won't actually begin a transaction in Firebird,
+        // it is expected to match a commit or rollback statement.
 
-        // sql.begin();
+        sql.begin();
 
         try
         {
@@ -65,6 +65,8 @@ void test1()
 void test2()
 {
     session sql(backEnd, connectString);
+
+    sql.begin();
 
     try
     {
@@ -168,6 +170,8 @@ void test3()
 {
     session sql(backEnd, connectString);
 
+    sql.begin();
+
     try
     {
         sql << "drop table test3";
@@ -221,6 +225,8 @@ void test3()
 void test4()
 {
     session sql(backEnd, connectString);
+
+    sql.begin();
 
     try
     {
@@ -302,6 +308,8 @@ void test5()
 {
     session sql(backEnd, connectString);
 
+    sql.begin();
+
     {
         short sh(0);
         sql << "select 3 from rdb$database", into(sh);
@@ -365,6 +373,8 @@ void test5()
 void test6()
 {
     session sql(backEnd, connectString);
+
+    sql.begin();
 
     try
     {
@@ -512,6 +522,8 @@ void test7()
 {
     session sql(backEnd, connectString);
 
+    sql.begin();
+
     try
     {
         sql << "drop table test7";
@@ -630,6 +642,8 @@ void test8()
 {
     session sql(backEnd, connectString);
 
+    sql.begin();
+
     try
     {
         sql << "drop table test8";
@@ -710,6 +724,8 @@ void test8()
 void test9()
 {
     session sql(backEnd, connectString);
+
+    sql.begin();
 
     try
     {
@@ -821,6 +837,8 @@ void test9()
 void test10()
 {
     session sql(backEnd, connectString);
+
+    sql.begin();
 
     try
     {
@@ -1010,6 +1028,8 @@ void test11()
 {
     session sql(backEnd, connectString);
 
+    sql.begin();
+
     try
     {
         sql << "drop table test11";
@@ -1078,6 +1098,8 @@ void test12()
 {
     session sql(backEnd, connectString);
 
+    sql.begin();
+
     try
     {
         sql << "drop table test12";
@@ -1138,6 +1160,8 @@ void test13()
     assert(format_decimal<int>(&a, -9) == "0.012345678");
 
     session sql(backEnd, connectString + " decimals_as_strings=1");
+
+    sql.begin();
 
     try
     {
@@ -1300,6 +1324,17 @@ class test_context : public tests::test_context_base
         {
             return "'" + datdt_string + "'";
         }
+
+        bool supportsTransactions() const
+        {
+            return true;
+        }
+
+        bool supportsNestedTransactions() const
+        {
+            return false;
+        }
+
 };
 
 

--- a/src/backends/mysql/session.cpp
+++ b/src/backends/mysql/session.cpp
@@ -349,19 +349,19 @@ void hard_exec(MYSQL *conn, const string & query)
 
 } // namespace unnamed
 
-void mysql_session_backend::begin()
+void mysql_session_backend::begin(const char *beginTx)
 {
-    hard_exec(conn_, "BEGIN");
+    hard_exec(conn_, beginTx);
 }
 
-void mysql_session_backend::commit()
+void mysql_session_backend::commit(const char *commitTx)
 {
-    hard_exec(conn_, "COMMIT");
+    hard_exec(conn_, commitTx);
 }
 
-void mysql_session_backend::rollback()
+void mysql_session_backend::rollback(const char *rollbackTx)
 {
-    hard_exec(conn_, "ROLLBACK");
+    hard_exec(conn_, rollbackTx);
 }
 
 void mysql_session_backend::clean_up()

--- a/src/backends/mysql/soci-mysql.h
+++ b/src/backends/mysql/soci-mysql.h
@@ -234,9 +234,9 @@ struct mysql_session_backend : details::session_backend
 
     ~mysql_session_backend();
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    virtual void begin(const char* beginTx);
+    virtual void commit(const char* commitTx);
+    virtual void rollback(const char* rollbackTx);
 
     virtual std::string get_backend_name() const { return "mysql"; }
 

--- a/src/backends/mysql/test/test-mysql.cpp
+++ b/src/backends/mysql/test/test-mysql.cpp
@@ -929,19 +929,29 @@ public:
         return "\'" + datdt_string + "\'";
     }
 
-};
+    bool are_transactions_supported() const
+    {
+        session sql(get_backend_factory(), get_connect_string());
+        sql << "drop table if exists soci_test";
+        sql << "create table soci_test (id int) engine=InnoDB";
+        row r;
+        sql << "show table status like \'soci_test\'", into(r);
+        bool retv = (r.get<std::string>(1) == "InnoDB");
+        sql << "drop table soci_test";
+        return retv;
+    }
 
-bool are_transactions_supported()
-{
-    session sql(backEnd, connectString);
-    sql << "drop table if exists soci_test";
-    sql << "create table soci_test (id int) engine=InnoDB";
-    row r;
-    sql << "show table status like \'soci_test\'", into(r);
-    bool retv = (r.get<std::string>(1) == "InnoDB");
-    sql << "drop table soci_test";
-    return retv;
-}
+    bool supportsTransactions() const
+    {
+        return are_transactions_supported();
+    }
+
+    bool supportsNestedTransactions() const
+    {
+        return are_transactions_supported();
+    }
+
+};
 
 int main(int argc, char** argv)
 {
@@ -962,8 +972,7 @@ int main(int argc, char** argv)
     {
         test_context tc(backEnd, connectString);
         common_tests tests(tc);
-        bool checkTransactions = are_transactions_supported();
-        tests.run(checkTransactions);
+        tests.run();
 
         std::cout << "\nSOCI MySQL Tests:\n\n";
 

--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -95,7 +95,7 @@ odbc_session_backend::~odbc_session_backend()
     clean_up();
 }
 
-void odbc_session_backend::begin()
+void odbc_session_backend::begin(const char* /*beginTx*/)
 {
     SQLRETURN rc = SQLSetConnectAttr( hdbc_, SQL_ATTR_AUTOCOMMIT,
                     (SQLPOINTER)SQL_AUTOCOMMIT_OFF, 0 );
@@ -106,7 +106,7 @@ void odbc_session_backend::begin()
     }
 }
 
-void odbc_session_backend::commit()
+void odbc_session_backend::commit(const char* /*commitTx*/)
 {
     SQLRETURN rc = SQLEndTran(SQL_HANDLE_DBC, hdbc_, SQL_COMMIT);
     if (is_odbc_error(rc))
@@ -117,7 +117,7 @@ void odbc_session_backend::commit()
     reset_transaction();
 }
 
-void odbc_session_backend::rollback()
+void odbc_session_backend::rollback(const char* /*rollbackTx*/)
 {
     SQLRETURN rc = SQLEndTran(SQL_HANDLE_DBC, hdbc_, SQL_ROLLBACK);
     if (is_odbc_error(rc))

--- a/src/backends/odbc/soci-odbc.h
+++ b/src/backends/odbc/soci-odbc.h
@@ -271,9 +271,9 @@ struct odbc_session_backend : details::session_backend
 
     ~odbc_session_backend();
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    virtual void begin(const char* beginTx);
+    virtual void commit(const char* commitTx);
+    virtual void rollback(const char* rollbackTx);
 
     virtual bool get_next_sequence_value(session & s,
         std::string const & sequence, long & value);

--- a/src/backends/odbc/test/test-odbc-access.cpp
+++ b/src/backends/odbc/test/test-odbc-access.cpp
@@ -107,6 +107,17 @@ test_context(backend_factory const &backEnd, std::string const &connectString)
     {
         return "#" + datdt_string + "#";
     }
+
+    bool supportsTransactions() const
+    {
+        return true;
+    }
+
+    bool supportsNestedTransactions() const
+    {
+        return false;
+    }
+
 };
 
 int main(int argc, char** argv)

--- a/src/backends/odbc/test/test-odbc-db2.cpp
+++ b/src/backends/odbc/test/test-odbc-db2.cpp
@@ -93,6 +93,16 @@ public:
     {
         return "\'" + datdt_string + "\'";
     }
+
+    bool supportsTransactions() const
+    {
+        return true;
+    }
+
+    bool supportsNestedTransactions() const
+    {
+        return false;
+    }
 };
 
 struct table_creator_bigint : table_creator_base

--- a/src/backends/odbc/test/test-odbc-mssql.cpp
+++ b/src/backends/odbc/test/test-odbc-mssql.cpp
@@ -97,6 +97,17 @@ public:
     {
         return "convert(datetime, \'" + datdt_string + "\', 120)";
     }
+
+    bool supportsTransactions() const
+    {
+        return true;
+    }
+
+    bool supportsNestedTransactions() const
+    {
+        return false;
+    }
+
 };
 
 int main(int argc, char** argv)

--- a/src/backends/odbc/test/test-odbc-mysql.cpp
+++ b/src/backends/odbc/test/test-odbc-mysql.cpp
@@ -97,6 +97,17 @@ public:
     {
         return "\'" + datdt_string + "\'";
     }
+
+    bool supportsTransactions() const
+    {
+        return true;
+    }
+
+    bool supportsNestedTransactions() const
+    {
+        return false;
+    }
+
 };
 
 int main(int argc, char** argv)

--- a/src/backends/odbc/test/test-odbc-postgresql.cpp
+++ b/src/backends/odbc/test/test-odbc-postgresql.cpp
@@ -98,6 +98,16 @@ public:
         return "timestamptz(\'" + datdt_string + "\')";
     }
 
+    bool supportsTransactions() const
+    {
+        return true;
+    }
+
+    bool supportsNestedTransactions() const
+    {
+        return false;
+    }
+
 };
 
 int main(int argc, char** argv)

--- a/src/backends/oracle/session.cpp
+++ b/src/backends/oracle/session.cpp
@@ -152,7 +152,7 @@ oracle_session_backend::~oracle_session_backend()
     clean_up();
 }
 
-void oracle_session_backend::begin()
+void oracle_session_backend::begin(const char* /*beginTx*/)
 {
     // This code is commented out because it causes one of the transaction
     // tests in common_tests::test10() to fail with error 'Invalid handle'
@@ -164,7 +164,7 @@ void oracle_session_backend::begin()
     //    }
 }
 
-void oracle_session_backend::commit()
+void oracle_session_backend::commit(const char* /*commitTx*/)
 {
     sword res = OCITransCommit(svchp_, errhp_, OCI_DEFAULT);
     if (res != OCI_SUCCESS)
@@ -173,7 +173,7 @@ void oracle_session_backend::commit()
     }
 }
 
-void oracle_session_backend::rollback()
+void oracle_session_backend::rollback(const char* /*rollbackTx*/)
 {
     sword res = OCITransRollback(svchp_, errhp_, OCI_DEFAULT);
     if (res != OCI_SUCCESS)

--- a/src/backends/oracle/soci-oracle.h
+++ b/src/backends/oracle/soci-oracle.h
@@ -250,9 +250,9 @@ struct oracle_session_backend : details::session_backend
 
     ~oracle_session_backend();
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    virtual void begin(const char* beginTx);
+    virtual void commit(const char* commitTx);
+    virtual void rollback(const char* rollbackTx);
 
     virtual std::string get_backend_name() const { return "oracle"; }
 

--- a/src/backends/oracle/test/test-oracle.cpp
+++ b/src/backends/oracle/test/test-oracle.cpp
@@ -1179,6 +1179,16 @@ public:
     {
         return "to_date('" + datdt_string + "', 'YYYY-MM-DD HH24:MI:SS')";
     }
+
+    bool supportsTransactions() const
+    {
+        return true;
+    }
+
+    bool supportsNestedTransactions() const
+    {
+        return false;
+    }
 };
 
 int main(int argc, char** argv)

--- a/src/backends/postgresql/session.cpp
+++ b/src/backends/postgresql/session.cpp
@@ -66,19 +66,19 @@ void hard_exec(PGconn * conn, char const * query, char const * errMsg)
 
 } // namespace unnamed
 
-void postgresql_session_backend::begin()
+void postgresql_session_backend::begin(const char* beginTx)
 {
-    hard_exec(conn_, "BEGIN", "Cannot begin transaction.");
+    hard_exec(conn_, beginTx, "Cannot begin transaction.");
 }
 
-void postgresql_session_backend::commit()
+void postgresql_session_backend::commit(const char* commitTx)
 {
-    hard_exec(conn_, "COMMIT", "Cannot commit transaction.");
+    hard_exec(conn_, commitTx, "Cannot commit transaction.");
 }
 
-void postgresql_session_backend::rollback()
+void postgresql_session_backend::rollback(const char* rollbackTx)
 {
-    hard_exec(conn_, "ROLLBACK", "Cannot rollback transaction.");
+    hard_exec(conn_, rollbackTx, "Cannot rollback transaction.");
 }
 
 void postgresql_session_backend::deallocate_prepared_statement(

--- a/src/backends/postgresql/soci-postgresql.h
+++ b/src/backends/postgresql/soci-postgresql.h
@@ -310,9 +310,9 @@ struct postgresql_session_backend : details::session_backend
 
     ~postgresql_session_backend();
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    virtual void begin(const char* beginTx);
+    virtual void commit(const char* commitTx);
+    virtual void rollback(const char* rollbackTx);
 
     void deallocate_prepared_statement(const std::string & statementName);
 

--- a/src/backends/postgresql/test/test-postgresql.cpp
+++ b/src/backends/postgresql/test/test-postgresql.cpp
@@ -782,6 +782,16 @@ public:
     {
         return "timestamptz(\'" + datdt_string + "\')";
     }
+
+    bool supportsTransactions() const
+    {
+        return true;
+    }
+
+    bool supportsNestedTransactions() const
+    {
+        return true;
+    }
 };
 
 int main(int argc, char** argv)

--- a/src/backends/sqlite3/blob.cpp
+++ b/src/backends/sqlite3/blob.cpp
@@ -7,6 +7,7 @@
 
 #include "soci-sqlite3.h"
 #include <cstring>
+#include <algorithm>
 
 using namespace soci;
 

--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -125,19 +125,19 @@ sqlite3_session_backend::~sqlite3_session_backend()
     clean_up();
 }
 
-void sqlite3_session_backend::begin()
+void sqlite3_session_backend::begin(const char* beginTx)
 {
-    execude_hardcoded(conn_, "BEGIN", "Cannot begin transaction.");
+    execude_hardcoded(conn_, beginTx, "Cannot begin transaction.");
 }
 
-void sqlite3_session_backend::commit()
+void sqlite3_session_backend::commit(const char* commitTx)
 {
-    execude_hardcoded(conn_, "COMMIT", "Cannot commit transaction.");
+    execude_hardcoded(conn_, commitTx, "Cannot commit transaction.");
 }
 
-void sqlite3_session_backend::rollback()
+void sqlite3_session_backend::rollback(const char* rollbackTx)
 {
-    execude_hardcoded(conn_, "ROLLBACK", "Cannot rollback transaction.");
+    execude_hardcoded(conn_, rollbackTx, "Cannot rollback transaction.");
 }
 
 void sqlite3_session_backend::clean_up()

--- a/src/backends/sqlite3/soci-sqlite3.h
+++ b/src/backends/sqlite3/soci-sqlite3.h
@@ -241,9 +241,9 @@ struct sqlite3_session_backend : details::session_backend
 
     ~sqlite3_session_backend();
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    virtual void begin(const char* beginTx);
+    virtual void commit(const char* commitTx);
+    virtual void rollback(const char* rollbackTx);
 
     virtual std::string get_backend_name() const { return "sqlite3"; }
 

--- a/src/backends/sqlite3/test/test-sqlite3.cpp
+++ b/src/backends/sqlite3/test/test-sqlite3.cpp
@@ -340,6 +340,17 @@ public:
     {
         return "datetime(\'" + datdt_string + "\')";
     }
+
+    bool supportsTransactions() const
+    {
+        return true;
+    }
+
+    bool supportsNestedTransactions() const
+    {
+        return true;
+    }
+
 };
 
 int main(int argc, char** argv)

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -35,7 +35,7 @@ void ensureConnected(session_backend * backEnd)
 session::session()
     : once(this), prepare(this), query_transformation_(NULL), logStream_(NULL),
       uppercaseColumnNames_(false), backEnd_(NULL),
-      isFromPool_(false), pool_(NULL)
+      isFromPool_(false), pool_(NULL), transaction_level_(0)
 {
 }
 
@@ -43,7 +43,7 @@ session::session(connection_parameters const & parameters)
     : once(this), prepare(this), query_transformation_(NULL), logStream_(NULL),
       lastConnectParameters_(parameters),
       uppercaseColumnNames_(false), backEnd_(NULL),
-      isFromPool_(false), pool_(NULL)
+      isFromPool_(false), pool_(NULL), transaction_level_(0)
 {
     open(lastConnectParameters_);
 }
@@ -53,7 +53,7 @@ session::session(backend_factory const & factory,
     : once(this), prepare(this), query_transformation_(NULL), logStream_(NULL),
       lastConnectParameters_(factory, connectString),
       uppercaseColumnNames_(false), backEnd_(NULL),
-      isFromPool_(false), pool_(NULL)
+      isFromPool_(false), pool_(NULL), transaction_level_(0)
 {
     open(lastConnectParameters_);
 }
@@ -63,7 +63,7 @@ session::session(std::string const & backendName,
     : once(this), prepare(this), query_transformation_(NULL), logStream_(NULL),
       lastConnectParameters_(backendName, connectString),
       uppercaseColumnNames_(false), backEnd_(NULL),
-      isFromPool_(false), pool_(NULL)
+      isFromPool_(false), pool_(NULL), transaction_level_(0)
 {
     open(lastConnectParameters_);
 }
@@ -72,13 +72,13 @@ session::session(std::string const & connectString)
     : once(this), prepare(this), query_transformation_(NULL), logStream_(NULL),
       lastConnectParameters_(connectString),
       uppercaseColumnNames_(false), backEnd_(NULL),
-      isFromPool_(false), pool_(NULL)
+      isFromPool_(false), pool_(NULL), transaction_level_(0)
 {
     open(lastConnectParameters_);
 }
 
 session::session(connection_pool & pool)
-    : query_transformation_(NULL), logStream_(NULL), isFromPool_(true), pool_(&pool)
+    : query_transformation_(NULL), logStream_(NULL), isFromPool_(true), pool_(&pool), transaction_level_(0)
 {
     poolPosition_ = pool.lease();
     session & pooledSession = pool.at(poolPosition_);
@@ -123,6 +123,7 @@ void session::open(connection_parameters const & parameters)
         backEnd_ = factory->make_session(parameters);
         lastConnectParameters_ = parameters;
     }
+    transaction_level_ = 0;
 }
 
 void session::open(backend_factory const & factory,
@@ -178,27 +179,67 @@ void session::reconnect()
 
         backEnd_ = lastFactory->make_session(lastConnectParameters_);
     }
+    transaction_level_ = 0;
 }
 
 void session::begin()
 {
     ensureConnected(backEnd_);
 
-    backEnd_->begin();
+    std::string sql;
+    if (transaction_level_ == 0)
+    {
+        sql = "BEGIN";
+    }
+    else
+    {
+        std::ostringstream ss;
+        ss << "SAVEPOINT SOCI_L" << transaction_level_;
+        sql = ss.str();
+    }
+
+    backEnd_->begin(sql.c_str());
+
+    ++transaction_level_;
 }
 
 void session::commit()
 {
     ensureConnected(backEnd_);
 
-    backEnd_->commit();
+    std::string sql;
+    transaction_commit_helper(true, sql);
+
+    backEnd_->commit(sql.c_str());
 }
 
 void session::rollback()
 {
     ensureConnected(backEnd_);
 
-    backEnd_->rollback();
+    std::string sql;
+    transaction_commit_helper(false, sql);
+
+    backEnd_->rollback(sql.c_str());
+}
+
+void session::transaction_commit_helper(bool commit, std::string &sql)
+{
+    if (transaction_level_ <= 0)
+    {
+        throw soci_error("invalid transaction state");
+    }
+    if (--transaction_level_ == 0)
+    {
+        sql = commit ? "COMMIT" : "ROLLBACK";
+    }
+    else
+    {
+        std::ostringstream ss;
+        ss << (commit ? "RELEASE SAVEPOINT " : "ROLLBACK TO SAVEPOINT ") << " SOCI_L" << transaction_level_;
+
+        sql = ss.str();
+    }
 }
 
 std::ostringstream & session::get_query_stream()

--- a/src/core/session.h
+++ b/src/core/session.h
@@ -143,6 +143,9 @@ private:
     bool isFromPool_;
     std::size_t poolPosition_;
     connection_pool * pool_;
+
+    void transaction_commit_helper(bool commit, std::string &sql);
+    int transaction_level_;
 };
 
 } // namespace soci

--- a/src/core/soci-backend.h
+++ b/src/core/soci-backend.h
@@ -225,9 +225,9 @@ public:
     session_backend() {}
     virtual ~session_backend() {}
 
-    virtual void begin() = 0;
-    virtual void commit() = 0;
-    virtual void rollback() = 0;
+    virtual void begin(const char* beginTx) = 0;
+    virtual void commit(const char* commitTx) = 0;
+    virtual void rollback(const char* rollbackTx) = 0;
 
     // At least one of these functions is usually not implemented for any given
     // backend as RDBMS support either sequences or auto-generated values, so

--- a/src/core/soci-platform.h
+++ b/src/core/soci-platform.h
@@ -24,9 +24,11 @@
 # define vsnprintf _vsnprintf
 #endif
 
+#if _MSC_VER < 1900
 // Define if you have the snprintf variants.
 #define HAVE_SNPRINTF 1
 #define snprintf _snprintf
+#endif
 
 // Define if you have the strtoll and strtoull variants.
 #if _MSC_VER >= 1300


### PR DESCRIPTION
Added support for nesting transactions.
I only included configuration I could test:
* constructed SQL using the most common syntax for nesting transactions (using savepoints)
* sqlite3, postgresql and mysql seems fine
* some backends seem to not support it at all (ODBC layer for example)
* Oracle seems to support this syntax, but I don't have a way to test this


replaces the previous PR I had https://github.com/SOCI/soci/pull/283