### PR TITLE
Fix silent truncation of VARCHAR columns in Firebird backend.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Version 4.0.0 differs from 3.2.x in the following ways:
 
 - Firebird
 -- Add SOCI_FIREBIRD_EMBEDDED option to allow building with embedded library.
+-- Throw an exception instead of truncating too long VARCHAR columns values.
 
 ---
 Version 3.2.3 differs from 3.2.2 in the following ways:

--- a/src/backends/firebird/common.cpp
+++ b/src/backends/firebird/common.cpp
@@ -90,7 +90,8 @@ void tmDecode(short type, void * src, std::tm * dst)
 void setTextParam(char const * s, std::size_t size, char * buf_,
     XSQLVAR * var)
 {
-    //std::cerr << "setTextParam: var->sqltype=" << var->sqltype << std::endl;
+    int const sqltype = var->sqltype & ~1;
+
     short sz = 0;
     if (size < static_cast<std::size_t>(var->sqllen))
     {
@@ -101,12 +102,12 @@ void setTextParam(char const * s, std::size_t size, char * buf_,
         sz = var->sqllen;
     }
 
-    if ((var->sqltype & ~1) == SQL_VARYING)
+    if (sqltype == SQL_VARYING)
     {
         std::memcpy(buf_, &sz, sizeof(short));
         std::memcpy(buf_ + sizeof(short), s, sz);
     }
-    else if ((var->sqltype & ~1) == SQL_TEXT)
+    else if (sqltype == SQL_TEXT)
     {
         std::memcpy(buf_, s, sz);
         if (sz < var->sqllen)
@@ -114,20 +115,20 @@ void setTextParam(char const * s, std::size_t size, char * buf_,
             std::memset(buf_+sz, ' ', var->sqllen - sz);
         }
     }
-    else if ((var->sqltype & ~1) == SQL_SHORT)
+    else if (sqltype == SQL_SHORT)
     {
         parse_decimal<short, unsigned short>(buf_, var, s);
     }
-    else if ((var->sqltype & ~1) == SQL_LONG)
+    else if (sqltype == SQL_LONG)
     {
         parse_decimal<int, unsigned int>(buf_, var, s);
     }
-    else if ((var->sqltype & ~1) == SQL_INT64)
+    else if (sqltype == SQL_INT64)
     {
         parse_decimal<long long, unsigned long long>(buf_, var, s);
     }
-    else if ((var->sqltype & ~1) == SQL_TIMESTAMP
-            || (var->sqltype & ~1) == SQL_TYPE_DATE)
+    else if (sqltype == SQL_TIMESTAMP
+            || sqltype == SQL_TYPE_DATE)
     {
         unsigned short year, month, day, hour, min, sec;
         if (std::sscanf(s, "%hu-%hu-%hu %hu:%hu:%hu",
@@ -154,7 +155,7 @@ void setTextParam(char const * s, std::size_t size, char * buf_,
         std::memcpy(buf_, &t, sizeof(t));
         tmEncode(var->sqltype, &t, buf_);
     }
-    else if ((var->sqltype & ~1) == SQL_TYPE_TIME)
+    else if (sqltype == SQL_TYPE_TIME)
     {
         unsigned short hour, min, sec;
         if (std::sscanf(s, "%hu:%hu:%hu", &hour, &min, &sec) != 3)

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -288,7 +288,7 @@ public:
     virtual bool has_multiple_select_bug() const { return false; }
 
     // Override this if the backend may not have transactions support.
-    virtual bool has_transactions_support() const { return true; }
+    virtual bool has_transactions_support(session&) const { return true; }
 
     virtual ~test_context_base()
     {
@@ -1759,13 +1759,13 @@ TEST_CASE_METHOD(common_tests, "Named parameters", "[core][use][named-params]")
 // transaction test
 TEST_CASE_METHOD(common_tests, "Transactions", "[core][transaction]")
 {
-    if (!tc_.has_transactions_support())
+    session sql(backEndFactory_, connectString_);
+
+    if (!tc_.has_transactions_support(sql))
     {
         WARN("Transactions not supported by the database, skipping the test.");
         return;
     }
-
-    session sql(backEndFactory_, connectString_);
 
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
 

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -120,13 +120,14 @@ TEST_CASE("Firebird char types", "[firebird][string]")
 #endif
 
     {
-        std::string b1("Hello, Firebird!"), b2, b3;
+        // The test string is exactly 10 bytes long, i.e. same as column length.
+        std::string b1("Hello, FB!"), b2, b3;
 
         sql << "insert into test2(p1, p2) values (?,?)", use(b1), use(b1);
         sql << "select p1, p2 from test2", into(b2), into(b3);
 
         CHECK(b2 == b3);
-        CHECK(b2 == "Hello, Fir");
+        CHECK(b2 == "Hello, FB!");
 
         sql << "delete from test2";
     }
@@ -144,18 +145,6 @@ TEST_CASE("Firebird char types", "[firebird][string]")
 
         CHECK(std::strncmp(buf, msg, 5) == 0);
         CHECK(std::strncmp(buf+5, "     ", 5) == 0);
-
-        sql << "delete from test2";
-    }
-
-    {
-        std::string str1("Hello, Firebird!"), str2, str3;
-        sql << "insert into test2(p1, p2) values (?, ?)",
-        use(str1), use(str1);
-
-        sql << "select p1, p2 from test2", into(str2), into(str3);
-        CHECK(str2 == "Hello, Fir");
-        CHECK(str3 == "Hello, Fir");
 
         sql << "delete from test2";
     }
@@ -1297,6 +1286,11 @@ class test_context : public tests::test_context_base
         std::string to_date_time(std::string const &datdt_string) const
         {
             return "'" + datdt_string + "'";
+        }
+
+        virtual void on_after_ddl(session& sql) const
+        {
+            sql.commit();
         }
 };
 

--- a/tests/mysql/test-mysql.cpp
+++ b/tests/mysql/test-mysql.cpp
@@ -8,7 +8,7 @@
 
 #include "soci/soci.h"
 #include "soci/mysql/soci-mysql.h"
-#include "common-tests.h"
+#include "mysql/test-mysql.h"
 #include <string.h>
 #include <iostream>
 #include <sstream>
@@ -20,9 +20,6 @@
 #include <cstdlib>
 #include <mysqld_error.h>
 #include <errmsg.h>
-
-using namespace soci;
-using namespace soci::tests;
 
 std::string connectString;
 backend_factory const &backEnd = *soci::factory_mysql();
@@ -839,105 +836,6 @@ void test15()
 
     std::cout << "test 15 passed" << std::endl;
 }
-
-// DDL Creation objects for common tests
-struct table_creator_one : public table_creator_base
-{
-    table_creator_one(session & sql)
-        : table_creator_base(sql)
-    {
-        sql << "create table soci_test(id integer, val integer, c char, "
-                 "str varchar(20), sh int2, ul numeric(20), d float8, "
-                 "num76 numeric(7,6), "
-                 "tm datetime, i1 integer, i2 integer, i3 integer, "
-                 "name varchar(20)) engine=InnoDB";
-    }
-};
-
-struct table_creator_two : public table_creator_base
-{
-    table_creator_two(session & sql)
-        : table_creator_base(sql)
-    {
-        sql  << "create table soci_test(num_float float8, num_int integer,"
-                     " name varchar(20), sometime datetime, chr char)";
-    }
-};
-
-struct table_creator_three : public table_creator_base
-{
-    table_creator_three(session & sql)
-        : table_creator_base(sql)
-    {
-        sql << "create table soci_test(name varchar(100) not null, "
-            "phone varchar(15))";
-    }
-};
-
-struct table_creator_for_get_affected_rows : table_creator_base
-{
-    table_creator_for_get_affected_rows(session & sql)
-        : table_creator_base(sql)
-    {
-        sql << "create table soci_test(val integer)";
-    }
-};
-
-//
-// Support for SOCI Common Tests
-//
-
-class test_context : public test_context_base
-{
-public:
-    test_context(backend_factory const &backEnd,
-                std::string const &connectString)
-        : test_context_base(backEnd, connectString) {}
-
-    table_creator_base* table_creator_1(session& s) const
-    {
-        return new table_creator_one(s);
-    }
-
-    table_creator_base* table_creator_2(session& s) const
-    {
-        return new table_creator_two(s);
-    }
-
-    table_creator_base* table_creator_3(session& s) const
-    {
-        return new table_creator_three(s);
-    }
-
-    table_creator_base* table_creator_4(session& s) const
-    {
-        return new table_creator_for_get_affected_rows(s);
-    }
-
-    std::string to_date_time(std::string const &datdt_string) const
-    {
-        return "\'" + datdt_string + "\'";
-    }
-
-    virtual bool has_fp_bug() const
-    {
-        // MySQL fails in the common test3() with "1.8000000000000000 !=
-        // 1.7999999999999998", so don't use exact doubles comparisons for it.
-        return true;
-    }
-
-    virtual bool has_transactions_support() const
-    {
-        session sql(backEnd, connectString);
-        sql << "drop table if exists soci_test";
-        sql << "create table soci_test (id int) engine=InnoDB";
-        row r;
-        sql << "show table status like \'soci_test\'", into(r);
-        bool retv = (r.get<std::string>(1) == "InnoDB");
-        sql << "drop table soci_test";
-        return retv;
-    }
-};
 
 int main(int argc, char** argv)
 {

--- a/tests/mysql/test-mysql.h
+++ b/tests/mysql/test-mysql.h
@@ -1,0 +1,107 @@
+#ifndef SOCI_TESTS_MYSQL_H_INCLUDED
+#define SOCI_TESTS_MYSQL_H_INCLUDED
+
+#include "common-tests.h"
+
+using namespace soci;
+using namespace soci::tests;
+
+// DDL Creation objects for common tests
+struct table_creator_one : public table_creator_base
+{
+    table_creator_one(session & sql)
+        : table_creator_base(sql)
+    {
+        sql << "create table soci_test(id integer, val integer, c char, "
+                 "str varchar(20), sh int2, ul numeric(20), d float8, "
+                 "num76 numeric(7,6), "
+                 "tm datetime, i1 integer, i2 integer, i3 integer, "
+                 "name varchar(20)) engine=InnoDB";
+    }
+};
+
+struct table_creator_two : public table_creator_base
+{
+    table_creator_two(session & sql)
+        : table_creator_base(sql)
+    {
+        sql  << "create table soci_test(num_float float8, num_int integer,"
+                     " name varchar(20), sometime datetime, chr char)";
+    }
+};
+
+struct table_creator_three : public table_creator_base
+{
+    table_creator_three(session & sql)
+        : table_creator_base(sql)
+    {
+        sql << "create table soci_test(name varchar(100) not null, "
+            "phone varchar(15))";
+    }
+};
+
+struct table_creator_for_get_affected_rows : table_creator_base
+{
+    table_creator_for_get_affected_rows(session & sql)
+        : table_creator_base(sql)
+    {
+        sql << "create table soci_test(val integer)";
+    }
+};
+
+//
+// Support for SOCI Common Tests
+//
+
+class test_context : public test_context_base
+{
+public:
+    test_context(backend_factory const &backEnd,
+                std::string const &connectString)
+        : test_context_base(backEnd, connectString) {}
+
+    table_creator_base* table_creator_1(session& s) const
+    {
+        return new table_creator_one(s);
+    }
+
+    table_creator_base* table_creator_2(session& s) const
+    {
+        return new table_creator_two(s);
+    }
+
+    table_creator_base* table_creator_3(session& s) const
+    {
+        return new table_creator_three(s);
+    }
+
+    table_creator_base* table_creator_4(session& s) const
+    {
+        return new table_creator_for_get_affected_rows(s);
+    }
+
+    std::string to_date_time(std::string const &datdt_string) const
+    {
+        return "\'" + datdt_string + "\'";
+    }
+
+    virtual bool has_fp_bug() const
+    {
+        // MySQL fails in the common test3() with "1.8000000000000000 !=
+        // 1.7999999999999998", so don't use exact doubles comparisons for it.
+        return true;
+    }
+
+    virtual bool has_transactions_support(session& sql) const
+    {
+        sql << "drop table if exists soci_test";
+        sql << "create table soci_test (id int) engine=InnoDB";
+        row r;
+        sql << "show table status like \'soci_test\'", into(r);
+        bool retv = (r.get<std::string>(1) == "InnoDB");
+        sql << "drop table soci_test";
+        return retv;
+    }
+};
+
+#endif // SOCI_TESTS_MYSQL_H_INCLUDED

--- a/tests/mysql/test-mysql.h
+++ b/tests/mysql/test-mysql.h
@@ -102,6 +102,16 @@ public:
         sql << "drop table soci_test";
         return retv;
     }
+
+    virtual bool has_silent_truncate_bug(session& sql) const
+    {
+        std::string sql_mode;
+        sql << "select @@session.sql_mode", into(sql_mode);
+
+        // The database must be configured to use STRICT_{ALL,TRANS}_TABLES in
+        // SQL mode to avoid silent truncation of too long values.
+        return sql_mode.find("STRICT_") == std::string::npos;
+    }
 };
 
 #endif // SOCI_TESTS_MYSQL_H_INCLUDED

--- a/tests/odbc/test-odbc-mysql.cpp
+++ b/tests/odbc/test-odbc-mysql.cpp
@@ -7,97 +7,14 @@
 
 #include "soci/soci.h"
 #include "soci/odbc/soci-odbc.h"
-#include "common-tests.h"
+#include "mysql/test-mysql.h"
 #include <iostream>
 #include <string>
 #include <ctime>
 #include <cmath>
 
-using namespace soci;
-using namespace soci::tests;
-
 std::string connectString;
 backend_factory const &backEnd = *soci::factory_odbc();
-
-// DDL Creation objects for common tests
-struct table_creator_one : public table_creator_base
-{
-    table_creator_one(session & sql)
-        : table_creator_base(sql)
-    {
-        sql << "create table soci_test(id integer, val integer, c char, "
-                 "str varchar(20), sh int2, ul numeric(20), d float8, "
-                 "num76 numeric(7,6), "
-                 "tm datetime, i1 integer, i2 integer, i3 integer, "
-                 "name varchar(20))";
-    }
-};
-
-struct table_creator_two : public table_creator_base
-{
-    table_creator_two(session & sql)
-        : table_creator_base(sql)
-    {
-        sql  << "create table soci_test(num_float float8, num_int integer,"
-                     " name varchar(20), sometime datetime, chr char)";
-    }
-};
-
-struct table_creator_three : public table_creator_base
-{
-    table_creator_three(session & sql)
-        : table_creator_base(sql)
-    {
-        sql << "create table soci_test(name varchar(100) not null, "
-            "phone varchar(15))";
-    }
-};
-
-struct table_creator_for_get_affected_rows : table_creator_base
-{
-    table_creator_for_get_affected_rows(session & sql)
-        : table_creator_base(sql)
-    {
-        sql << "create table soci_test(val integer)";
-    }
-};
-
-//
-// Support for SOCI Common Tests
-//
-
-class test_context : public test_context_base
-{
-public:
-    test_context(backend_factory const &backEnd,
-                std::string const &connectString)
-        : test_context_base(backEnd, connectString) {}
-
-    table_creator_base * table_creator_1(session& s) const
-    {
-        return new table_creator_one(s);
-    }
-
-    table_creator_base * table_creator_2(session& s) const
-    {
-        return new table_creator_two(s);
-    }
-
-    table_creator_base * table_creator_3(session& s) const
-    {
-        return new table_creator_three(s);
-    }
-
-    table_creator_base * table_creator_4(session& s) const
-    {
-        return new table_creator_for_get_affected_rows(s);
-    }
-
-    std::string to_date_time(std::string const &datdt_string) const
-    {
-        return "\'" + datdt_string + "\'";
-    }
-};
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
This ensures that all backends (except SQLite and MySQL in its default broken mode) throw when trying to insert a value too long to fit a column.

Closes #51 