### PR TITLE
Small cleanup remaining from the attempt to fix timezone handling

### DIFF
--- a/include/private/soci-mktime.h
+++ b/include/private/soci-mktime.h
@@ -1,0 +1,46 @@
+//
+// Copyright (C) 2015 Vadim Zeitlin.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_PRIVATE_SOCI_MKTIME_H_INCLUDED
+#define SOCI_PRIVATE_SOCI_MKTIME_H_INCLUDED
+
+// Not <ctime> because we also want to get timegm() if available.
+#include <time.h>
+
+namespace soci
+{
+
+namespace details
+{
+
+// Fill the provided struct tm with the values corresponding to the given date
+// in UTC.
+//
+// Notice that both years and months are normal human 1-based values here and
+// not 1900 or 0-based as in struct tm itself.
+inline
+void
+mktime_from_ymdhms(tm& t,
+                   int year, int month, int day,
+                   int hour, int minute, int second)
+{
+    t.tm_isdst = -1;
+    t.tm_year = year - 1900;
+    t.tm_mon  = month - 1;
+    t.tm_mday = day;
+    t.tm_hour = hour;
+    t.tm_min  = minute;
+    t.tm_sec  = second;
+
+    mktime(&t);
+}
+
+} // namespace details
+
+} // namespace soci
+
+#endif // SOCI_PRIVATE_SOCI_MKTIME_H_INCLUDED

--- a/src/backends/db2/standard-into-type.cpp
+++ b/src/backends/db2/standard-into-type.cpp
@@ -9,6 +9,7 @@
 #define SOCI_DB2_SOURCE
 #include "soci/db2/soci-db2.h"
 #include "soci-exchange-cast.h"
+#include "soci-mktime.h"
 #include "common.h"
 #include <ctime>
 
@@ -144,16 +145,10 @@ void db2_standard_into_type_backend::post_fetch(
             std::tm& t = exchange_type_cast<x_stdtm>(data);
 
             TIMESTAMP_STRUCT * ts = reinterpret_cast<TIMESTAMP_STRUCT*>(buf);
-            t.tm_isdst = -1;
-            t.tm_year = ts->year - 1900;
-            t.tm_mon = ts->month - 1;
-            t.tm_mday = ts->day;
-            t.tm_hour = ts->hour;
-            t.tm_min = ts->minute;
-            t.tm_sec = ts->second;
 
-            // normalize and compute the remaining fields
-            std::mktime(&t);
+            details::mktime_from_ymdhms(t,
+                                        ts->year, ts->month, ts->day,
+                                        ts->hour, ts->minute, ts->second);
         }
     }
 }

--- a/src/backends/db2/vector-into-type.cpp
+++ b/src/backends/db2/vector-into-type.cpp
@@ -8,6 +8,7 @@
 
 #define SOCI_DB2_SOURCE
 #include "soci/db2/soci-db2.h"
+#include "soci-mktime.h"
 #include <cctype>
 #include <cstdio>
 #include <cstring>
@@ -209,20 +210,10 @@ void db2_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             std::size_t const vsize = v.size();
             for (std::size_t i = 0; i != vsize; ++i)
             {
-                std::tm t;
-
                 TIMESTAMP_STRUCT * ts = reinterpret_cast<TIMESTAMP_STRUCT*>(pos);
-                t.tm_isdst = -1;
-                t.tm_year = ts->year - 1900;
-                t.tm_mon = ts->month - 1;
-                t.tm_mday = ts->day;
-                t.tm_hour = ts->hour;
-                t.tm_min = ts->minute;
-                t.tm_sec = ts->second;
-
-                // normalize and compute the remaining fields
-                std::mktime(&t);
-                v[i] = t;
+                details::mktime_from_ymdhms(v[i],
+                                            ts->year, ts->month, ts->day,
+                                            ts->hour, ts->minute, ts->second);
                 pos += colSize;
             }
         }

--- a/src/backends/mysql/common.cpp
+++ b/src/backends/mysql/common.cpp
@@ -7,6 +7,7 @@
 
 #include "common.h"
 #include "soci/soci-backend.h"
+#include "soci-mktime.h"
 #include <ciso646>
 #include <cstdlib>
 #include <cstring>
@@ -64,15 +65,7 @@ void soci::details::mysql::parse_std_tm(char const *buf, std::tm &t)
         second = parse10(p1, p2, errMsg);
     }
 
