### PR TITLE
Provide error context in the exceptions.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,10 @@ This file contains the history of changes in the SOCI library.
 ---
 Version 4.0.0 differs from 3.2.x in the following ways:
 
+- Provide context of the failure in soci_error::what() which now returns a
+  longer and more useful message. Use the new get_error_message() method to get
+  just the brief error message which used to be returned by what().
+
 - Firebird
 -- Add SOCI_FIREBIRD_EMBEDDED option to allow building with embedded library.
 

--- a/docs/errors.html
+++ b/docs/errors.html
@@ -30,6 +30,12 @@ int main()
 }
 </pre>
 
+<p>
+The only public method of <code>soci_error</code> is <code>std::string get_error_message() const</code>,
+which returns just the brief error message, without any additional information
+that can be present in the full error message returned by <code>what()</code>.
+</p>
+
 <div class="note">
 <p><span class="note">Portability note:</span></p>
 <p>The Oracle backend can also throw the instances of the <code>oracle_soci_error</code>,

--- a/include/soci/error.h
+++ b/include/soci/error.h
@@ -22,8 +22,27 @@ class SOCI_DECL soci_error : public std::runtime_error
 public:
     explicit soci_error(std::string const & msg);
 
+    soci_error(soci_error const& e);
+    soci_error& operator=(soci_error const& e);
+
+    virtual ~soci_error() throw();
+
     // Returns just the error message itself, without the context.
     std::string get_error_message() const;
+
+    // Returns the full error message combining the message given to the ctor
+    // with all the available context records.
+    virtual char const* what() const throw();
+
+    // This is used only by SOCI itself to provide more information about the
+    // exception as it bubbles up. It can be called multiple times, with the
+    // first call adding the lowest level context and the last one -- the
+    // highest level context.
+    void add_context(std::string const& context);
+
+private:
+    // Optional extra information (currently just the context data).
+    class soci_error_extra_info* info_;
 };
 
 } // namespace soci

--- a/include/soci/error.h
+++ b/include/soci/error.h
@@ -1,5 +1,6 @@
 //
 // Copyright (C) 2004-2008 Maciej Sobczak
+// Copyright (C) 2015 Vadim Zeitlin
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -20,6 +21,9 @@ class SOCI_DECL soci_error : public std::runtime_error
 {
 public:
     explicit soci_error(std::string const & msg);
+
+    // Returns just the error message itself, without the context.
+    std::string get_error_message() const;
 };
 
 } // namespace soci

--- a/include/soci/statement.h
+++ b/include/soci/statement.h
@@ -77,6 +77,11 @@ protected:
     std::vector<indicator *> indicators_;
 
 private:
+    // Call this method from a catch clause (only!) to rethrow the exception
+    // after adding the context in which it happened, including the provided
+    // description of the operation that failed, the SQL query and, if
+    // applicable, its parameters.
+    void rethrow_current_exception_with_context(char const* operation);
 
     int refCount_;
 

--- a/include/soci/use-type.h
+++ b/include/soci/use-type.h
@@ -13,6 +13,7 @@
 #include "soci/exchange-traits.h"
 // std
 #include <cstddef>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -28,6 +29,8 @@ public:
     virtual ~use_type_base() {}
 
     virtual void bind(statement_impl & st, int & position) = 0;
+    virtual std::string get_name() const = 0;
+    virtual void dump_value(std::ostream& os) const = 0;
     virtual void pre_use() = 0;
     virtual void post_use(bool gotData) = 0;
     virtual void clean_up() = 0;
@@ -70,7 +73,8 @@ public:
 
     virtual ~standard_use_type();
     virtual void bind(statement_impl & st, int & position);
-    std::string get_name() const { return name_; }
+    virtual std::string get_name() const { return name_; }
+    virtual void dump_value(std::ostream& os) const;
     virtual void * get_data() { return data_; }
 
     // conversion hook (from arbitrary user type to base type)
@@ -120,6 +124,8 @@ public:
 
 private:
     virtual void bind(statement_impl& st, int & position);
+    virtual std::string get_name() const { return name_; }
+    virtual void dump_value(std::ostream& os) const;
     virtual void pre_use();
     virtual void post_use(bool) { /* nothing to do */ }
     virtual void clean_up();

--- a/include/soci/values-exchange.h
+++ b/include/soci/values-exchange.h
@@ -14,6 +14,7 @@
 #include "soci/row-exchange.h"
 // std
 #include <cstddef>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -51,6 +52,32 @@ public:
 
         convert_to_base();
         st.bind(v_);
