### PR TITLE
C++11 Standard

### DIFF
--- a/cmake/SociBackend.cmake
+++ b/cmake/SociBackend.cmake
@@ -189,6 +189,11 @@ macro(soci_backend NAME)
           ${THIS_BACKEND_SOURCES}
           ${THIS_BACKEND_HEADERS})
 
+        target_link_libraries(${THIS_BACKEND_TARGET_STATIC}
+          ${SOCI_CORE_TARGET}
+          ${THIS_BACKEND_DEPENDS_LIBRARIES})
+
+
         set_target_properties(${THIS_BACKEND_TARGET_STATIC}
           PROPERTIES
           OUTPUT_NAME ${THIS_BACKEND_OUTPUT_NAME}
@@ -347,6 +352,7 @@ macro(soci_backend_test)
         ${SOCI_CORE_DEPS_LIBS}
         ${THIS_TEST_DEPENDS_LIBRARIES}
         soci_core_static
+        dl # BEN - Temp fix
         soci_${BACKENDL}_static)
 
       add_test(${TEST_TARGET_STATIC}

--- a/cmake/SociConfig.cmake
+++ b/cmake/SociConfig.cmake
@@ -29,16 +29,16 @@ if (MSVC)
 else()
 
   set(SOCI_GCC_CLANG_COMMON_FLAGS
-	"-pedantic -ansi -Wall -Wpointer-arith -Wcast-align -Wcast-qual -Wfloat-equal -Wredundant-decls -Wno-long-long")
+	"-pedantic -ansi -Wall -Werror -Wpointer-arith -Wcast-align -Wcast-qual -Wfloat-equal -Wredundant-decls -Wno-long-long")
 
   if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC ${SOCI_GCC_CLANG_COMMON_FLAGS}")
     if (CMAKE_COMPILER_IS_GNUCXX)
         if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++98")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
         else()
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98 -Wno-variadic-macros")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-variadic-macros")
         endif()
     endif()
 

--- a/include/soci/row.h
+++ b/include/soci/row.h
@@ -18,6 +18,13 @@
 #include <string>
 #include <vector>
 
+// Annoyingly, there is some weird template stuff going on that causes warnings
+#ifdef __GNUG__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
+
 namespace soci
 {
 
@@ -143,5 +150,9 @@ private:
 };
 
 } // namespace soci
+
+#ifdef __GNUG__
+#pragma GCC diagnostic pop
+#endif
 
 #endif // SOCI_ROW_H_INCLUDED

--- a/include/soci/rowset.h
+++ b/include/soci/rowset.h
@@ -154,8 +154,8 @@ private:
 
     unsigned int refs_;
 
