### PR TITLE
Add helper exchange_type_cast<>() template function.

### DIFF
--- a/include/private/soci-exchange-cast.h
+++ b/include/private/soci-exchange-cast.h
@@ -1,0 +1,84 @@
+//
+// Copyright (C) 2015 Vadim Zeitlin
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_EXCHANGE_CAST_H_INCLUDED
+#define SOCI_EXCHANGE_CAST_H_INCLUDED
+
+#include "soci/soci-backend.h"
+
+#include <ctime>
+
+namespace soci
+{
+
+namespace details
+{
+
+// cast the given non-null untyped pointer to its corresponding type
+template <exchange_type e> struct exchange_type_traits;
+
+template <>
+struct exchange_type_traits<x_char>
+{
+  typedef char value_type;
+};
+
+template <>
+struct exchange_type_traits<x_stdstring>
+{
+  typedef std::string value_type;
+};
+
+template <>
+struct exchange_type_traits<x_short>
+{
+  typedef short value_type;
+};
+
+template <>
+struct exchange_type_traits<x_integer>
+{
+  typedef int value_type;
+};
+
+template <>
+struct exchange_type_traits<x_long_long>
+{
+  typedef long long value_type;
+};
+
+template <>
+struct exchange_type_traits<x_unsigned_long_long>
+{
+  typedef unsigned long long value_type;
+};
+
+template <>
+struct exchange_type_traits<x_double>
+{
+  typedef double value_type;
+};
+
+template <>
+struct exchange_type_traits<x_stdtm>
+{
+  typedef std::tm value_type;
+};
+
+// exchange_type_traits not defined for x_statement, x_rowid and x_blob here.
+
+template <exchange_type e>
+typename exchange_type_traits<e>::value_type& exchange_type_cast(void *data)
+{
+    return *static_cast<typename exchange_type_traits<e>::value_type*>(data);
+}
+
+} // namespace details
+
+} // namespace soci
+
+#endif // SOCI_EXCHANGE_CAST_H_INCLUDED

--- a/src/backends/db2/standard-into-type.cpp
+++ b/src/backends/db2/standard-into-type.cpp
@@ -8,6 +8,7 @@
 
 #define SOCI_DB2_SOURCE
 #include "soci/db2/soci-db2.h"
+#include "soci-exchange-cast.h"
 #include "common.h"
 #include <ctime>
 
@@ -127,33 +128,32 @@ void db2_standard_into_type_backend::post_fetch(
         // only std::string and std::tm need special handling
         if (type == x_char)
         {
-            char *c = static_cast<char*>(data);
-            *c = buf[0];
+            exchange_type_cast<x_char>(data) = buf[0];
         }
         if (type == x_stdstring)
         {
-            std::string *s = static_cast<std::string *>(data);
-            *s = buf;
-            if (s->size() >= (details::db2::cli_max_buffer - 1))
+            std::string& s = exchange_type_cast<x_stdstring>(data);
+            s = buf;
+            if (s.size() >= (details::db2::cli_max_buffer - 1))
             {
                 throw soci_error("Buffer size overflow; maybe got too large string");
             }
         }
         else if (type == x_stdtm)
         {
-            std::tm *t = static_cast<std::tm *>(data);
+            std::tm& t = exchange_type_cast<x_stdtm>(data);
 
             TIMESTAMP_STRUCT * ts = reinterpret_cast<TIMESTAMP_STRUCT*>(buf);
-            t->tm_isdst = -1;
-            t->tm_year = ts->year - 1900;
-            t->tm_mon = ts->month - 1;
-            t->tm_mday = ts->day;
-            t->tm_hour = ts->hour;
-            t->tm_min = ts->minute;
-            t->tm_sec = ts->second;
+            t.tm_isdst = -1;
+            t.tm_year = ts->year - 1900;
+            t.tm_mon = ts->month - 1;
+            t.tm_mday = ts->day;
+            t.tm_hour = ts->hour;
+            t.tm_min = ts->minute;
+            t.tm_sec = ts->second;
 
             // normalize and compute the remaining fields
-            std::mktime(t);
+            std::mktime(&t);
         }
     }
 }

--- a/src/backends/db2/standard-use-type.cpp
+++ b/src/backends/db2/standard-use-type.cpp
@@ -7,6 +7,7 @@
 
 #define SOCI_DB2_SOURCE
 #include "soci/db2/soci-db2.h"
+#include "soci-exchange-cast.h"
 #include <cctype>
 #include <cstdio>
 #include <cstring>
@@ -55,8 +56,7 @@ void *db2_standard_use_type_backend::prepare_for_bind(
             cType = SQL_C_CHAR;
             size = sizeof(char) + 1;
             buf = new char[size];
-            char *c = static_cast<char*>(data);
-            buf[0] = *c;
+            buf[0] = exchange_type_cast<x_char>(data);
             buf[1] = '\0';
             ind = SQL_NTS;
         }
