### PR TITLE
Avoid warnings about int-to-pointer conversions in DB2 backend.

### DIFF
--- a/include/soci/db2/soci-db2.h
+++ b/include/soci/db2/soci-db2.h
@@ -46,6 +46,17 @@ namespace soci
             BOUND_BY_NAME,
             BOUND_BY_POSITION
         };
+
+        inline SQLPOINTER int_as_ptr(int n)
+        {
+            union
+            {
+                SQLPOINTER p;
+                int n;
+            } u;
+            u.n = n;
+            return u.p;
+        }
     }}
 
     static const std::size_t maxBuffer =  1024 * 1024 * 1024; //CLI limit is about 3 GB, but 1GB should be enough

--- a/src/backends/db2/statement.cpp
+++ b/src/backends/db2/statement.cpp
@@ -171,7 +171,7 @@ db2_statement_backend::fetch(int  number )
     numRowsFetched = 0;
 
     SQLSetStmtAttr(hStmt, SQL_ATTR_ROW_BIND_TYPE, SQL_BIND_BY_COLUMN, 0);
-    SQLSetStmtAttr(hStmt, SQL_ATTR_ROW_ARRAY_SIZE, (SQLPOINTER)number, 0);
+    SQLSetStmtAttr(hStmt, SQL_ATTR_ROW_ARRAY_SIZE, db2::int_as_ptr(number), 0);
     SQLSetStmtAttr(hStmt, SQL_ATTR_ROWS_FETCHED_PTR, &numRowsFetched, 0);
 
     SQLRETURN cliRC = SQLFetch(hStmt);

--- a/src/backends/db2/vector-use-type.cpp
+++ b/src/backends/db2/vector-use-type.cpp
@@ -195,7 +195,7 @@ void db2_vector_use_type_backend::bind_helper(int &position, void *data, details
     prepare_for_bind(data, size, sqlType, cType);
 
     SQLINTEGER arraySize = (SQLINTEGER)indVec.size();
-    SQLSetStmtAttr(statement_.hStmt, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)arraySize, 0);
+    SQLSetStmtAttr(statement_.hStmt, SQL_ATTR_PARAMSET_SIZE, db2::int_as_ptr(arraySize), 0);
 
     SQLRETURN cliRC = SQLBindParameter(statement_.hStmt, static_cast<SQLUSMALLINT>(position++),
                                     SQL_PARAM_INPUT, cType, sqlType, size, 0,


### PR DESCRIPTION
These warnings are harmless as the cast to pointer needs to be used just
because SQLSetStmtAttr() is "polymorphic" and takes both pointers and
integers, but annoying, so avoid them by using a helper cast-like function.