-    t.tm_isdst = -1;
-    t.tm_year = year - 1900;
-    t.tm_mon  = month - 1;
-    t.tm_mday = day;
-    t.tm_hour = hour;
-    t.tm_min  = minute;
-    t.tm_sec  = second;
-
-    std::mktime(&t);
+    details::mktime_from_ymdhms(t, year, month, day, hour, minute, second);
 }
 
 char * soci::details::mysql::quote(MYSQL * conn, const char *s, int len)

--- a/src/backends/odbc/standard-into-type.cpp
+++ b/src/backends/odbc/standard-into-type.cpp
@@ -9,6 +9,7 @@
 #include "soci/soci-platform.h"
 #include "soci/odbc/soci-odbc.h"
 #include "soci-exchange-cast.h"
+#include "soci-mktime.h"
 #include <ctime>
 #include <stdio.h>  // sscanf()
 
@@ -163,16 +164,10 @@ void odbc_standard_into_type_backend::post_fetch(
             std::tm& t = exchange_type_cast<x_stdtm>(data_);
 
             TIMESTAMP_STRUCT * ts = reinterpret_cast<TIMESTAMP_STRUCT*>(buf_);
-            t.tm_isdst = -1;
-            t.tm_year = ts->year - 1900;
-            t.tm_mon = ts->month - 1;
-            t.tm_mday = ts->day;
-            t.tm_hour = ts->hour;
-            t.tm_min = ts->minute;
-            t.tm_sec = ts->second;
 
-            // normalize and compute the remaining fields
-            std::mktime(&t);
+            details::mktime_from_ymdhms(t,
+                                        ts->year, ts->month, ts->day,
+                                        ts->hour, ts->minute, ts->second);
         }
         else if (type_ == x_long_long && use_string_for_bigint())
         {

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -8,6 +8,7 @@
 #define SOCI_ODBC_SOURCE
 #include "soci/odbc/soci-odbc.h"
 #include "soci/soci-platform.h"
+#include "soci-mktime.h"
 #include <cassert>
 #include <cctype>
 #include <cstdio>
@@ -238,20 +239,10 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             std::size_t const vsize = v.size();
             for (std::size_t i = 0; i != vsize; ++i)
             {
-                std::tm t;
-
                 TIMESTAMP_STRUCT * ts = reinterpret_cast<TIMESTAMP_STRUCT*>(pos);
-                t.tm_isdst = -1;
-                t.tm_year = ts->year - 1900;
-                t.tm_mon = ts->month - 1;
-                t.tm_mday = ts->day;
-                t.tm_hour = ts->hour;
-                t.tm_min = ts->minute;
-                t.tm_sec = ts->second;
-
-                // normalize and compute the remaining fields
-                std::mktime(&t);
-                v[i] = t;
+                details::mktime_from_ymdhms(v[i],
+                                            ts->year, ts->month, ts->day,
+                                            ts->hour, ts->minute, ts->second);
                 pos += colSize_;
             }
         }

--- a/src/backends/oracle/standard-into-type.cpp
+++ b/src/backends/oracle/standard-into-type.cpp
@@ -13,6 +13,7 @@
 #include "soci/statement.h"
 #include "soci/soci-platform.h"
 #include "soci-exchange-cast.h"
+#include "soci-mktime.h"
 #include <cctype>
 #include <cstdio>
 #include <cstring>
@@ -201,17 +202,15 @@ void oracle_standard_into_type_backend::post_fetch(
                 std::tm& t = exchange_type_cast<x_stdtm>(data_);
 
                 ub1 *pos = reinterpret_cast<ub1*>(buf_);
-                t.tm_isdst = -1;
-                t.tm_year = (*pos++ - 100) * 100;
-                t.tm_year += *pos++ - 2000;
-                t.tm_mon = *pos++ - 1;
-                t.tm_mday = *pos++;
-                t.tm_hour = *pos++ - 1;
-                t.tm_min = *pos++ - 1;
-                t.tm_sec = *pos++ - 1;
+                int year = (*pos++ - 100) * 100;
+                year += *pos++ - 100;
+                int const month = *pos++;
+                int const day = *pos++;
+                int const hour = *pos++ - 1;
+                int const minute = *pos++ - 1;
+                int const second = *pos++ - 1;
 
-                // normalize and compute the remaining fields
-                std::mktime(&t);
+                details::mktime_from_ymdhms(t, year, month, day, hour, minute, second);
             }
         }
         else if (type_ == x_statement)