@@ -65,12 +65,12 @@ void *db2_standard_use_type_backend::prepare_for_bind(
     {
         // TODO: No textual value is assigned here!
 
-        std::string* s = static_cast<std::string*>(data);
+        std::string const& s = exchange_type_cast<x_stdstring>(data);
         sqlType = SQL_LONGVARCHAR;
         cType = SQL_C_CHAR;
-        size = s->size() + 1;
+        size = s.size() + 1;
         buf = new char[size];
-        strncpy(buf, s->c_str(), size);
+        strncpy(buf, s.c_str(), size);
         ind = SQL_NTS;
     }
     break;
@@ -79,7 +79,7 @@ void *db2_standard_use_type_backend::prepare_for_bind(
             sqlType = SQL_TIMESTAMP;
             cType = SQL_C_TIMESTAMP;
             buf = new char[sizeof(TIMESTAMP_STRUCT)];
-            std::tm *t = static_cast<std::tm *>(data);
+            std::tm const& t = exchange_type_cast<x_stdtm>(data);
             data = buf;
             size = 19; // This number is not the size in bytes, but the number
                        // of characters in the date if it was written out
@@ -87,12 +87,12 @@ void *db2_standard_use_type_backend::prepare_for_bind(
 
             TIMESTAMP_STRUCT * ts = reinterpret_cast<TIMESTAMP_STRUCT*>(buf);
 
-            ts->year = static_cast<SQLSMALLINT>(t->tm_year + 1900);
-            ts->month = static_cast<SQLUSMALLINT>(t->tm_mon + 1);
-            ts->day = static_cast<SQLUSMALLINT>(t->tm_mday);
-            ts->hour = static_cast<SQLUSMALLINT>(t->tm_hour);
-            ts->minute = static_cast<SQLUSMALLINT>(t->tm_min);
-            ts->second = static_cast<SQLUSMALLINT>(t->tm_sec);
+            ts->year = static_cast<SQLSMALLINT>(t.tm_year + 1900);
+            ts->month = static_cast<SQLUSMALLINT>(t.tm_mon + 1);
+            ts->day = static_cast<SQLUSMALLINT>(t.tm_mday);
+            ts->hour = static_cast<SQLUSMALLINT>(t.tm_hour);
+            ts->minute = static_cast<SQLUSMALLINT>(t.tm_min);
+            ts->second = static_cast<SQLUSMALLINT>(t.tm_sec);
             ts->fraction = 0;
         }
         break;

--- a/src/backends/firebird/standard-into-type.cpp
+++ b/src/backends/firebird/standard-into-type.cpp
@@ -7,6 +7,7 @@
 
 #define SOCI_FIREBIRD_SOURCE
 #include "soci/firebird/soci-firebird.h"
+#include "soci-exchange-cast.h"
 #include "firebird/common.h"
 #include "soci/soci.h"
 
@@ -70,46 +71,36 @@ void firebird_standard_into_type_backend::exchangeData()
     {
             // simple cases
         case x_char:
-            *reinterpret_cast<char*>(data_) = getTextParam(var)[0];
+            exchange_type_cast<x_char>(data_) = getTextParam(var)[0];
             break;
         case x_short:
-            {
-                short t = from_isc<short>(var);
-                *reinterpret_cast<short*>(data_) = t;
-            }
+            exchange_type_cast<x_short>(data_) = from_isc<short>(var);
             break;
         case x_integer:
-            {
-                int t = from_isc<int>(var);
-                *reinterpret_cast<int *>(data_) = t;
-            }
+            exchange_type_cast<x_integer>(data_) = from_isc<int>(var);
             break;
         case x_long_long:
-            {
-                long long t = from_isc<long long>(var);
-                *reinterpret_cast<long long *>(data_) = t;
-            }
+            exchange_type_cast<x_long_long>(data_) = from_isc<long long>(var);
             break;
         case x_double:
-            {
-                double t = from_isc<double>(var);
-                *reinterpret_cast<double*>(data_) = t;
-            }
+            exchange_type_cast<x_double>(data_) = from_isc<double>(var);
             break;
 
             // cases that require adjustments and buffer management
         case x_stdstring:
-            *(reinterpret_cast<std::string*>(data_)) = getTextParam(var);
+            exchange_type_cast<x_stdstring>(data_) = getTextParam(var);
             break;
         case x_stdtm:
-            tmDecode(var->sqltype,
-                     buf_, static_cast<std::tm*>(data_));
+            {
+                std::tm& t = exchange_type_cast<x_stdtm>(data_);
+                tmDecode(var->sqltype, buf_, &t);
 
-            // isc_decode_timestamp() used by tmDecode() incorrectly sets
-            // tm_isdst to 0 in the struct that it creates, see
-            // http://tracker.firebirdsql.org/browse/CORE-3877, work around it
-            // by pretending the DST is actually unknown.
-            static_cast<std::tm*>(data_)->tm_isdst = -1;
+                // isc_decode_timestamp() used by tmDecode() incorrectly sets
+                // tm_isdst to 0 in the struct that it creates, see
+                // http://tracker.firebirdsql.org/browse/CORE-3877, work around it
+                // by pretending the DST is actually unknown.
+                t.tm_isdst = -1;
+            }
             break;
 
             // cases that require special handling

--- a/src/backends/firebird/standard-use-type.cpp
+++ b/src/backends/firebird/standard-use-type.cpp
@@ -7,6 +7,7 @@
 
 #define SOCI_FIREBIRD_SOURCE
 #include "soci/firebird/soci-firebird.h"
+#include "soci-exchange-cast.h"
 #include "firebird/common.h"
 #include "soci/soci.h"
 
@@ -104,7 +105,7 @@ void firebird_standard_use_type_backend::exchangeData()
     switch (type_)
     {
         case x_char:
-            setTextParam(static_cast<char*>(data_), 1, buf_, var);
+            setTextParam(&exchange_type_cast<x_char>(data_), 1, buf_, var);
             break;
         case x_short:
             to_isc<short>(data_, var);
@@ -121,13 +122,12 @@ void firebird_standard_use_type_backend::exchangeData()
 
         case x_stdstring:
             {
-                std::string *tmp = static_cast<std::string*>(data_);
-                setTextParam(tmp->c_str(), tmp->size(), buf_, var);
+                std::string const& tmp = exchange_type_cast<x_stdstring>(data_);
+                setTextParam(tmp.c_str(), tmp.size(), buf_, var);
             }
             break;
         case x_stdtm:
-            tmEncode(var->sqltype,
-                     static_cast<std::tm*>(data_), buf_);
+            tmEncode(var->sqltype, &exchange_type_cast<x_stdtm>(data_), buf_);
             break;
 
             // cases that require special handling

--- a/src/backends/mysql/standard-into-type.cpp
+++ b/src/backends/mysql/standard-into-type.cpp
@@ -10,6 +10,7 @@
 #include "soci/mysql/soci-mysql.h"
 #include "soci/soci-platform.h"
 #include "common.h"
+#include "soci-exchange-cast.h"
 // std
 #include <cassert>
 #include <ciso646>
@@ -78,56 +79,34 @@ void mysql_standard_into_type_backend::post_fetch(
         switch (type_)
         {
         case x_char:
-            {
-                char *dest = static_cast<char*>(data_);
-                *dest = *buf;
-            }
+            exchange_type_cast<x_char>(data_) = *buf;
             break;
         case x_stdstring:
             {
-                std::string *dest = static_cast<std::string *>(data_);
+                std::string& dest = exchange_type_cast<x_stdstring>(data_);
                 unsigned long * lengths =
                     mysql_fetch_lengths(statement_.result_);
-                dest->assign(buf, lengths[pos]);
+                dest.assign(buf, lengths[pos]);
             }
             break;
         case x_short:
-            {
-                short *dest = static_cast<short*>(data_);
-                parse_num(buf, *dest);
-            }
+            parse_num(buf, exchange_type_cast<x_short>(data_));
             break;
         case x_integer:
-            {
-                int *dest = static_cast<int*>(data_);
-                parse_num(buf, *dest);
-            }
+            parse_num(buf, exchange_type_cast<x_integer>(data_));
             break;
         case x_long_long:
-            {
-                long long *dest = static_cast<long long *>(data_);
-                parse_num(buf, *dest);
-            }
+            parse_num(buf, exchange_type_cast<x_long_long>(data_));
             break;
         case x_unsigned_long_long:
-            {
-                unsigned long long *dest =
-                    static_cast<unsigned long long*>(data_);
-                parse_num(buf, *dest);
-            }
+            parse_num(buf, exchange_type_cast<x_unsigned_long_long>(data_));
             break;
         case x_double:
-            {
-                double *dest = static_cast<double*>(data_);
-                parse_num(buf, *dest);
-            }
+            parse_num(buf, exchange_type_cast<x_double>(data_));
             break;
         case x_stdtm:
-            {
-                // attempt to parse the string and convert to std::tm
-                std::tm *dest = static_cast<std::tm *>(data_);
-                parse_std_tm(buf, *dest);
-            }
+            // attempt to parse the string and convert to std::tm
+            parse_std_tm(buf, exchange_type_cast<x_stdtm>(data_));
             break;
         default:
             throw soci_error("Into element used with non-supported type.");

--- a/src/backends/mysql/standard-use-type.cpp
+++ b/src/backends/mysql/standard-use-type.cpp
@@ -11,6 +11,7 @@
 #include "common.h"
 #include "soci/soci-platform.h"
 #include "soci-dtocstr.h"
+#include "soci-exchange-cast.h"
 // std
 #include <ciso646>
 #include <cstdio>
@@ -56,15 +57,15 @@ void mysql_standard_use_type_backend::pre_use(indicator const *ind)
         {
         case x_char:
             {
-                char buf[] = { *static_cast<char*>(data_), '\0' };
+                char buf[] = { exchange_type_cast<x_char>(data_), '\0' };
                 buf_ = quote(statement_.session_.conn_, buf, 1);
             }
             break;
         case x_stdstring:
             {
-                std::string *s = static_cast<std::string *>(data_);
+                std::string const& s = exchange_type_cast<x_stdstring>(data_);
                 buf_ = quote(statement_.session_.conn_,
-                             s->c_str(), s->size());
+                             s.c_str(), s.size());
             }
             break;
         case x_short:
@@ -73,7 +74,7 @@ void mysql_standard_use_type_backend::pre_use(indicator const *ind)
                     = std::numeric_limits<short>::digits10 + 3;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%d",
-                    static_cast<int>(*static_cast<short*>(data_)));
+                    static_cast<int>(exchange_type_cast<x_short>(data_)));
             }
             break;
         case x_integer:
@@ -81,7 +82,7 @@ void mysql_standard_use_type_backend::pre_use(indicator const *ind)
                 std::size_t const bufSize
                     = std::numeric_limits<int>::digits10 + 3;
                 buf_ = new char[bufSize];
-                snprintf(buf_, bufSize, "%d", *static_cast<int*>(data_));
+                snprintf(buf_, bufSize, "%d", exchange_type_cast<x_integer>(data_));
             }
             break;
         case x_long_long:
@@ -89,7 +90,7 @@ void mysql_standard_use_type_backend::pre_use(indicator const *ind)
                 std::size_t const bufSize
                     = std::numeric_limits<long long>::digits10 + 3;
                 buf_ = new char[bufSize];
-                snprintf(buf_, bufSize, "%" LL_FMT_FLAGS "d", *static_cast<long long *>(data_));
+                snprintf(buf_, bufSize, "%" LL_FMT_FLAGS "d", exchange_type_cast<x_long_long>(data_));
             }
             break;
         case x_unsigned_long_long:
@@ -98,19 +99,20 @@ void mysql_standard_use_type_backend::pre_use(indicator const *ind)
                     = std::numeric_limits<unsigned long long>::digits10 + 3;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%" LL_FMT_FLAGS "u",
-                         *static_cast<unsigned long long *>(data_));
+                         exchange_type_cast<x_unsigned_long_long>(data_));
             }
             break;
 
         case x_double:
             {
-                if (is_infinity_or_nan(*static_cast<double*>(data_))) {
+                double const d = exchange_type_cast<x_double>(data_);
+                if (is_infinity_or_nan(d)) {
                     throw soci_error(
                         "Use element used with infinity or NaN, which are "
                         "not supported by the MySQL server.");
                 }
 
-                std::string const s = double_to_cstring(*static_cast<double *>(data_));
+                std::string const s = double_to_cstring(d);
 
                 buf_ = new char[s.size() + 1];
                 std::strcpy(buf_, s.c_str());
@@ -121,11 +123,11 @@ void mysql_standard_use_type_backend::pre_use(indicator const *ind)
                 std::size_t const bufSize = 22;
                 buf_ = new char[bufSize];
 
-                std::tm *t = static_cast<std::tm *>(data_);
+                std::tm const& t = exchange_type_cast<x_stdtm>(data_);
                 snprintf(buf_, bufSize,
                     "\'%d-%02d-%02d %02d:%02d:%02d\'",
-                    t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
-                    t->tm_hour, t->tm_min, t->tm_sec);
+                    t.tm_year + 1900, t.tm_mon + 1, t.tm_mday,
+                    t.tm_hour, t.tm_min, t.tm_sec);
             }
             break;
         default:

