### PR TITLE
Don't always disable ODBC MS SQL test under Unix, just when using Travis.

### DIFF
--- a/bin/ci/common.sh
+++ b/bin/ci/common.sh
@@ -30,5 +30,5 @@ run_make()
 
 run_test()
 {
-    ctest -V --output-on-failure .
+    ctest -V --output-on-failure "$@" .
 }

--- a/bin/ci/script_odbc.sh
+++ b/bin/ci/script_odbc.sh
@@ -28,4 +28,6 @@ cmake \
    ..
 
 run_make
-run_test
+
+# Exclude the test which can't be run as there is no MS SQL server available.
+run_test -E soci_odbc_test_mssql

--- a/tests/assert/odbc/CMakeLists.txt
+++ b/tests/assert/odbc/CMakeLists.txt
@@ -10,7 +10,6 @@
 ###############################################################################
 
 if (WIN32)
-  
   # MDBTools driver seems unreliable
   soci_backend_test(
     NAME access
@@ -18,17 +17,16 @@ if (WIN32)
     DEPENDS ODBC
     SOURCE test-odbc-access.cpp ${SOCI_TESTS_COMMON}
     CONNSTR "test-access.dsn")
-
-  # We have no means to test SQL Server at travis-ci.org
-  soci_backend_test(
-    NAME mssql
-    BACKEND ODBC
-    DEPENDS ODBC
-    SOURCE test-odbc-mssql.cpp ${SOCI_TESTS_COMMON}
-    CONNSTR "test-mssql.dsn")
 else()
-    message(STATUS "SQL Server, MS Access tests disabled on non-Windows platform")
+    message(STATUS "MS Access test disabled on non-Windows platform")
 endif()
+
+soci_backend_test(
+  NAME mssql
+  BACKEND ODBC
+  DEPENDS ODBC
+  SOURCE test-odbc-mssql.cpp ${SOCI_TESTS_COMMON}
+  CONNSTR "test-mssql.dsn")
 
 soci_backend_test(
   NAME mysql


### PR DESCRIPTION
This test can be run under Unix platforms too and can be built under Travis,
we just can't run it there.