-    const std::auto_ptr<statement> st_;
-    const std::auto_ptr<T> define_;
+    const std::unique_ptr<statement> st_;
+    const std::unique_ptr<T> define_;
 
     // Non-copyable
     rowset_impl(rowset_impl const &);

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -40,7 +40,7 @@ class SOCI_DECL session
 {
 private:
 
-    void set_query_transformation_(std::auto_ptr<details::query_transformation_function> qtf);
+    void set_query_transformation_(std::unique_ptr<details::query_transformation_function> & qtf);
 
 public:
     session();
@@ -77,7 +77,7 @@ public:
     template <typename T>
     void set_query_transformation(T callback)
     {
-        std::auto_ptr<details::query_transformation_function> qtf(new details::query_transformation<T>(callback));
+        std::unique_ptr<details::query_transformation_function> qtf(new details::query_transformation<T>(callback));
         set_query_transformation_(qtf);
 
         assert(qtf.get() == NULL);

--- a/include/soci/type-conversion.h
+++ b/include/soci/type-conversion.h
@@ -17,6 +17,13 @@
 #include <string>
 #include <vector>
 
+// BEN - Under Clang this naughty passing of a subclass reference to a parent base class is rightly caught
+// but I've no idea how to fix it properly
+#ifdef _COMPILER_CLANG
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wuninitialized"
+#endif
+
 namespace soci
 {
 
@@ -361,5 +368,9 @@ use_type_ptr do_use(T const & t, indicator & ind,
 } // namespace details
 
 } // namespace soci
+
+#ifdef _COMPILER_CLANG
+#pragma clang diagnostic pop
+#endif
 
 #endif // SOCI_TYPE_CONVERSION_H_INCLUDED

--- a/include/soci/values.h
+++ b/include/soci/values.h
@@ -19,6 +19,13 @@
 #include <utility>
 #include <vector>
 
+
+// Annoyingly, there is some weird template stuff going on that causes warnings
+#ifdef __GNUG__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 namespace soci
 {
 
@@ -350,5 +357,9 @@ private:
 };
 
 } // namespace soci
+
+#ifdef __GNUG__
+#pragma GCC diagnostic pop
+#endif
 
 #endif // SOCI_VALUES_H_INCLUDED

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -235,7 +235,7 @@ std::string session::get_query() const
 }
 
 void session::set_query_transformation_(
-        std::auto_ptr<details::query_transformation_function> qtf)
+        std::unique_ptr<details::query_transformation_function> &qtf)
 {
     if (isFromPool_)
     {

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -987,7 +987,6 @@ namespace Catch {
 #include <limits>
 #include <vector>
 #include <cstddef>
-#include <boost/optional.hpp>
 
 #ifdef __OBJC__
 // #included from: catch_objc_arc.hpp

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -987,6 +987,7 @@ namespace Catch {
 #include <limits>
 #include <vector>
 #include <cstddef>
+#include <boost/optional.hpp>
 
 #ifdef __OBJC__
 // #included from: catch_objc_arc.hpp
@@ -1091,7 +1092,9 @@ namespace Detail {
             oss << _value;
             return oss.str();
         }
+
     };
+
 
     std::string rawMemoryToString( const void *object, std::size_t size );
 

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -2799,6 +2799,7 @@ TEST_CASE_METHOD(common_tests, "Dynamic binding with rowset", "[core][dynamic][t
 
 // test for handling NULL values with boost::optional
 // (both into and use)
+
 TEST_CASE_METHOD(common_tests, "NULL with optional", "[core][boost][null]")
 {
 

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -18,6 +18,14 @@
 #include <cstring>
 #include <cmath>
 
+
+namespace boost {
+    std::basic_ostream<char, std::char_traits<char> >& operator<< (std::basic_ostream<char, std::char_traits<char> > & stream, boost::optional<int> const & value){
+        std::ostringstream oss;
+        return oss << "Currently not supported."; 
+    }
+}
+
 using namespace soci;
 
 std::string connectString;

--- a/tests/mysql/test-mysql.cpp
+++ b/tests/mysql/test-mysql.cpp
@@ -27,6 +27,13 @@ using namespace soci::tests;
 std::string connectString;
 backend_factory const &backEnd = *soci::factory_mysql();
 
+namespace boost {
+    std::basic_ostream<char, std::char_traits<char> >& operator<< (std::basic_ostream<char, std::char_traits<char> > & stream, boost::optional<int> const & value){
+        std::ostringstream oss;
+        return oss << "Currently not supported."; 
+    }
+}
+
 
 // procedure call test
 TEST_CASE("MySQL stored procedures", "[mysql][stored-procedure]")

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -22,6 +22,13 @@ using namespace soci::tests;
 std::string connectString;
 backend_factory const &backEnd = *soci::factory_postgresql();
 
+namespace boost {
+    std::basic_ostream<char, std::char_traits<char> >& operator<< (std::basic_ostream<char, std::char_traits<char> > & stream, boost::optional<int> const & value){
+        std::ostringstream oss;
+        return oss << "Currently not supported."; 
+    }
+}
+
 // Postgres-specific tests
 
 struct oid_table_creator : public table_creator_base

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -21,6 +21,13 @@ using namespace soci::tests;
 std::string connectString;
 backend_factory const &backEnd = *soci::factory_sqlite3();
 
+namespace boost {
+    std::basic_ostream<char, std::char_traits<char> >& operator<< (std::basic_ostream<char, std::char_traits<char> > & stream, boost::optional<int> const & value){
+        std::ostringstream oss;
+        return oss << "Currently not supported."; 
+    }
+}
+
 // ROWID test
 // In sqlite3 the row id can be called ROWID, _ROWID_ or oid
 TEST_CASE("SQLite rowid", "[sqlite][rowid][oid]")


### PR DESCRIPTION
Moving from C++98 to C++11. 

General changes include:
- removing auto_ptr, swapping with unique_ptr.
- Changing areas of the CMakeLists
- Warnings as Errors (because it's neater and good style)
- Unfixed warnings documented where necessary (in relation to the above)
- Currently, boost::optional seems to be causing problems with catch.hpp testing so I've overridden it for now
- Missing library dependencies for the static tests