--- a/src/backends/odbc/standard-use-type.cpp
+++ b/src/backends/odbc/standard-use-type.cpp
@@ -6,6 +6,7 @@
 #define SOCI_ODBC_SOURCE
 #include "soci/soci-platform.h"
 #include "soci/odbc/soci-odbc.h"
+#include "soci-exchange-cast.h"
 #include <cctype>
 #include <cstdio>
 #include <cstring>
@@ -45,7 +46,7 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
           size = max_bigint_length;
           buf_ = new char[size];
           snprintf(buf_, size, "%" LL_FMT_FLAGS "d",
-                   *static_cast<long long *>(data_));
+                   exchange_type_cast<x_long_long>(data_));
           indHolder_ = SQL_NTS;
         }
         else // Normal case, use ODBC support.
@@ -63,7 +64,7 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
           size = max_bigint_length;
           buf_ = new char[size];
           snprintf(buf_, size, "%" LL_FMT_FLAGS "u",
-                   *static_cast<unsigned long long *>(data_));
+                   exchange_type_cast<x_unsigned_long_long>(data_));
           indHolder_ = SQL_NTS;
         }
         else // Normal case, use ODBC support.
@@ -84,25 +85,25 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
         cType = SQL_C_CHAR;
         size = 2;
         buf_ = new char[size];
