### PR TITLE
Don't start implicit transaction too eagerly in Firebird backend.

### DIFF
--- a/docs/backends/firebird.html
+++ b/docs/backends/firebird.html
@@ -36,7 +36,6 @@
 <div class="navigation-indented">
     <a href="#firebird_soci_error">FirebirdSOCIError</a><br />
 </div>
-  <a href="#options">Configuration options</a><br />
 </div>
 
 <h3 id="prerequisites">Prerequisites</h3>
@@ -168,8 +167,11 @@ sql &lt;&lt; "select name from person where id = :id", use(id, "id")
 <h4 id="transactions">Transactions</h4>
 
 <p><a href="../statements.html#transactions">Transactions</a> are also fully 
-supported by the Firebird backend. In fact, there is always a transaction which is automatically commited in <code>Session's</code> destructor.
-<br />See the <a href="#options">Configuration options</a> section for more details.</p>
+supported by the Firebird backend. In fact, an implicit transaction is always
+started when using this backend if one hadn't been started by explicitly calling
+<tt>begin()</tt> before. The current transaction is automatically committed in
+<code>Session's</code> destructor.
+</p>
 
 <h4 id="blob">BLOB Data Type</h4>
 
@@ -228,15 +230,6 @@ modifications of existing Blob means creating a new one. Firebird backend hides 
 <p>The Firebird backend can throw instances of class <code>FirebirdSOCIError</code>,
 which is publicly derived from <code>SOCIError</code> and has an
 additional public <code>status_</code> member containing the Firebird status vector.</p>
-
-<h3 id="options">Configuration options</h3>
-
-<p>The Firebird backend recognize the following configuration macros :</p>
-<ul>
-<li><code>SOCI_FIREBIRD_NORESTARTTRANSACTION </code> - 
-    Transactions will not be restarted automatically after commit() or rollback().
-    The default is to restart transactions.</li>
-</ul>
 
 <p class="copyright">Copyright &copy; 2004-2006 Maciej Sobczak, Stephen Hutton, Rafal Bobrowski</p>
 </body>

--- a/include/soci/firebird/soci-firebird.h
+++ b/include/soci/firebird/soci-firebird.h
@@ -320,7 +320,15 @@ struct firebird_session_backend : details::session_backend
 
     bool get_option_decimals_as_strings() { return decimals_as_strings_; }
 
+    // Returns the pointer to the current transaction handle, starting a new
+    // transaction if necessary.
+    //
+    // The returned pointer should
+    isc_tr_handle* current_transaction();
+
     isc_db_handle dbhp_;
+
+private:
     isc_tr_handle trhp_;
     std::string dpb_;
     bool decimals_as_strings_;

--- a/src/backends/firebird/blob.cpp
+++ b/src/backends/firebird/blob.cpp
@@ -139,8 +139,8 @@ void firebird_blob_backend::open()
 
     ISC_STATUS stat[20];
 
-    if (isc_open_blob2(stat, &session_.dbhp_, &session_.trhp_, &bhp_,
-                       &bid_, 0, NULL))
+    if (isc_open_blob2(stat, &session_.dbhp_, session_.current_transaction(),
+                       &bhp_, &bid_, 0, NULL))
     {
         bhp_ = 0L;
         throw_iscerror(stat);
@@ -238,7 +238,7 @@ void firebird_blob_backend::save()
     }
 
     // create new blob
-    if (isc_create_blob(stat, &session_.dbhp_, &session_.trhp_,
+    if (isc_create_blob(stat, &session_.dbhp_, session_.current_transaction(),
                         &bhp_, &bid_))
     {
         throw_iscerror(stat);

--- a/src/backends/firebird/session.cpp
+++ b/src/backends/firebird/session.cpp
@@ -247,16 +247,11 @@ firebird_session_backend::firebird_session_backend(
     {
         decimals_as_strings_ = param == "1" || param == "Y" || param == "y";
     }
-    // starting transaction
-    begin();
 }
 
 
 void firebird_session_backend::begin()
 {
-    // Transaction is always started in ctor, because Firebird can't work
-    // without active transaction.
-    // Transaction will be automatically commited in cleanUp method.
     if (trhp_ == 0)
     {
         ISC_STATUS stat[stat_size];
@@ -299,11 +294,6 @@ void firebird_session_backend::commit()
 
         trhp_ = 0;
     }
-
-#ifndef SOCI_FIREBIRD_NORESTARTTRANSACTION
-    begin();
-#endif
-
 }
 
 void firebird_session_backend::rollback()
@@ -319,11 +309,14 @@ void firebird_session_backend::rollback()
 
         trhp_ = 0;
     }
+}
 
-#ifndef SOCI_FIREBIRD_NORESTARTTRANSACTION
+isc_tr_handle* firebird_session_backend::current_transaction()
+{
+    // It will do nothing if we're already inside a transaction.
     begin();
-#endif
 
+    return &trhp_;
 }
 
 void firebird_session_backend::cleanUp()

--- a/src/backends/firebird/statement.cpp
+++ b/src/backends/firebird/statement.cpp
@@ -226,7 +226,7 @@ void firebird_statement_backend::rewriteQuery(
     }
 
     // prepare temporary statement
-    if (isc_dsql_prepare(stat, &(session_.trhp_), &tmpStmtp, 0,
+    if (isc_dsql_prepare(stat, session_.current_transaction(), &tmpStmtp, 0,
         &tmpQuery[0], SQL_DIALECT_V6, sqldap_))
     {
         throw_iscerror(stat);
@@ -302,7 +302,7 @@ void firebird_statement_backend::prepare(std::string const & query,
     ISC_STATUS stat[stat_size];
 
     // prepare real statement
-    if (isc_dsql_prepare(stat, &(session_.trhp_), &stmtp_, 0,
+    if (isc_dsql_prepare(stat, session_.current_transaction(), &stmtp_, 0,
         &queryBuffer[0], SQL_DIALECT_V6, sqldap_))
     {
         throw_iscerror(stat);
@@ -423,7 +423,7 @@ firebird_statement_backend::execute(int number)
             }
 
             // then execute query
-            if (isc_dsql_execute(stat, &session_.trhp_, &stmtp_, SQL_DIALECT_V6, t))
+            if (isc_dsql_execute(stat, session_.current_transaction(), &stmtp_, SQL_DIALECT_V6, t))
             {
                 // preserve the number of rows affected so far.
                 rowsAffectedBulk_ = rowsAffectedBulkTemp;
@@ -442,7 +442,7 @@ firebird_statement_backend::execute(int number)
     else
     {
         // use elements aren't vectors
-        if (isc_dsql_execute(stat, &session_.trhp_, &stmtp_, SQL_DIALECT_V6, t))
+        if (isc_dsql_execute(stat, session_.current_transaction(), &stmtp_, SQL_DIALECT_V6, t))
         {
             throw_iscerror(stat);
         }


### PR DESCRIPTION
Firebird backend used to start a transaction immediately after construction or
after committing or rolling back the previous transaction. This created
problems due to unexpectedly not seeing any changes to the database not
performed via the same connection object because of the transaction isolation
and so SOCI_FIREBIRD_NORESTARTTRANSACTION existed to allow changing this
behaviour.

However it is not necessary to create the transactions so eagerly in the first
place, we can wait with doing it until the transaction handle is really
needed, i.e. when a statement is about to be executed. This solves the
problems due to having the implicit transaction open all the time and removes
the need for SOCI_FIREBIRD_NORESTARTTRANSACTION, simplifying the code.