### PR TITLE
Use a base-class member instead of shadowing it.

### DIFF
--- a/src/core/ref-counted-prepare-info.h
+++ b/src/core/ref-counted-prepare-info.h
@@ -32,7 +32,6 @@ class ref_counted_prepare_info : public ref_counted_statement_base
 public:
     ref_counted_prepare_info(session& s)
         : ref_counted_statement_base(s)
-        , session_(s)
     {}
 
     void exchange(into_type_ptr const& i);
@@ -43,8 +42,6 @@ public:
 private:
     friend class statement_impl;
     friend class procedure_impl;
-
-    session& session_;
 
     std::vector<into_type_base*> intos_;
     std::vector<use_type_base*> uses_;


### PR DESCRIPTION
The class `ref_counted_prepare_info` shadows a member variable of its parent to the same thing: it keeps a redundant reference to a `session`.

Remove the redundant reference and use the one from the parent instead.