-        buf_[0] = *static_cast<char*>(data_);
+        buf_[0] = exchange_type_cast<x_char>(data_);
         buf_[1] = '\0';
         indHolder_ = SQL_NTS;
         break;
     case x_stdstring:
     {
-        std::string* s = static_cast<std::string*>(data_);
+        std::string const& s = exchange_type_cast<x_stdstring>(data_);
         sqlType = SQL_VARCHAR;
         cType = SQL_C_CHAR;
-        size = s->size();
+        size = s.size();
         buf_ = new char[size+1];
-        memcpy(buf_, s->c_str(), size);
+        memcpy(buf_, s.c_str(), size);
         buf_[size++] = '\0';
         indHolder_ = SQL_NTS;
     }
     break;
     case x_stdtm:
     {
-        std::tm *t = static_cast<std::tm *>(data_);
+        std::tm const& t = exchange_type_cast<x_stdtm>(data_);
 
         sqlType = SQL_TIMESTAMP;
         cType = SQL_C_TIMESTAMP;
@@ -113,12 +114,12 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
 
         TIMESTAMP_STRUCT * ts = reinterpret_cast<TIMESTAMP_STRUCT*>(buf_);
 
-        ts->year = static_cast<SQLSMALLINT>(t->tm_year + 1900);
-        ts->month = static_cast<SQLUSMALLINT>(t->tm_mon + 1);
-        ts->day = static_cast<SQLUSMALLINT>(t->tm_mday);
-        ts->hour = static_cast<SQLUSMALLINT>(t->tm_hour);
-        ts->minute = static_cast<SQLUSMALLINT>(t->tm_min);
-        ts->second = static_cast<SQLUSMALLINT>(t->tm_sec);
+        ts->year = static_cast<SQLSMALLINT>(t.tm_year + 1900);
+        ts->month = static_cast<SQLUSMALLINT>(t.tm_mon + 1);
+        ts->day = static_cast<SQLUSMALLINT>(t.tm_mday);
+        ts->hour = static_cast<SQLUSMALLINT>(t.tm_hour);
+        ts->minute = static_cast<SQLUSMALLINT>(t.tm_min);
+        ts->second = static_cast<SQLUSMALLINT>(t.tm_sec);
         ts->fraction = 0;
     }
     break;