--- a/src/backends/oracle/vector-into-type.cpp
+++ b/src/backends/oracle/vector-into-type.cpp
@@ -10,6 +10,7 @@
 #include "soci/statement.h"
 #include "error.h"
 #include "soci/soci-platform.h"
+#include "soci-mktime.h"
 #include <cctype>
 #include <cstdio>
 #include <cstring>
@@ -253,20 +254,15 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
                 }
                 else
                 {
-                    std::tm t;
-                    t.tm_isdst = -1;
+                    int year = (*pos++ - 100) * 100;
+                    year += *pos++ - 100;
+                    int const month = *pos++;
+                    int const day = *pos++;
+                    int const hour = *pos++ - 1;
+                    int const minute = *pos++ - 1;
+                    int const second = *pos++ - 1;
 
-                    t.tm_year = (*pos++ - 100) * 100;
-                    t.tm_year += *pos++ - 2000;
-                    t.tm_mon = *pos++ - 1;
-                    t.tm_mday = *pos++;
-                    t.tm_hour = *pos++ - 1;
-                    t.tm_min = *pos++ - 1;
-                    t.tm_sec = *pos++ - 1;
-
-                    // normalize and compute the remaining fields
-                    std::mktime(&t);
-                    v[i] = t;
+                    details::mktime_from_ymdhms(v[i], year, month, day, hour, minute, second);
                 }
             }
         }

--- a/src/backends/postgresql/common.cpp
+++ b/src/backends/postgresql/common.cpp
@@ -7,6 +7,7 @@
 
 #include "soci/soci-platform.h"
 #include "soci/soci-backend.h"
+#include "soci-mktime.h"
 #include <cstdlib>
 #include <ctime>
 #include "common.h"
@@ -81,13 +82,5 @@ void soci::details::postgresql::parse_std_tm(char const * buf, std::tm & t)
         }
     }
 
-    t.tm_isdst = -1;
-    t.tm_year = year - 1900;
-    t.tm_mon  = month - 1;
-    t.tm_mday = day;
-    t.tm_hour = hour;
-    t.tm_min  = minute;
-    t.tm_sec  = second;
-
-    std::mktime(&t);
+    details::mktime_from_ymdhms(t, year, month, day, hour, minute, second);
 }

--- a/src/backends/sqlite3/common.cpp
+++ b/src/backends/sqlite3/common.cpp
@@ -8,6 +8,7 @@
 #include "soci/soci-platform.h"
 #include "common.h"
 #include "soci/soci-backend.h"
+#include "soci-mktime.h"
 // std
 #include <cstdlib>
 #include <ctime>
@@ -54,14 +55,5 @@ void soci::details::sqlite3::parse_std_tm(char const *buf, std::tm &t)
         second = parse10(p1, p2, errMsg);
     }
 
-    t.tm_isdst = -1;
-    t.tm_year = year - 1900;
-    t.tm_mon  = month - 1;
-    t.tm_mday = day;
-    t.tm_hour = hour;
-    t.tm_min  = minute;
-    t.tm_sec  = second;
-
-    std::mktime(&t);
+    details::mktime_from_ymdhms(t, year, month, day, hour, minute, second);
 }
-

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -413,6 +413,14 @@ protected:
 
 typedef std::auto_ptr<table_creator_base> auto_table_creator;
 
+// Define the test cases in their own namespace to avoid clashes with the test
+// cases defined in individual backend tests: as only line number is used for
+// building the name of the "anonymous" function by the TEST_CASE macro, we
+// could have a conflict between a test defined here and in some backend if
+// they happened to start on the same line.
+namespace test_cases
+{
+
 TEST_CASE_METHOD(common_tests, "Exception on not connected", "[core][exception]")
 {
     soci::session sql; // no connection
@@ -4000,6 +4008,8 @@ TEST_CASE_METHOD(common_tests, "Insert error", "[core][insert][exception]")
         }
     }
 }
+
+} // namespace test_cases
 
 } // namespace tests
 


### PR DESCRIPTION
As I wrote in #190, I finally don't think it's right to call `timegm()`, but I could be wrong and if we do decide to do it, it would be much simpler to change it if it can be done in one place only, so I think it would make sense to commit this refactoring which I had done in order to call `timegm()` -- even if we don't do anything else, it still makes the code slightly tidier IMHO.