+    }
+
+    virtual std::string get_name() const
+    {
+        std::ostringstream oss;
+
+        oss << "(";
+
+        std::size_t const num_columns = v_.get_number_of_columns();
+        for (std::size_t n = 0; n < num_columns; ++n)
+        {
+            if (n != 0)
+                oss << ", ";
+
+            oss << v_.get_properties(n).get_name();
+        }
+
+        oss << ")";
+
+        return oss.str();
+    }
+
+    virtual void dump_value(std::ostream& os) const
+    {
+        // TODO: Dump all columns.
+        os << "<value>";
     }
 
     virtual void post_use(bool /*gotData*/)

--- a/src/core/error.cpp
+++ b/src/core/error.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (C) 2004-2008 Maciej Sobczak, Stephen Hutton
+// Copyright (C) 2015 Vadim Zeitlin
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -14,4 +15,9 @@ using namespace soci;
 soci_error::soci_error(std::string const & msg)
      : std::runtime_error(msg)
 {
+}
+
+std::string soci_error::get_error_message() const
+{
+    return std::runtime_error::what();
 }

--- a/src/core/error.cpp
+++ b/src/core/error.cpp
@@ -10,14 +10,116 @@
 
 #include "soci/error.h"
 
-using namespace soci;
+#include <sstream>
+#include <vector>
+
+namespace soci
+{
+
+class soci_error_extra_info
+{
+public:
+    soci_error_extra_info()
+    {
+    }
+
+    // Default copy ctor, assignment operator and dtor are fine.
+
+    char const* get_full_message(std::string const& message)
+    {
+        if (full_message_.empty())
+        {
+            full_message_ = message;
+
+            if (!contexts_.empty())
+            {
+                // This is a hack, but appending the extra context to the
+                // message looks much better if we remove the full stop at its
+                // end first.
+                if (*full_message_.rbegin() == '.')
+                    full_message_.erase(full_message_.size() - 1);
+
+                // Now do append all the extra context we have.
+                typedef std::vector<std::string>::const_iterator iter_type;
+                for (iter_type i = contexts_.begin(); i != contexts_.end(); ++i)
+                {
+                    full_message_ += " ";
+                    full_message_ += *i;
+                }
+
+                // It seems better to always terminate the full message with a
+                // full stop, even if the original error message didn't have it
+                // (and if it had, we just restore the one we chopped off).
+                full_message_ += ".";
+            }
+        }
+
+        return full_message_.c_str();
+    }
+
+    void add_context(std::string const& context)
+    {
+        full_message_.clear();
+        contexts_.push_back(context);
+    }
+
+private:
+    // The full error message, we need to store it as a string as we return a
+    // pointer to its contents from get_full_message().
+    std::string full_message_;
+
+    // If non-empty, contains extra context for this exception, e.g.
+    // information about the SQL statement that resulted in it, with the top
+    // element corresponding to the most global context.
+    std::vector<std::string> contexts_;
+};
 
 soci_error::soci_error(std::string const & msg)
      : std::runtime_error(msg)
 {
+    info_ = NULL;
+}
+
+soci_error::soci_error(soci_error const& e)
+    : std::runtime_error(e)
+{
+    info_ = e.info_ ? new soci_error_extra_info(*e.info_) : NULL;
+}
+
+soci_error& soci_error::operator=(soci_error const& e)
+{
+    std::runtime_error::operator=(e);
+
+    delete info_;
+    info_ = e.info_ ? new soci_error_extra_info(*e.info_) : NULL;
+
+    return *this;
+}
+
+soci_error::~soci_error() throw()
+{
+    delete info_;
 }
 
 std::string soci_error::get_error_message() const
 {
     return std::runtime_error::what();
 }
+
+char const* soci_error::what() const throw()
+{
+    if (info_)
+        return info_->get_full_message(get_error_message());
+
+    return std::runtime_error::what();
+}
+
+void soci_error::add_context(std::string const& context)
+{
+    if (!info_)
+        info_ = new soci_error_extra_info();
+
+    info_->add_context(context);
+}
+
+} // namespace soci

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -593,8 +593,7 @@ TEST_CASE_METHOD(common_tests, "Use and into", "[core][into]")
         }
         catch (soci_error const &e)
         {
-            std::string error = e.what();
-            CHECK(error ==
+            CHECK(e.get_error_message() ==
                 "Null value fetched and no indicator defined.");
         }
 
@@ -676,8 +675,8 @@ TEST_CASE_METHOD(common_tests, "Repeated and bulk fetch", "[core][bulk]")
             }
             catch (soci_error const &e)
             {
-                 std::string msg = e.what();
-                 CHECK(msg == "Vectors of size 0 are not allowed.");
+                 CHECK(e.get_error_message() ==
+                     "Vectors of size 0 are not allowed.");
             }
         }
 