--- a/src/backends/oracle/standard-into-type.cpp
+++ b/src/backends/oracle/standard-into-type.cpp
@@ -12,6 +12,7 @@
 #include "soci/rowid.h"
 #include "soci/statement.h"
 #include "soci/soci-platform.h"
+#include "soci-exchange-cast.h"
 #include <cctype>
 #include <cstdio>
 #include <cstring>
@@ -176,44 +177,41 @@ void oracle_standard_into_type_backend::post_fetch(
         {
             if (indOCIHolder_ != -1)
             {
-                std::string *s = static_cast<std::string *>(data_);
-                *s = buf_;
+                exchange_type_cast<x_stdstring>(data_) = buf_;
             }
         }
         else if (type_ == x_long_long)
         {
             if (indOCIHolder_ != -1)
             {
-                long long *v = static_cast<long long *>(data_);
-                *v = std::strtoll(buf_, NULL, 10);
+                exchange_type_cast<x_long_long>(data_) = std::strtoll(buf_, NULL, 10);
             }
         }
         else if (type_ == x_unsigned_long_long)
         {
             if (indOCIHolder_ != -1)
             {
-                unsigned long long *v = static_cast<unsigned long long *>(data_);
-                *v = std::strtoull(buf_, NULL, 10);
+                exchange_type_cast<x_unsigned_long_long>(data_) = std::strtoull(buf_, NULL, 10);
             }
         }
         else if (type_ == x_stdtm)
         {
             if (indOCIHolder_ != -1)
             {
-                std::tm *t = static_cast<std::tm *>(data_);
+                std::tm& t = exchange_type_cast<x_stdtm>(data_);
 
                 ub1 *pos = reinterpret_cast<ub1*>(buf_);
-                t->tm_isdst = -1;
-                t->tm_year = (*pos++ - 100) * 100;
-                t->tm_year += *pos++ - 2000;
-                t->tm_mon = *pos++ - 1;
-                t->tm_mday = *pos++;
-                t->tm_hour = *pos++ - 1;
-                t->tm_min = *pos++ - 1;
-                t->tm_sec = *pos++ - 1;
+                t.tm_isdst = -1;
+                t.tm_year = (*pos++ - 100) * 100;
+                t.tm_year += *pos++ - 2000;
+                t.tm_mon = *pos++ - 1;
+                t.tm_mday = *pos++;
+                t.tm_hour = *pos++ - 1;
+                t.tm_min = *pos++ - 1;
+                t.tm_sec = *pos++ - 1;
                 
                 // normalize and compute the remaining fields
-                std::mktime(t);
+                std::mktime(&t);
             }
         }
         else if (type_ == x_statement)

--- a/src/backends/oracle/standard-use-type.cpp
+++ b/src/backends/oracle/standard-use-type.cpp
@@ -14,6 +14,7 @@
 #include "soci/soci-platform.h"
 
 #include "soci-compiler.h"
+#include "soci-exchange-cast.h"
 
 #include <cctype>
 #include <cstdio>
@@ -209,64 +210,64 @@ void oracle_standard_use_type_backend::pre_use(indicator const *ind)
     case x_char:
         if (readOnly_)
         {
-            buf_[0] = *static_cast<char *>(data_);
+            buf_[0] = exchange_type_cast<x_char>(data_);
         }
         break;
     case x_short:
         if (readOnly_)
         {
-            *static_cast<short *>(static_cast<void *>(buf_)) = *static_cast<short *>(data_);
+            exchange_type_cast<x_short>(buf_) = exchange_type_cast<x_short>(data_);
         }
         break;
     case x_integer:
         if (readOnly_)
         {
-            *static_cast<int *>(static_cast<void *>(buf_)) = *static_cast<int *>(data_);
+            exchange_type_cast<x_integer>(buf_) = exchange_type_cast<x_integer>(data_);
         }
         break;
     case x_long_long:
         {
             size_t const size = 100; // arbitrary, but consistent with prepare_for_bind
-            snprintf(buf_, size, "%" LL_FMT_FLAGS "d", *static_cast<long long *>(data_));
+            snprintf(buf_, size, "%" LL_FMT_FLAGS "d", exchange_type_cast<x_long_long>(data_));
         }
         break;
     case x_unsigned_long_long:
         {
             size_t const size = 100; // arbitrary, but consistent with prepare_for_bind
-            snprintf(buf_, size, "%" LL_FMT_FLAGS "u", *static_cast<unsigned long long *>(data_));
+            snprintf(buf_, size, "%" LL_FMT_FLAGS "u", exchange_type_cast<x_unsigned_long_long>(data_));
         }
         break;
     case x_double:
         if (readOnly_)
         {
-            *static_cast<double *>(static_cast<void *>(buf_)) = *static_cast<double *>(data_);
+            exchange_type_cast<x_double>(buf_) = exchange_type_cast<x_double>(data_);
         }
         break;
     case x_stdstring:
         {
-            std::string *s = static_cast<std::string *>(data_);
+            std::string const& s = exchange_type_cast<x_stdstring>(data_);
 
             // 4000 is Oracle max VARCHAR2 size; 32768 is max LONG size
             std::size_t const bufSize = 32769;
-            std::size_t const sSize = s->size();
+            std::size_t const sSize = s.size();
             std::size_t const toCopy =
                 sSize < bufSize -1 ? sSize + 1 : bufSize - 1;
-            strncpy(buf_, s->c_str(), toCopy);
+            strncpy(buf_, s.c_str(), toCopy);
             buf_[toCopy] = '\0';
         }
         break;
     case x_stdtm:
         {
-            std::tm *t = static_cast<std::tm *>(data_);
+            std::tm const& t = exchange_type_cast<x_stdtm>(data_);
             ub1* pos = reinterpret_cast<ub1*>(buf_);
 
-            *pos++ = static_cast<ub1>(100 + (1900 + t->tm_year) / 100);
-            *pos++ = static_cast<ub1>(100 + t->tm_year % 100);
-            *pos++ = static_cast<ub1>(t->tm_mon + 1);
-            *pos++ = static_cast<ub1>(t->tm_mday);
-            *pos++ = static_cast<ub1>(t->tm_hour + 1);
-            *pos++ = static_cast<ub1>(t->tm_min + 1);
-            *pos = static_cast<ub1>(t->tm_sec + 1);
+            *pos++ = static_cast<ub1>(100 + (1900 + t.tm_year) / 100);
+            *pos++ = static_cast<ub1>(100 + t.tm_year % 100);
+            *pos++ = static_cast<ub1>(t.tm_mon + 1);
+            *pos++ = static_cast<ub1>(t.tm_mday);
+            *pos++ = static_cast<ub1>(t.tm_hour + 1);
+            *pos++ = static_cast<ub1>(t.tm_min + 1);
+            *pos = static_cast<ub1>(t.tm_sec + 1);
         }
         break;
     case x_statement:
@@ -309,7 +310,7 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
         case x_char:
             if (readOnly_)
             {
-                const char original = *static_cast<char *>(data_);
+                const char original = exchange_type_cast<x_char>(data_);
                 const char bound = buf_[0];
 
                 if (original != bound)
@@ -321,8 +322,8 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
         case x_short:
             if (readOnly_)
             {
-                const short original = *static_cast<short *>(data_);
-                const short bound = *static_cast<short *>(static_cast<void *>(buf_));
+                const short original = exchange_type_cast<x_short>(data_);
+                const short bound = exchange_type_cast<x_short>(buf_);
 
                 if (original != bound)
                 {
@@ -333,8 +334,8 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
         case x_integer:
             if (readOnly_)
             {
-                const int original = *static_cast<int *>(data_);
-                const int bound = *static_cast<int *>(static_cast<void *>(buf_));
+                const int original = exchange_type_cast<x_integer>(data_);
+                const int bound = exchange_type_cast<x_integer>(buf_);
 
                 if (original != bound)
                 {
@@ -345,7 +346,7 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
         case x_long_long:
             if (readOnly_)
             {
-                long long const original = *static_cast<long long *>(data_);
+                long long const original = exchange_type_cast<x_long_long>(data_);
                 long long const bound = std::strtoll(buf_, NULL, 10);
 
                 if (original != bound)
@@ -357,7 +358,7 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
         case x_unsigned_long_long:
             if (readOnly_)
             {
-                unsigned long long const original = *static_cast<unsigned long long *>(data_);
+                unsigned long long const original = exchange_type_cast<x_unsigned_long_long>(data_);
                 unsigned long long const bound = std::strtoull(buf_, NULL, 10);
 
                 if (original != bound)
@@ -369,8 +370,8 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
         case x_double:
             if (readOnly_)
             {
-                const double original = *static_cast<double *>(data_);
-                const double bound = *static_cast<double *>(static_cast<void *>(buf_));
+                const double original = exchange_type_cast<x_double>(data_);
+                const double bound = exchange_type_cast<x_double>(buf_);
 
                 // Exact comparison is fine here, they are really supposed to
                 // be exactly the same.
@@ -386,7 +387,7 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
             break;
         case x_stdstring:
             {
-                std::string & original = *static_cast<std::string *>(data_);
+                std::string& original = exchange_type_cast<x_stdstring>(data_);
                 if (original != buf_)
                 {
                     if (readOnly_)
@@ -402,7 +403,7 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
             break;
         case x_stdtm:
             {
-                std::tm & original = *static_cast<std::tm *>(data_);
+                std::tm& original = exchange_type_cast<x_stdtm>(data_);
 
                 std::tm bound;
                 ub1 *pos = reinterpret_cast<ub1*>(buf_);

--- a/src/backends/postgresql/standard-into-type.cpp
+++ b/src/backends/postgresql/standard-into-type.cpp
@@ -12,6 +12,7 @@
 #include "common.h"
 #include "soci/rowid.h"
 #include "soci/blob.h"
+#include "soci-exchange-cast.h"
 #include <libpq/libpq-fs.h> // libpq
 #include <cctype>
 #include <cstdio>
@@ -88,53 +89,29 @@ void postgresql_standard_into_type_backend::post_fetch(
         switch (type_)
         {
         case x_char:
-            {
-                char * dest = static_cast<char *>(data_);
-                *dest = *buf;
-            }
+            exchange_type_cast<x_char>(data_) = *buf;
             break;
         case x_stdstring:
-            {
-                std::string * dest = static_cast<std::string *>(data_);
-                dest->assign(buf);
-            }
+            exchange_type_cast<x_stdstring>(data_) = buf;
             break;
         case x_short:
-            {
-                short * dest = static_cast<short *>(data_);
-                *dest = string_to_integer<short>(buf);
-            }
+            exchange_type_cast<x_short>(data_) = string_to_integer<short>(buf);
             break;
         case x_integer:
-            {
-                int * dest = static_cast<int *>(data_);
-                *dest = string_to_integer<int>(buf);
-            }
+            exchange_type_cast<x_integer>(data_) = string_to_integer<int>(buf);
             break;
         case x_long_long:
-            {
-                long long * dest = static_cast<long long *>(data_);
-                *dest = string_to_integer<long long>(buf);
-            }
+            exchange_type_cast<x_long_long>(data_) = string_to_integer<long long>(buf);
             break;
         case x_unsigned_long_long:
-            {
-                unsigned long long * dest = static_cast<unsigned long long *>(data_);
-                *dest = string_to_unsigned_integer<unsigned long long>(buf);
-            }
+            exchange_type_cast<x_unsigned_long_long>(data_) = string_to_unsigned_integer<unsigned long long>(buf);
             break;
         case x_double:
-            {
-                double * dest = static_cast<double *>(data_);
-                *dest = cstring_to_double(buf);
-            }
+            exchange_type_cast<x_double>(data_) = cstring_to_double(buf);
             break;
         case x_stdtm:
-            {
-                // attempt to parse the string and convert to std::tm
-                std::tm * dest = static_cast<std::tm *>(data_);
-                parse_std_tm(buf, *dest);
-            }
+            // attempt to parse the string and convert to std::tm
+            parse_std_tm(buf, exchange_type_cast<x_stdtm>(data_));
             break;
         case x_rowid:
             {

--- a/src/backends/postgresql/standard-use-type.cpp
+++ b/src/backends/postgresql/standard-use-type.cpp
@@ -11,6 +11,7 @@
 #include "soci/rowid.h"
 #include "soci/soci-platform.h"
 #include "soci-dtocstr.h"
+#include "soci-exchange-cast.h"
 #include <libpq/libpq-fs.h> // libpq
 #include <cctype>
 #include <cstdio>
@@ -69,15 +70,15 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
         case x_char:
             {
                 buf_ = new char[2];
-                buf_[0] = *static_cast<char *>(data_);
+                buf_[0] = exchange_type_cast<x_char>(data_);
                 buf_[1] = '\0';
             }
             break;
         case x_stdstring:
             {
-                std::string * s = static_cast<std::string *>(data_);
-                buf_ = new char[s->size() + 1];
-                std::strcpy(buf_, s->c_str());
+                std::string const& s = exchange_type_cast<x_stdstring>(data_);
+                buf_ = new char[s.size() + 1];
+                std::strcpy(buf_, s.c_str());
             }
             break;
         case x_short:
@@ -86,7 +87,7 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
                     = std::numeric_limits<short>::digits10 + 3;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%d",
-                    static_cast<int>(*static_cast<short *>(data_)));
+                    static_cast<int>(exchange_type_cast<x_short>(data_)));
             }
             break;
         case x_integer:
@@ -95,7 +96,7 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
                     = std::numeric_limits<int>::digits10 + 3;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%d",
-                    *static_cast<int *>(data_));
+                    exchange_type_cast<x_integer>(data_));
             }
             break;
         case x_long_long:
@@ -104,7 +105,7 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
                     = std::numeric_limits<long long>::digits10 + 3;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%" LL_FMT_FLAGS "d",
-                    *static_cast<long long *>(data_));
+                    exchange_type_cast<x_long_long>(data_));
             }
             break;
         case x_unsigned_long_long:
@@ -113,12 +114,12 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
                     = std::numeric_limits<unsigned long long>::digits10 + 2;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%" LL_FMT_FLAGS "u",
-                    *static_cast<unsigned long long *>(data_));
+                    exchange_type_cast<x_unsigned_long_long>(data_));
             }
             break;
         case x_double:
             {
-                std::string const s = double_to_cstring(*static_cast<double *>(data_));
+                std::string const s = double_to_cstring(exchange_type_cast<x_double>(data_));
 
                 buf_ = new char[s.size() + 1];
                 std::strcpy(buf_, s.c_str());
@@ -129,10 +130,10 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
                 std::size_t const bufSize = 20;
                 buf_ = new char[bufSize];
 
-                std::tm * t = static_cast<std::tm *>(data_);
+                std::tm const& t = exchange_type_cast<x_stdtm>(data_);
                 snprintf(buf_, bufSize, "%d-%02d-%02d %02d:%02d:%02d",
-                    t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
-                    t->tm_hour, t->tm_min, t->tm_sec);
+                    t.tm_year + 1900, t.tm_mon + 1, t.tm_mday,
+                    t.tm_hour, t.tm_min, t.tm_sec);
             }
             break;
         case x_rowid:

--- a/src/backends/sqlite3/standard-into-type.cpp
+++ b/src/backends/sqlite3/standard-into-type.cpp
@@ -11,6 +11,7 @@
 #include "common.h"
 #include "soci/blob.h"
 #include "soci-cstrtod.h"
+#include "soci-exchange-cast.h"
 // std
 #include <cstdlib>
 #include <ctime>
@@ -80,55 +81,35 @@ void sqlite3_standard_into_type_backend::post_fetch(bool gotData,
         switch (type_)
         {
         case x_char:
-            {
-                char *dest = static_cast<char*>(data_);
-                *dest = *buf;
-            }
+            exchange_type_cast<x_char>(data_) = *buf;
             break;
         case x_stdstring:
-            {
-                std::string *dest = static_cast<std::string *>(data_);
-                dest->assign(buf);
-            }
+            exchange_type_cast<x_stdstring>(data_) = buf;
             break;
         case x_short:
             {
-                short *dest = static_cast<short*>(data_);
                 long val = std::strtol(buf, NULL, 10);
-                *dest = static_cast<short>(val);
+                exchange_type_cast<x_short>(data_) = static_cast<short>(val);
             }
             break;
         case x_integer:
             {
-                int *dest = static_cast<int*>(data_);
                 long val = std::strtol(buf, NULL, 10);
-                *dest = static_cast<int>(val);
+                exchange_type_cast<x_integer>(data_) = static_cast<int>(val);
             }
             break;
         case x_long_long:
-            {
-                long long* dest = static_cast<long long*>(data_);
-                *dest = std::strtoll(buf, NULL, 10);
-            }
+            exchange_type_cast<x_long_long>(data_) = std::strtoll(buf, NULL, 10);
             break;
         case x_unsigned_long_long:
-            {
-                unsigned long long* dest = static_cast<unsigned long long*>(data_);
-                *dest = string_to_unsigned_integer<unsigned long long>(buf);
-            }
+            exchange_type_cast<x_unsigned_long_long>(data_) = string_to_unsigned_integer<unsigned long long>(buf);
             break;
         case x_double:
-            {
-                double *dest = static_cast<double*>(data_);
-                *dest = cstring_to_double(buf);
-            }
+            exchange_type_cast<x_double>(data_) = cstring_to_double(buf);
             break;
         case x_stdtm:
-            {
-                // attempt to parse the string and convert to std::tm
-                std::tm *dest = static_cast<std::tm *>(data_);
-                parse_std_tm(buf, *dest);
-            }
+            // attempt to parse the string and convert to std::tm
+            parse_std_tm(buf, exchange_type_cast<x_stdtm>(data_));
             break;
         case x_rowid:
             {

--- a/src/backends/sqlite3/standard-use-type.cpp
+++ b/src/backends/sqlite3/standard-use-type.cpp
@@ -10,6 +10,7 @@
 #include "soci/rowid.h"
 #include "soci/blob.h"
 #include "soci-dtocstr.h"
+#include "soci-exchange-cast.h"
 // std
 #include <cstdio>
 #include <cstdlib>
@@ -93,15 +94,15 @@ void sqlite3_standard_use_type_backend::pre_use(indicator const * ind)
         case x_char:
             {
                 buf_ = new char[2];
-                buf_[0] = *static_cast<char*>(data_);
+                buf_[0] = exchange_type_cast<x_char>(data_);
                 buf_[1] = '\0';
             }
             break;
         case x_stdstring:
             {
-                std::string *s = static_cast<std::string *>(data_);
-                buf_ = new char[s->size() + 1];
-                std::strcpy(buf_, s->c_str());
+                std::string const& s = exchange_type_cast<x_stdstring>(data_);
+                buf_ = new char[s.size() + 1];
+                std::strcpy(buf_, s.c_str());
             }
             break;
         case x_short:
@@ -110,7 +111,7 @@ void sqlite3_standard_use_type_backend::pre_use(indicator const * ind)
                     = std::numeric_limits<short>::digits10 + 3;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%d",
-                    static_cast<int>(*static_cast<short*>(data_)));
+                    static_cast<int>(exchange_type_cast<x_short>(data_)));
             }
             break;
         case x_integer:
@@ -119,7 +120,7 @@ void sqlite3_standard_use_type_backend::pre_use(indicator const * ind)
                     = std::numeric_limits<int>::digits10 + 3;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%d",
-                    *static_cast<int*>(data_));
+                    exchange_type_cast<x_integer>(data_));
             }
             break;
         case x_long_long:
@@ -128,7 +129,7 @@ void sqlite3_standard_use_type_backend::pre_use(indicator const * ind)
                     = std::numeric_limits<long long>::digits10 + 3;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%" LL_FMT_FLAGS "d",
-                    *static_cast<long long *>(data_));
+                    exchange_type_cast<x_long_long>(data_));
             }
             break;
         case x_unsigned_long_long:
@@ -137,12 +138,12 @@ void sqlite3_standard_use_type_backend::pre_use(indicator const * ind)
                     = std::numeric_limits<unsigned long long>::digits10 + 2;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%" LL_FMT_FLAGS "u",
-                    *static_cast<unsigned long long *>(data_));
+                    exchange_type_cast<x_unsigned_long_long>(data_));
             }
             break;
         case x_double:
             {
-                std::string const s = double_to_cstring(*static_cast<double *>(data_));
+                std::string const s = double_to_cstring(exchange_type_cast<x_double>(data_));
 
                 buf_ = new char[s.size() + 1];
                 std::strcpy(buf_, s.c_str());
@@ -153,10 +154,10 @@ void sqlite3_standard_use_type_backend::pre_use(indicator const * ind)
                 std::size_t const bufSize = 20;
                 buf_ = new char[bufSize];
 
-                std::tm *t = static_cast<std::tm *>(data_);
+                std::tm& t = exchange_type_cast<x_stdtm>(data_);
                 snprintf(buf_, bufSize, "%d-%02d-%02d %02d:%02d:%02d",
-                    t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
-                    t->tm_hour, t->tm_min, t->tm_sec);
+                    t.tm_year + 1900, t.tm_mon + 1, t.tm_mday,
+                    t.tm_hour, t.tm_min, t.tm_sec);
             }
             break;
         case x_rowid:


### PR DESCRIPTION
The new functions replaces explicit static_cast<> and can be used to upcast a
void pointer to the type of the value corresponding to the exchange_type
associated with it somewhat more safely and less verbosely.

There are no real changes in this commit.