### PR TITLE
Use SQLT_BDOUBLE instead of SQLT_FLT in Oracle backend.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,9 @@ Version 4.0.0 differs from 3.2.x in the following ways:
 - Firebird
 -- Add SOCI_FIREBIRD_EMBEDDED option to allow building with embedded library.
 
+- Oracle
+-- Use SQLT_BDOUBLE for floating point values instead of SQLT_FLT.
+
 ---
 Version 3.2.3 differs from 3.2.2 in the following ways:
 

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -265,6 +265,11 @@ struct oracle_session_backend : details::session_backend
 
     bool get_option_decimals_as_strings() { return decimals_as_strings_; }
 
+    // Return either SQLT_FLT or SQLT_BDOUBLE as the type to use when binding
+    // values of C type "double" (the latter is preferable but might not be
+    // always available).
+    ub2 get_double_sql_type() const;
+
     OCIEnv *envhp_;
     OCIServer *srvhp_;
     OCIError *errhp_;

--- a/src/backends/oracle/session.cpp
+++ b/src/backends/oracle/session.cpp
@@ -214,3 +214,18 @@ oracle_blob_backend * oracle_session_backend::make_blob_backend()
 {
     return new oracle_blob_backend(*this);
 }
+
+ub2 oracle_session_backend::get_double_sql_type() const
+{
+    // SQLT_BDOUBLE avoids unnecessary conversions which is better from both
+    // performance and correctness point of view as it avoids rounding
+    // problems, however it's only available starting in Oracle 10.1, so
+    // normally we should do run-time Oracle version detection here, but for
+    // now just assume that if we use new headers (i.e. have high enough
+    // compile-time version), then the run-time is at least as high.
+#ifdef SQLT_BDOUBLE
+    return SQLT_BDOUBLE;
+#else
+    return SQLT_FLT;
+#endif
+}

--- a/src/backends/oracle/standard-into-type.cpp
+++ b/src/backends/oracle/standard-into-type.cpp
@@ -78,7 +78,7 @@ void oracle_standard_into_type_backend::define_by_pos(
         size = sizeof(int);
         break;
     case x_double:
-        oracleType = SQLT_FLT;
+        oracleType = statement_.session_.get_double_sql_type();
         size = sizeof(double);
         break;
 

--- a/src/backends/oracle/standard-use-type.cpp
+++ b/src/backends/oracle/standard-use-type.cpp
@@ -69,7 +69,7 @@ void oracle_standard_use_type_backend::prepare_for_bind(
         }
         break;
     case x_double:
-        oracleType = SQLT_FLT;
+        oracleType = statement_.session_.get_double_sql_type();
         size = sizeof(double);
         if (readOnly)
         {

--- a/src/backends/oracle/vector-into-type.cpp
+++ b/src/backends/oracle/vector-into-type.cpp
@@ -84,7 +84,7 @@ void oracle_vector_into_type_backend::define_by_pos(
         break;
     case x_double:
         {
-            oracleType = SQLT_FLT;
+            oracleType = statement_.session_.get_double_sql_type();
             size = sizeof(double);
             std::vector<double> *vp = static_cast<std::vector<double> *>(data);
             std::vector<double> &v(*vp);

--- a/src/backends/oracle/vector-use-type.cpp
+++ b/src/backends/oracle/vector-use-type.cpp
@@ -73,7 +73,7 @@ void oracle_vector_use_type_backend::prepare_for_bind(
         break;
     case x_double:
         {
-            oracleType = SQLT_FLT;
+            oracleType = statement_.session_.get_double_sql_type();
             size = sizeof(double);
             std::vector<double> *vp = static_cast<std::vector<double> *>(data);
             std::vector<double> &v(*vp);


### PR DESCRIPTION
This is recommended by Oracle documentation for performance reasons as it
avoids conversion from the native double to Oracle format and back but, more
importantly, avoids rounding problems and allows the "Repeated and bulk fetch"
unit test to pass for doubles whereas it failed previously because the double
value of 0.6*3 was written into the database as exactly 1.8, which is
different from IEEE 754 representation.

Notice that this commit assumes that Oracle 10.1+ is used during run-time if
10.1+ headers are used for compiling SOCI. This is not true in general, but is
hopefully good enough in practice -- and if it isn't, run-time Oracle version
checking will need to be added later.