### PR TITLE
Don't add DB2_INCLUDE_DIR to global include directories.

### DIFF
--- a/cmake/modules/FindDB2.cmake
+++ b/cmake/modules/FindDB2.cmake
@@ -82,13 +82,8 @@ if(DB2_LIBRARY)
   get_filename_component(DB2_LIBRARY_DIR ${DB2_LIBRARY} PATH)
 endif()
 
-# TODO: To be removed to avoid setting *_directories at random directory-scope
 if(DB2_INCLUDE_DIR AND DB2_LIBRARY_DIR)
   set(DB2_FOUND TRUE)
-
-  include_directories(${DB2_INCLUDE_DIR})
-  link_directories(${DB2_LIBRARY_DIR})
-
 endif()
 
 set(DB2_LIBRARIES ${DB2_LIBRARY})


### PR DESCRIPTION
This breaks the build of ODBC backend and the tests using it as DB2 headers
directory contains sqlext.h file which is also used by ODBC.

And it was unnecessary anyhow because the generic soci_backend() macro already
takes care of adding $BACKEND_INCLUDE_DIR to the include directories just for
the $BACKEND target.

Also remove similar link_directories() line -- even though it doesn't seem to
result in any problems, it's still unnecessary.