@@ -1751,8 +1750,7 @@ TEST_CASE_METHOD(common_tests, "Named parameters", "[core][use][named-params]")
         }
         catch (soci_error const& e)
         {
-            std::string what(e.what());
-            CHECK(what ==
+            CHECK(e.get_error_message() ==
                 "Binding for use elements must be either by position "
                 "or by name.");
         }
@@ -1869,8 +1867,7 @@ TEST_CASE_METHOD(common_tests, "Transactions", "[core][transaction]")
         }
         catch (soci_error const &e)
         {
-            std::string msg = e.what();
-            CHECK(msg ==
+            CHECK(e.get_error_message() ==
                 "The transaction object cannot be handled twice.");
         }
     }
@@ -3207,8 +3204,8 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
         }
         catch (soci_error const &e)
         {
-            CHECK(e.what() == std::string(
-                       "Cannot reconnect without previous connection."));
+            CHECK(e.get_error_message() ==
+               "Cannot reconnect without previous connection.");
         }
 
         // open from empty session
@@ -3226,8 +3223,8 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
         }
         catch (soci_error const &e)
         {
-            CHECK(e.what() == std::string(
-                       "Cannot open already connected session."));
+            CHECK(e.get_error_message() ==
+               "Cannot open already connected session.");
         }
 
         sql.close();
@@ -3249,7 +3246,8 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
         }
         catch (soci_error const &e)
         {
-            CHECK(e.what() == std::string("Session is not connected."));
+            CHECK(e.get_error_message() ==
+                "Session is not connected.");
         }
     }
 
@@ -3585,7 +3583,8 @@ TEST_CASE_METHOD(common_tests, "Boost date", "[core][boost][datetime]")
         }
         catch (soci_error const & e)
         {
-            CHECK(e.what() == std::string("Null value not allowed for this type"));
+            CHECK(e.get_error_message() ==
+                "Null value not allowed for this type");
         }
     }
 

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -277,8 +277,7 @@ TEST_CASE("Firebird floating point", "[firebird][float]")
     }
     catch (soci_error const &e)
     {
-        std::string error = e.what();
-        CHECK(error ==
+        CHECK(e.get_error_message() ==
                "Can't convert value with scale 2 to integral type");
     }
 
@@ -293,8 +292,7 @@ TEST_CASE("Firebird floating point", "[firebird][float]")
     }
     catch (soci_error const &e)
     {
-        std::string error = e.what();
-        CHECK(error ==
+        CHECK(e.get_error_message() ==
                "Can't convert non-integral value to integral column type");
     }
 
@@ -352,8 +350,7 @@ TEST_CASE("Firebird integers", "[firebird][int]")
         }
         catch (soci_error const &e)
         {
-            std::string error = e.what();
-            CHECK(error ==
+            CHECK(e.get_error_message() ==
                    "Null value fetched and no indicator defined.");
         }
 
@@ -438,8 +435,8 @@ TEST_CASE("Firebird bulk operations", "[firebird][bulk]")
         }
         catch (soci_error const &e)
         {
-            std::string msg = e.what();
-            CHECK(msg == "Vectors of size 0 are not allowed.");
+            CHECK(e.get_error_message() ==
+                "Vectors of size 0 are not allowed.");
         }
     }
 

--- a/tests/mysql/test-mysql.cpp
+++ b/tests/mysql/test-mysql.cpp
@@ -623,7 +623,7 @@ TEST_CASE("MySQL special floating point values", "[mysql][float]")
     try {
         st.execute(true);
     } catch (soci_error const &e) {
-        CHECK(e.what() == expectedError);
+        CHECK(e.get_error_message() == expectedError);
     }
   }
   {
@@ -634,7 +634,7 @@ TEST_CASE("MySQL special floating point values", "[mysql][float]")
     try {
         st.execute(true);
     } catch (soci_error const &e) {
-        CHECK(e.what() == expectedError);
+        CHECK(e.get_error_message() == expectedError);
     }
   }
   {
@@ -645,7 +645,7 @@ TEST_CASE("MySQL special floating point values", "[mysql][float]")
     try {
         sql << "insert into soci_test (val) values (:val)", use(v);
     } catch (soci_error const &e) {
-        CHECK(e.what() == expectedError);
+        CHECK(e.get_error_message() == expectedError);
     }
   }
   {
@@ -656,7 +656,7 @@ TEST_CASE("MySQL special floating point values", "[mysql][float]")
     try {
         sql << "insert into soci_test (val) values (:val)", use(v);
     } catch (soci_error const &e) {
-        CHECK(e.what() == expectedError);
+        CHECK(e.get_error_message() == expectedError);
     }
   }
 }

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -339,7 +339,8 @@ TEST_CASE("PostgreSQL dynamic backend", "[postgresql][backend][.]")
     }
     catch (soci_error const & e)
     {
-        CHECK(e.what() == std::string("Failed to open: libsoci_nosuchbackend.so"));
+        CHECK(e.get_error_message() ==
+            "Failed to open: libsoci_nosuchbackend.so");
     }
 
     {


### PR DESCRIPTION
Include information about the failed query and its parameters, if applicable, in the exception object itself.