### PR TITLE
Fix inserting strings longer than 8000 bytes with ODBC/MS SQL.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,9 @@ Version 4.0.0 differs from 3.2.x in the following ways:
 -- Add SOCI_FIREBIRD_EMBEDDED option to allow building with embedded library.
 -- Throw an exception instead of truncating too long VARCHAR columns values.
 
+- ODBC/MS SQL
+-- Fix inserting strings of length greater than 8000 bytes into database.
+
 - Oracle
 -- Use SQLT_BDOUBLE for floating point values instead of SQLT_FLT.
 

--- a/src/backends/odbc/standard-use-type.cpp
+++ b/src/backends/odbc/standard-use-type.cpp
@@ -99,6 +99,15 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
         memcpy(buf_, s.c_str(), size);
         buf_[size++] = '\0';
         indHolder_ = SQL_NTS;
+
+        // Strings of greater length are silently truncated at 8000 limit by MS
+        // SQL unless SQL_SS_LENGTH_UNLIMITED (which is defined as 0, but not
+        // available in all headers) is used.
+        if (size > 8000)
+        {
+          sqlType = SQL_LONGVARCHAR;
+          size = 0 /* SQL_SS_LENGTH_UNLIMITED */;
+        }
     }
     break;
     case x_stdtm:


### PR DESCRIPTION
Use SQL_LONGVARCHAR and SQL_SS_LENGTH_UNLIMITED for such strings, otherwise
they were silently truncated when inserting them into an nvarchar(max) column.

See #287.