### PR TITLE
Make SOCI_NORETURN public and use it in declaration.

### DIFF
--- a/include/private/soci-compiler.h
+++ b/include/private/soci-compiler.h
@@ -36,12 +36,4 @@
 #   define GCC_WARNING_RESTORE(x)
 #endif
 
-#if defined(__GNUC__)
-#   define SOCI_NORETURN __attribute__((noreturn)) void
-#elif defined(__VISUALC__)
-#   define SOCI_NORETURN __declspec(noreturn) void
-#else
-#   define SOCI_NORETURN void
-#endif
-
 #endif // SOCI_PRIVATE_SOCI_COMPILER_H_INCLUDED

--- a/include/soci/noreturn.h
+++ b/include/soci/noreturn.h
@@ -1,0 +1,22 @@
+//
+// Copyright (C) 2015 Vadim Zeitlin
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_NORETURN_H_INCLUDED
+#define SOCI_NORETURN_H_INCLUDED
+
+// Define a portable SOCI_NORETURN macro.
+//
+// TODO-C++11: Use [[noreturn]] attribute.
+#if defined(__GNUC__)
+#   define SOCI_NORETURN __attribute__((noreturn)) void
+#elif defined(_MSC_VER)
+#   define SOCI_NORETURN __declspec(noreturn) void
+#else
+#   define SOCI_NORETURN void
+#endif
+
+#endif // SOCI_NORETURN_H_INCLUDED

--- a/include/soci/statement.h
+++ b/include/soci/statement.h
@@ -11,6 +11,7 @@
 #include "soci/bind-values.h"
 #include "soci/into-type.h"
 #include "soci/into.h"
+#include "soci/noreturn.h"
 #include "soci/use-type.h"
 #include "soci/use.h"
 #include "soci/soci-backend.h"
@@ -95,7 +96,7 @@ private:
     // after adding the context in which it happened, including the provided
     // description of the operation that failed, the SQL query and, if
     // applicable, its parameters.
-    void rethrow_current_exception_with_context(char const* operation);
+    SOCI_NORETURN rethrow_current_exception_with_context(char const* operation);
 
     int refCount_;
 


### PR DESCRIPTION
SOCI_NORETURN had to be moved to a public header to avoid MSVC error C2381
("'function' : redefinition; __declspec(noreturn) differs") which was given if
SOCI_NORETURN was specified on the function definition only and not its
declaration.

Use SOCI_NORETURN when both declaring and defining the function now (notice
that C++11 [[noreturn]] attribute also must be used on declarations).