### PR TITLE
Fully qualify uses of session class with namespace soci::session

### DIFF
--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -450,7 +450,7 @@ TEST_CASE_METHOD(common_tests, "Exception on not connected", "[core][exception]"
 
 TEST_CASE_METHOD(common_tests, "Basic functionality")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
@@ -465,7 +465,7 @@ TEST_CASE_METHOD(common_tests, "Basic functionality")
 // "into" tests, type conversions, etc.
 TEST_CASE_METHOD(common_tests, "Use and into", "[core][into]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
@@ -621,7 +621,7 @@ TEST_CASE_METHOD(common_tests, "Use and into", "[core][into]")
 // repeated fetch and bulk fetch
 TEST_CASE_METHOD(common_tests, "Repeated and bulk fetch", "[core][bulk]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     // create and populate the test table
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
@@ -1032,7 +1032,7 @@ TEST_CASE_METHOD(common_tests, "Repeated and bulk fetch", "[core][bulk]")
 // test for indicators (repeated fetch and bulk)
 TEST_CASE_METHOD(common_tests, "Indicators", "[core][indicator]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     // create and populate the test table
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
@@ -1147,7 +1147,7 @@ TEST_CASE_METHOD(common_tests, "Indicators", "[core][indicator]")
 // (library should force ind. vector to have same size as data vector)
 TEST_CASE_METHOD(common_tests, "Indicators vector", "[core][indicator][vector]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     // create and populate the test table
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
@@ -1184,7 +1184,7 @@ TEST_CASE_METHOD(common_tests, "Indicators vector", "[core][indicator][vector]")
 // "use" tests, type conversions, etc.
 TEST_CASE_METHOD(common_tests, "Use type conversion", "[core][use]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
@@ -1409,7 +1409,7 @@ TEST_CASE_METHOD(common_tests, "Use type conversion", "[core][use]")
 // test for multiple use (and into) elements
 TEST_CASE_METHOD(common_tests, "Multiple use and into", "[core][use][into]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
     {
@@ -1502,7 +1502,7 @@ TEST_CASE_METHOD(common_tests, "Multiple use and into", "[core][use][into]")
 // use vector elements
 TEST_CASE_METHOD(common_tests, "Use vector", "[core][use][vector]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
@@ -1695,7 +1695,7 @@ TEST_CASE_METHOD(common_tests, "Use vector", "[core][use][vector]")
 // test for named binding
 TEST_CASE_METHOD(common_tests, "Named parameters", "[core][use][named-params]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
     {
         auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
@@ -1767,7 +1767,7 @@ TEST_CASE_METHOD(common_tests, "Named parameters", "[core][use][named-params]")
 // transaction test
 TEST_CASE_METHOD(common_tests, "Transactions", "[core][transaction]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     if (!tc_.has_transactions_support(sql))
     {
@@ -1841,7 +1841,7 @@ TEST_CASE_METHOD(common_tests, "Transactions", "[core][transaction]")
 // test of use elements with indicators
 TEST_CASE_METHOD(common_tests, "Use with indicators", "[core][use][indicator]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
@@ -1910,7 +1910,7 @@ TEST_CASE_METHOD(common_tests, "Use with indicators", "[core][use][indicator]")
 // Dynamic binding to Row objects
 TEST_CASE_METHOD(common_tests, "Dynamic row binding", "[core][dynamic]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     sql.uppercase_column_names(true);
 
@@ -2027,7 +2027,7 @@ TEST_CASE_METHOD(common_tests, "Dynamic row binding", "[core][dynamic]")
 // more dynamic bindings
 TEST_CASE_METHOD(common_tests, "Dynamic row binding 2", "[core][dynamic]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
@@ -2084,7 +2084,7 @@ TEST_CASE_METHOD(common_tests, "Dynamic row binding 2", "[core][dynamic]")
 // More Dynamic binding to row objects
 TEST_CASE_METHOD(common_tests, "Dynamic row binding 3", "[core][dynamic]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     sql.uppercase_column_names(true);
 
@@ -2116,7 +2116,7 @@ TEST_CASE_METHOD(common_tests, "Dynamic row binding 3", "[core][dynamic]")
 // This is like the previous test but with a type_conversion instead of a row
 TEST_CASE_METHOD(common_tests, "Dynamic binding with type conversions", "[core][dynamic][type_conversion]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     sql.uppercase_column_names(true);
 
@@ -2269,7 +2269,7 @@ TEST_CASE_METHOD(common_tests, "Dynamic binding with type conversions", "[core][
 
 TEST_CASE_METHOD(common_tests, "Prepared insert with ORM", "[core][orm]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     sql.uppercase_column_names(true);
     auto_table_creator tableCreator(tc_.table_creator_3(sql));
@@ -2295,7 +2295,7 @@ TEST_CASE_METHOD(common_tests, "Prepared insert with ORM", "[core][orm]")
 
 TEST_CASE_METHOD(common_tests, "Partial match with ORM", "[core][orm]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
     sql.uppercase_column_names(true);
     auto_table_creator tableCreator(tc_.table_creator_3(sql));
 
@@ -2311,7 +2311,7 @@ TEST_CASE_METHOD(common_tests, "Partial match with ORM", "[core][orm]")
 
 TEST_CASE_METHOD(common_tests, "Numeric round trip", "[core][float]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
     double d1 = 0.003958,
@@ -2339,7 +2339,7 @@ TEST_CASE_METHOD(common_tests, "Numeric round trip", "[core][float]")
 // test for bulk fetch with single use
 TEST_CASE_METHOD(common_tests, "Bulk fetch with single use", "[core][bulk]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
@@ -2365,7 +2365,7 @@ TEST_CASE_METHOD(common_tests, "Bulk fetch with single use", "[core][bulk]")
 // test for basic logging support
 TEST_CASE_METHOD(common_tests, "Basic logging support", "[core][logging]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     std::ostringstream log;
     sql.set_log_stream(&log);
@@ -2406,7 +2406,7 @@ TEST_CASE_METHOD(common_tests, "Basic logging support", "[core][logging]")
 // test for rowset creation and copying
 TEST_CASE_METHOD(common_tests, "Rowset creation and copying", "[core][rowset]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     // create and populate the test table
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
@@ -2448,7 +2448,7 @@ TEST_CASE_METHOD(common_tests, "Rowset creation and copying", "[core][rowset]")
 // test for simple iterating using rowset iterator (without reading data)
 TEST_CASE_METHOD(common_tests, "Rowset iteration", "[core][rowset]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     // create and populate the test table
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
@@ -2470,7 +2470,7 @@ TEST_CASE_METHOD(common_tests, "Rowset iteration", "[core][rowset]")
 // test for reading rowset<row> using iterator
 TEST_CASE_METHOD(common_tests, "Reading rows from rowset", "[core][row][rowset]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     sql.uppercase_column_names(true);
 
@@ -2650,7 +2650,7 @@ TEST_CASE_METHOD(common_tests, "Reading rows from rowset", "[core][row][rowset]"
 // test for reading rowset<int> using iterator
 TEST_CASE_METHOD(common_tests, "Reading ints from rowset", "[core][rowset]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     // create and populate the test table
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
@@ -2686,7 +2686,7 @@ TEST_CASE_METHOD(common_tests, "Reading ints from rowset", "[core][rowset]")
 // test for handling 'use' and reading rowset<std::string> using iterator
 TEST_CASE_METHOD(common_tests, "Reading strings from rowset", "[core][rowset]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     // create and populate the test table
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
@@ -2719,7 +2719,7 @@ TEST_CASE_METHOD(common_tests, "Reading strings from rowset", "[core][rowset]")
 // test for handling troublemaker
 TEST_CASE_METHOD(common_tests, "Rowset expected exception", "[core][exception][rowset]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     // create and populate the test table
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
@@ -2737,7 +2737,7 @@ TEST_CASE_METHOD(common_tests, "Rowset expected exception", "[core][exception][r
 // "Null value fetched and no indicator defined."
 TEST_CASE_METHOD(common_tests, "NULL expected exception", "[core][exception][null]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     // create and populate the test table
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
@@ -2763,7 +2763,7 @@ TEST_CASE_METHOD(common_tests, "NULL expected exception", "[core][exception][nul
 // This is like the first dynamic binding test but with rowset and iterators use
 TEST_CASE_METHOD(common_tests, "Dynamic binding with rowset", "[core][dynamic][type_conversion]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     sql.uppercase_column_names(true);
 
@@ -2810,7 +2810,7 @@ TEST_CASE_METHOD(common_tests, "Dynamic binding with rowset", "[core][dynamic][t
 TEST_CASE_METHOD(common_tests, "NULL with optional", "[core][boost][null]")
 {
 
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     // create and populate the test table
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
@@ -3147,7 +3147,7 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
 {
     {
         // empty session
-        session sql;
+        soci::session sql;
 
         // idempotent:
         sql.close();
@@ -3192,7 +3192,7 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
     }
 
     {
-        session sql;
+        soci::session sql;
 
         try
         {
@@ -3212,7 +3212,7 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
 
 TEST_CASE_METHOD(common_tests, "Boost tuple", "[core][boost][tuple]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     auto_table_creator tableCreator(tc_.table_creator_2(sql));
     {
@@ -3360,7 +3360,7 @@ TEST_CASE_METHOD(common_tests, "Boost tuple", "[core][boost][tuple]")
 TEST_CASE_METHOD(common_tests, "Boost fusion", "[core][boost][fusion]")
 {
 
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     auto_table_creator tableCreator(tc_.table_creator_2(sql));
     {
@@ -3508,7 +3508,7 @@ TEST_CASE_METHOD(common_tests, "Boost fusion", "[core][boost][fusion]")
 // test for boost::gregorian::date
 TEST_CASE_METHOD(common_tests, "Boost date", "[core][boost][datetime]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     {
         auto_table_creator tableCreator(tc_.table_creator_1(sql));
@@ -3579,9 +3579,9 @@ TEST_CASE_METHOD(common_tests, "Connection pool", "[core][connection][pool]")
     for (std::size_t i = 0; i != pool_size; ++i)
     {
         // poor man way to lease more than one connection
-        session sql_unused1(pool);
-        session sql(pool);
-        session sql_unused2(pool);
+        soci::session sql_unused1(pool);
+        soci::session sql(pool);
+        soci::session sql_unused2(pool);
         {
             auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
@@ -3711,7 +3711,7 @@ void run_query_transformation_test(test_context_base const& tc, session& sql)
 
 TEST_CASE_METHOD(common_tests, "Query transformation", "[core][query-transform]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
     run_query_transformation_test(tc_, sql);
 }
 
@@ -3727,7 +3727,7 @@ TEST_CASE_METHOD(common_tests, "Query transformation with connection pool", "[co
         sql.open(backEndFactory_, connectString_);
     }
 
-    session sql(pool);
+    soci::session sql(pool);
     run_query_transformation_test(tc_, sql);
 }
 
@@ -3738,7 +3738,7 @@ TEST_CASE_METHOD(common_tests, "Query transformation with connection pool", "[co
 // Implement get_affected_rows for SQLite3 backend
 TEST_CASE_METHOD(common_tests, "Get affected rows", "[core][affected-rows]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
     auto_table_creator tableCreator(tc_.table_creator_4(sql));
     if (!tableCreator.get())
     {
@@ -3822,7 +3822,7 @@ TEST_CASE_METHOD(common_tests, "Backend with connection pool", "[core][pool]")
 // soci::details::statement_impl::backEnd_ must not leak
 TEST_CASE_METHOD(common_tests, "Backend memory leak", "[core][leak]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
     try
     {
@@ -3845,7 +3845,7 @@ TEST_CASE_METHOD(common_tests, "Backend memory leak", "[core][leak]")
 // soci::details::standard_use_type_backend and vector_use_type_backend must not leak
 TEST_CASE_METHOD(common_tests, "Bind memory leak", "[core][leak]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
     sql << "insert into soci_test(id) values (1)";
     {
@@ -3883,7 +3883,7 @@ TEST_CASE_METHOD(common_tests, "Bind memory leak", "[core][leak]")
 
 TEST_CASE_METHOD(common_tests, "Insert error", "[core][insert][exception]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     struct pk_table_creator : table_creator_base
     {
@@ -3989,7 +3989,7 @@ void check_for_exception_on_truncation(session& sql)
 
 TEST_CASE_METHOD(common_tests, "Truncation error", "[core][insert][truncate][exception]")
 {
-    session sql(backEndFactory_, connectString_);
+    soci::session sql(backEndFactory_, connectString_);
 
     if (tc_.has_silent_truncate_bug(sql))
     {

--- a/tests/db2/test-db2.cpp
+++ b/tests/db2/test-db2.cpp
@@ -43,7 +43,7 @@ namespace boost {
 
 struct table_creator_one : public table_creator_base
 {
-    table_creator_one(session & sql)
+    table_creator_one(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "CREATE TABLE SOCI_TEST(ID INTEGER, VAL SMALLINT, C CHAR, STR VARCHAR(20), SH SMALLINT, UL NUMERIC(20), D DOUBLE, "
@@ -54,7 +54,7 @@ struct table_creator_one : public table_creator_base
 
 struct table_creator_two : public table_creator_base
 {
-    table_creator_two(session & sql)
+    table_creator_two(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "CREATE TABLE SOCI_TEST(NUM_FLOAT DOUBLE, NUM_INT INTEGER, NAME VARCHAR(20), SOMETIME TIMESTAMP, CHR CHAR)";
@@ -63,7 +63,7 @@ struct table_creator_two : public table_creator_base
 
 struct table_creator_three : public table_creator_base
 {
-    table_creator_three(session & sql)
+    table_creator_three(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "CREATE TABLE SOCI_TEST(NAME VARCHAR(100) NOT NULL, PHONE VARCHAR(15))";
@@ -72,7 +72,7 @@ struct table_creator_three : public table_creator_base
 
 struct table_creator_for_get_affected_rows : table_creator_base
 {
-    table_creator_for_get_affected_rows(session & sql)
+    table_creator_for_get_affected_rows(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "CREATE TABLE SOCI_TEST(VAL INTEGER)";
@@ -85,25 +85,25 @@ public:
     test_context(backend_factory const & pi_back_end, std::string const & pi_connect_string)
         : test_context_base(pi_back_end, pi_connect_string) {}
 
-    table_creator_base* table_creator_1(session & pr_s) const
+    table_creator_base* table_creator_1(soci::session & pr_s) const
     {
         pr_s << "SET CURRENT SCHEMA = 'DB2INST1'";
         return new table_creator_one(pr_s);
     }
 
-    table_creator_base* table_creator_2(session & pr_s) const
+    table_creator_base* table_creator_2(soci::session & pr_s) const
     {
         pr_s << "SET CURRENT SCHEMA = 'DB2INST1'";
         return new table_creator_two(pr_s);
     }
 
-    table_creator_base* table_creator_3(session & pr_s) const
+    table_creator_base* table_creator_3(soci::session & pr_s) const
     {
         pr_s << "SET CURRENT SCHEMA = 'DB2INST1'";
         return new table_creator_three(pr_s);
     }
 
-    table_creator_base* table_creator_4(session& s) const
+    table_creator_base* table_creator_4(soci::session& s) const
     {
         return new table_creator_for_get_affected_rows(s);
     }

--- a/tests/db2/test-db2.cpp
+++ b/tests/db2/test-db2.cpp
@@ -121,7 +121,7 @@ public:
 
 TEST_CASE("DB2 test 1", "[db2]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     sql << "SELECT CURRENT TIMESTAMP FROM SYSIBM.SYSDUMMY1";
     sql << "SELECT " << 123 << " FROM SYSIBM.SYSDUMMY1";
@@ -303,7 +303,7 @@ TEST_CASE("DB2 test 1", "[db2]")
 
 TEST_CASE("DB2 test 2", "[db2]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     std::string query = "CREATE TABLE DB2INST1.SOCI_TEST (ID BIGINT,DATA VARCHAR(8),DT TIMESTAMP)";
     sql << query;
@@ -350,7 +350,7 @@ TEST_CASE("DB2 test 2", "[db2]")
 
 TEST_CASE("DB2 test 3", "[db2]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     int i;
 
     std::string query = "CREATE TABLE DB2INST1.SOCI_TEST (ID BIGINT,DATA VARCHAR(8),DT TIMESTAMP)";

--- a/tests/empty/test-empty.cpp
+++ b/tests/empty/test-empty.cpp
@@ -76,7 +76,7 @@ namespace soci
 
 TEST_CASE("Dummy test", "[empty]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     sql << "Do what I want.";
     sql << "Do what I want " << 123 << " times.";

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -1225,7 +1225,7 @@ TEST_CASE("Firebird decimals as strings", "[firebird][decimal][string]")
 
 struct TableCreator1 : public tests::table_creator_base
 {
-    TableCreator1(session & sql)
+    TableCreator1(soci::session & sql)
             : tests::table_creator_base(sql)
     {
         sql << "create table soci_test(id integer, val integer, c char, "
@@ -1239,7 +1239,7 @@ struct TableCreator1 : public tests::table_creator_base
 
 struct TableCreator2 : public tests::table_creator_base
 {
-    TableCreator2(session & sql)
+    TableCreator2(soci::session & sql)
             : tests::table_creator_base(sql)
     {
         sql  << "create table soci_test(num_float float, num_int integer, "
@@ -1251,7 +1251,7 @@ struct TableCreator2 : public tests::table_creator_base
 
 struct TableCreator3 : public tests::table_creator_base
 {
-    TableCreator3(session & sql)
+    TableCreator3(soci::session & sql)
             : tests::table_creator_base(sql)
     {
         sql << "create table soci_test(name varchar(100) not null, "
@@ -1263,7 +1263,7 @@ struct TableCreator3 : public tests::table_creator_base
 
 struct TableCreator4 : public tests::table_creator_base
 {
-    TableCreator4(session & sql)
+    TableCreator4(soci::session & sql)
             : tests::table_creator_base(sql)
     {
         sql << "create table soci_test(val integer)";
@@ -1280,22 +1280,22 @@ class test_context : public tests::test_context_base
                 : test_context_base(backEnd, connectString)
         {}
 
-        tests::table_creator_base* table_creator_1(session& s) const
+        tests::table_creator_base* table_creator_1(soci::session& s) const
         {
             return new TableCreator1(s);
         }
 
-        tests::table_creator_base* table_creator_2(session& s) const
+        tests::table_creator_base* table_creator_2(soci::session& s) const
         {
             return new TableCreator2(s);
         }
 
-        tests::table_creator_base* table_creator_3(session& s) const
+        tests::table_creator_base* table_creator_3(soci::session& s) const
         {
             return new TableCreator3(s);
         }
 
-        tests::table_creator_base* table_creator_4(session& s) const
+        tests::table_creator_base* table_creator_4(soci::session& s) const
         {
             return new TableCreator4(s);
         }
@@ -1305,7 +1305,7 @@ class test_context : public tests::test_context_base
             return "'" + datdt_string + "'";
         }
 
-        virtual void on_after_ddl(session& sql) const
+        virtual void on_after_ddl(soci::session& sql) const
         {
             sql.commit();
         }

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -43,7 +43,7 @@ namespace boost {
 // fundamental tests - transactions in Firebird
 TEST_CASE("Firebird transactions", "[firebird][transaction]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     // In Firebird transaction is always required and is started
     // automatically when session is opened. There is no need to
@@ -77,7 +77,7 @@ TEST_CASE("Firebird transactions", "[firebird][transaction]")
 // character types
 TEST_CASE("Firebird char types", "[firebird][string]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     try
     {
@@ -172,7 +172,7 @@ TEST_CASE("Firebird char types", "[firebird][string]")
 // date and time
 TEST_CASE("Firebird date and time", "[firebird][datetime]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     try
     {
@@ -225,7 +225,7 @@ TEST_CASE("Firebird date and time", "[firebird][datetime]")
 // floating points
 TEST_CASE("Firebird floating point", "[firebird][float]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     try
     {
@@ -308,7 +308,7 @@ TEST_CASE("Firebird floating point", "[firebird][float]")
 // integer types and indicators
 TEST_CASE("Firebird integers", "[firebird][int]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     {
         short sh(0);
@@ -369,7 +369,7 @@ TEST_CASE("Firebird integers", "[firebird][int]")
 // repeated fetch and bulk operations for character types
 TEST_CASE("Firebird bulk operations", "[firebird][bulk]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     try
     {
@@ -518,7 +518,7 @@ TEST_CASE("Firebird bulk operations", "[firebird][bulk]")
 // blob test
 TEST_CASE("Firebird blobs", "[firebird][blob]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     try
     {
@@ -637,7 +637,7 @@ TEST_CASE("Firebird blobs", "[firebird][blob]")
 // named parameters
 TEST_CASE("Firebird named parameters", "[firebird][named-params]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     try
     {
@@ -720,7 +720,7 @@ TEST_CASE("Firebird named parameters", "[firebird][named-params]")
 // Dynamic binding to row objects
 TEST_CASE("Firebird dynamic binding", "[firebird][dynamic]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     try
     {
@@ -812,7 +812,7 @@ TEST_CASE("Firebird dynamic binding", "[firebird][dynamic]")
 // stored procedures
 TEST_CASE("Firebird stored procedures", "[firebird][procedure]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     try
     {
@@ -1004,7 +1004,7 @@ namespace soci
 
 TEST_CASE("Firebird direct API use", "[firebird][native]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     try
     {
@@ -1071,7 +1071,7 @@ TEST_CASE("Firebird direct API use", "[firebird][native]")
 
 TEST_CASE("Firebird string coercions", "[firebird][string]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     try
     {
@@ -1141,7 +1141,7 @@ TEST_CASE("Firebird decimals as strings", "[firebird][decimal][string]")
     CHECK(format_decimal<int>(&a, -8) == "0.12345678");
     CHECK(format_decimal<int>(&a, -9) == "0.012345678");
 
-    session sql(backEnd, connectString + " decimals_as_strings=1");
+    soci::session sql(backEnd, connectString + " decimals_as_strings=1");
 
     try
     {

--- a/tests/mysql/test-mysql.cpp
+++ b/tests/mysql/test-mysql.cpp
@@ -148,7 +148,7 @@ TEST_CASE("MySQL error reporting", "[mysql][exception]")
 
 struct bigint_table_creator : table_creator_base
 {
-    bigint_table_creator(session & sql)
+    bigint_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val bigint)";
@@ -157,7 +157,7 @@ struct bigint_table_creator : table_creator_base
 
 struct bigint_unsigned_table_creator : table_creator_base
 {
-    bigint_unsigned_table_creator(session & sql)
+    bigint_unsigned_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val bigint unsigned)";
@@ -504,7 +504,7 @@ TEST_CASE("MySQL text and blob", "[mysql][text][blob]")
 
 struct integer_value_table_creator : table_creator_base
 {
-    integer_value_table_creator(session & sql)
+    integer_value_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val integer)";
@@ -570,7 +570,7 @@ TEST_CASE("MySQL statements after reconnect", "[mysql][connect]")
 
 struct unsigned_value_table_creator : table_creator_base
 {
-    unsigned_value_table_creator(session & sql)
+    unsigned_value_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val int unsigned)";
@@ -610,7 +610,7 @@ TEST_CASE("MySQL function call", "[mysql][function]")
 
 struct double_value_table_creator : table_creator_base
 {
-    double_value_table_creator(session & sql)
+    double_value_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val double)";
@@ -676,7 +676,7 @@ TEST_CASE("MySQL special floating point values", "[mysql][float]")
 
 struct tinyint_value_table_creator : table_creator_base
 {
-    tinyint_value_table_creator(session & sql)
+    tinyint_value_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val tinyint)";
@@ -685,7 +685,7 @@ struct tinyint_value_table_creator : table_creator_base
 
 struct tinyint_unsigned_value_table_creator : table_creator_base
 {
-    tinyint_unsigned_value_table_creator(session & sql)
+    tinyint_unsigned_value_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val tinyint unsigned)";
@@ -750,7 +750,7 @@ TEST_CASE("MySQL tinyint", "[mysql][int][tinyint]")
 
 struct strings_table_creator : table_creator_base
 {
-    strings_table_creator(session & sql)
+    strings_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(s1 char(20), s2 varchar(20), "
@@ -791,7 +791,7 @@ TEST_CASE("MySQL strings", "[mysql][string]")
 
 struct table_creator_for_get_last_insert_id : table_creator_base
 {
-    table_creator_for_get_last_insert_id(session & sql)
+    table_creator_for_get_last_insert_id(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(id integer not null auto_increment, "

--- a/tests/mysql/test-mysql.cpp
+++ b/tests/mysql/test-mysql.cpp
@@ -44,7 +44,7 @@ namespace boost {
 // procedure call test
 TEST_CASE("MySQL stored procedures", "[mysql][stored-procedure]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     mysql_session_backend *sessionBackEnd
         = static_cast<mysql_session_backend *>(sql.get_backend());
@@ -99,7 +99,7 @@ TEST_CASE("MySQL error reporting", "[mysql][exception]")
     {
         try
         {
-            session sql(backEnd, "host=test.soci.invalid");
+            soci::session sql(backEnd, "host=test.soci.invalid");
         }
         catch (mysql_soci_error const &e)
         {
@@ -113,7 +113,7 @@ TEST_CASE("MySQL error reporting", "[mysql][exception]")
     }
 
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
         sql << "create table soci_test (id integer)";
         try
         {
@@ -167,7 +167,7 @@ struct bigint_unsigned_table_creator : table_creator_base
 TEST_CASE("MySQL long long", "[mysql][longlong]")
 {
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
 
         bigint_table_creator tableCreator(sql);
 
@@ -182,7 +182,7 @@ TEST_CASE("MySQL long long", "[mysql][longlong]")
 
     // vector<long long>
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
 
         bigint_table_creator tableCreator(sql);
 
@@ -207,7 +207,7 @@ TEST_CASE("MySQL long long", "[mysql][longlong]")
     }
 
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
 
         bigint_unsigned_table_creator tableCreator(sql);
 
@@ -217,7 +217,7 @@ TEST_CASE("MySQL long long", "[mysql][longlong]")
     }
 
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
 
         bigint_unsigned_table_creator tableCreator(sql);
 
@@ -231,7 +231,7 @@ TEST_CASE("MySQL long long", "[mysql][longlong]")
     }
 
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
 
         bigint_unsigned_table_creator tableCreator(sql);
 
@@ -245,7 +245,7 @@ TEST_CASE("MySQL long long", "[mysql][longlong]")
     }
 
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
 
         bigint_unsigned_table_creator tableCreator(sql);
 
@@ -257,7 +257,7 @@ TEST_CASE("MySQL long long", "[mysql][longlong]")
     }
 
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
 
         bigint_unsigned_table_creator tableCreator(sql);
 
@@ -282,7 +282,7 @@ void test_num(const char* s, bool valid, T value)
 {
     try
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
         T val;
         sql << "select \'" << s << "\'", into(val);
         if (valid)
@@ -377,7 +377,7 @@ TEST_CASE("MySQL number conversion", "[mysql][float][int]")
 
 TEST_CASE("MySQL datetime", "[mysql][datetime]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     std::tm t;
     sql << "select maketime(19, 54, 52)", into(t);
     CHECK(t.tm_year == 100);
@@ -391,7 +391,7 @@ TEST_CASE("MySQL datetime", "[mysql][datetime]")
 // TEXT and BLOB types support test.
 TEST_CASE("MySQL text and blob", "[mysql][text][blob]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     std::string a("asdfg\0hjkl", 10);
     std::string b("lkjhg\0fd\0\0sa\0", 13);
     std::string c("\\0aa\\0bb\\0cc\\0", 10);
@@ -513,7 +513,7 @@ struct integer_value_table_creator : table_creator_base
 
 TEST_CASE("MySQL get affected rows", "[mysql][affected-rows]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     integer_value_table_creator tableCreator(sql);
 
@@ -539,7 +539,7 @@ TEST_CASE("MySQL get affected rows", "[mysql][affected-rows]")
 // The prepared statements should survive session::reconnect().
 TEST_CASE("MySQL statements after reconnect", "[mysql][connect]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     integer_value_table_creator tableCreator(sql);
 
@@ -580,7 +580,7 @@ struct unsigned_value_table_creator : table_creator_base
 // rowset<> should be able to take INT UNSIGNED.
 TEST_CASE("MySQL unsigned int", "[mysql][int]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     unsigned_value_table_creator tableCreator(sql);
 
@@ -598,7 +598,7 @@ TEST_CASE("MySQL unsigned int", "[mysql][int]")
 
 TEST_CASE("MySQL function call", "[mysql][function]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     row r;
 
@@ -629,7 +629,7 @@ TEST_CASE("MySQL special floating point values", "[mysql][float]")
       "Use element used with infinity or NaN, which are "
       "not supported by the MySQL server.";
   {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     double x = std::numeric_limits<double>::quiet_NaN();
     statement st = (sql.prepare << "SELECT :x", use(x, "x"));
@@ -640,7 +640,7 @@ TEST_CASE("MySQL special floating point values", "[mysql][float]")
     }
   }
   {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     double x = std::numeric_limits<double>::infinity();
     statement st = (sql.prepare << "SELECT :x", use(x, "x"));
@@ -651,7 +651,7 @@ TEST_CASE("MySQL special floating point values", "[mysql][float]")
     }
   }
   {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     double_value_table_creator tableCreator(sql);
 
     std::vector<double> v(1, std::numeric_limits<double>::quiet_NaN());
@@ -662,7 +662,7 @@ TEST_CASE("MySQL special floating point values", "[mysql][float]")
     }
   }
   {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     double_value_table_creator tableCreator(sql);
 
     std::vector<double> v(1, std::numeric_limits<double>::infinity());
@@ -695,7 +695,7 @@ struct tinyint_unsigned_value_table_creator : table_creator_base
 TEST_CASE("MySQL tinyint", "[mysql][int][tinyint]")
 {
   {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     unsigned_value_table_creator tableCreator(sql);
     unsigned int mask = 0xffffff00;
     sql << "insert into soci_test set val = " << mask;
@@ -707,7 +707,7 @@ TEST_CASE("MySQL tinyint", "[mysql][int][tinyint]")
     CHECK(r.get<unsigned>("val") == 0xffffff00);
   }
   {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     tinyint_value_table_creator tableCreator(sql);
     sql << "insert into soci_test set val = -123";
     row r;
@@ -717,7 +717,7 @@ TEST_CASE("MySQL tinyint", "[mysql][int][tinyint]")
     CHECK(r.get<int>("val") == -123);
   }
   {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     tinyint_unsigned_value_table_creator tableCreator(sql);
     sql << "insert into soci_test set val = 123";
     row r;
@@ -727,7 +727,7 @@ TEST_CASE("MySQL tinyint", "[mysql][int][tinyint]")
     CHECK(r.get<int>("val") == 123);
   }
   {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     bigint_unsigned_table_creator tableCreator(sql);
     sql << "insert into soci_test set val = 123456789012345";
     row r;
@@ -737,7 +737,7 @@ TEST_CASE("MySQL tinyint", "[mysql][int][tinyint]")
     CHECK(r.get<unsigned long long>("val") == 123456789012345ULL);
   }
   {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     bigint_table_creator tableCreator(sql);
     sql << "insert into soci_test set val = -123456789012345";
     row r;
@@ -762,7 +762,7 @@ struct strings_table_creator : table_creator_base
 
 TEST_CASE("MySQL strings", "[mysql][string]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     strings_table_creator tableCreator(sql);
     std::string text = "Ala ma kota.";
     std::string binary("Ala\0ma\0kota.........", 20);
@@ -802,7 +802,7 @@ struct table_creator_for_get_last_insert_id : table_creator_base
 
 TEST_CASE("MySQL last insert id", "[mysql][last-insert-id]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     table_creator_for_get_last_insert_id tableCreator(sql);
     sql << "insert into soci_test () values ()";
     long id;
@@ -825,7 +825,7 @@ std::string escape_string(soci::session& sql, const std::string& s)
 void test14()
 {
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
         strings_table_creator tableCreator(sql);
         std::string s = "word1'word2:word3";
         std::string escaped = escape_string(sql, s);
@@ -844,7 +844,7 @@ void test14()
 void test15()
 {
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
         int n;
         sql << "select @a := 123", into(n);
         CHECK(n == 123);

--- a/tests/mysql/test-mysql.h
+++ b/tests/mysql/test-mysql.h
@@ -9,7 +9,7 @@ using namespace soci::tests;
 // DDL Creation objects for common tests
 struct table_creator_one : public table_creator_base
 {
-    table_creator_one(session & sql)
+    table_creator_one(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(id integer, val integer, c char, "
@@ -22,7 +22,7 @@ struct table_creator_one : public table_creator_base
 
 struct table_creator_two : public table_creator_base
 {
-    table_creator_two(session & sql)
+    table_creator_two(soci::session & sql)
         : table_creator_base(sql)
     {
         sql  << "create table soci_test(num_float float8, num_int integer,"
@@ -32,7 +32,7 @@ struct table_creator_two : public table_creator_base
 
 struct table_creator_three : public table_creator_base
 {
-    table_creator_three(session & sql)
+    table_creator_three(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(name varchar(100) not null, "
@@ -42,7 +42,7 @@ struct table_creator_three : public table_creator_base
 
 struct table_creator_for_get_affected_rows : table_creator_base
 {
-    table_creator_for_get_affected_rows(session & sql)
+    table_creator_for_get_affected_rows(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val integer)";
@@ -60,22 +60,22 @@ public:
                 std::string const &connectString)
         : test_context_base(backEnd, connectString) {}
 
-    table_creator_base* table_creator_1(session& s) const
+    table_creator_base* table_creator_1(soci::session& s) const
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base* table_creator_2(session& s) const
+    table_creator_base* table_creator_2(soci::session& s) const
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base* table_creator_3(session& s) const
+    table_creator_base* table_creator_3(soci::session& s) const
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base* table_creator_4(session& s) const
+    table_creator_base* table_creator_4(soci::session& s) const
     {
         return new table_creator_for_get_affected_rows(s);
     }
@@ -92,7 +92,7 @@ public:
         return true;
     }
 
-    virtual bool has_transactions_support(session& sql) const
+    virtual bool has_transactions_support(soci::session& sql) const
     {
         sql << "drop table if exists soci_test";
         sql << "create table soci_test (id int) engine=InnoDB";
@@ -103,7 +103,7 @@ public:
         return retv;
     }
 
-    virtual bool has_silent_truncate_bug(session& sql) const
+    virtual bool has_silent_truncate_bug(soci::session& sql) const
     {
         std::string sql_mode;
         sql << "select @@session.sql_mode", into(sql_mode);

--- a/tests/odbc/test-odbc-access.cpp
+++ b/tests/odbc/test-odbc-access.cpp
@@ -39,7 +39,7 @@ backend_factory const &backEnd = *soci::factory_odbc();
 // DDL Creation objects for common tests
 struct table_creator_one : public table_creator_base
 {
-    table_creator_one(session & sql)
+    table_creator_one(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(id integer, val integer, c char, "
@@ -52,7 +52,7 @@ struct table_creator_one : public table_creator_base
 
 struct table_creator_two : public table_creator_base
 {
-    table_creator_two(session & sql)
+    table_creator_two(soci::session & sql)
         : table_creator_base(sql)
     {
         sql  << "create table soci_test(num_float float, num_int integer,"
@@ -62,7 +62,7 @@ struct table_creator_two : public table_creator_base
 
 struct table_creator_three : public table_creator_base
 {
-    table_creator_three(session & sql)
+    table_creator_three(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(name varchar(100) not null, "
@@ -72,7 +72,7 @@ struct table_creator_three : public table_creator_base
 
 struct table_creator_for_get_affected_rows : table_creator_base
 {
-    table_creator_for_get_affected_rows(session & sql)
+    table_creator_for_get_affected_rows(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val integer)";
@@ -90,22 +90,22 @@ public:
 test_context(backend_factory const &backEnd, std::string const &connectString)
         : test_context_base(backEnd, connectString) {}
 
-    table_creator_base * table_creator_1(session& s) const
+    table_creator_base * table_creator_1(soci::session& s) const
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base * table_creator_2(session& s) const
+    table_creator_base * table_creator_2(soci::session& s) const
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base * table_creator_3(session& s) const
+    table_creator_base * table_creator_3(soci::session& s) const
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base * table_creator_4(session& s) const
+    table_creator_base * table_creator_4(soci::session& s) const
     {
         return new table_creator_for_get_affected_rows(s);
     }

--- a/tests/odbc/test-odbc-db2.cpp
+++ b/tests/odbc/test-odbc-db2.cpp
@@ -39,7 +39,7 @@ backend_factory const &backEnd = *soci::factory_odbc();
 // DDL Creation objects for common tests
 struct table_creator_one : public table_creator_base
 {
-    table_creator_one(session & sql)
+    table_creator_one(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "CREATE TABLE SOCI_TEST(ID INTEGER, VAL SMALLINT, C CHAR, STR VARCHAR(20), SH SMALLINT, UL NUMERIC(20), D DOUBLE, "
@@ -50,7 +50,7 @@ struct table_creator_one : public table_creator_base
 
 struct table_creator_two : public table_creator_base
 {
-    table_creator_two(session & sql)
+    table_creator_two(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "CREATE TABLE SOCI_TEST(NUM_FLOAT DOUBLE, NUM_INT INTEGER, NAME VARCHAR(20), SOMETIME TIMESTAMP, CHR CHAR)";
@@ -59,7 +59,7 @@ struct table_creator_two : public table_creator_base
 
 struct table_creator_three : public table_creator_base
 {
-    table_creator_three(session & sql)
+    table_creator_three(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "CREATE TABLE SOCI_TEST(NAME VARCHAR(100) NOT NULL, PHONE VARCHAR(15))";
@@ -68,7 +68,7 @@ struct table_creator_three : public table_creator_base
 
 struct table_creator_for_get_affected_rows : table_creator_base
 {
-    table_creator_for_get_affected_rows(session & sql)
+    table_creator_for_get_affected_rows(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "CREATE TABLE SOCI_TEST(VAL INTEGER)";
@@ -86,22 +86,22 @@ public:
                 std::string const &connectString)
         : test_context_base(backEnd, connectString) {}
 
-    table_creator_base * table_creator_1(session& s) const
+    table_creator_base * table_creator_1(soci::session& s) const
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base * table_creator_2(session& s) const
+    table_creator_base * table_creator_2(soci::session& s) const
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base * table_creator_3(session& s) const
+    table_creator_base * table_creator_3(soci::session& s) const
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base * table_creator_4(session& s) const
+    table_creator_base * table_creator_4(soci::session& s) const
     {
         return new table_creator_for_get_affected_rows(s);
     }
@@ -114,7 +114,7 @@ public:
 
 struct table_creator_bigint : table_creator_base
 {
-    table_creator_bigint(session & sql)
+    table_creator_bigint(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "CREATE TABLE SOCI_TEST (VAL BIGINT)";

--- a/tests/odbc/test-odbc-db2.cpp
+++ b/tests/odbc/test-odbc-db2.cpp
@@ -124,7 +124,7 @@ struct table_creator_bigint : table_creator_base
 TEST_CASE("ODBC/DB2 long long", "[odbc][db2][longlong]")
 {
     const int num_recs = 100;
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     table_creator_bigint table(sql);
 
     {
@@ -153,7 +153,7 @@ TEST_CASE("ODBC/DB2 long long", "[odbc][db2][longlong]")
 TEST_CASE("ODBC/DB2 unsigned long long", "[odbc][db2][unsigned][longlong]")
 {
     const int num_recs = 100;
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     table_creator_bigint table(sql);
 
     {
@@ -182,7 +182,7 @@ TEST_CASE("ODBC/DB2 unsigned long long", "[odbc][db2][unsigned][longlong]")
 TEST_CASE("ODBC/DB2 vector long long", "[odbc][db2][vector][longlong]")
 {
     const std::size_t num_recs = 100;
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     table_creator_bigint table(sql);
 
     {
@@ -223,7 +223,7 @@ TEST_CASE("ODBC/DB2 vector long long", "[odbc][db2][vector][longlong]")
 TEST_CASE("ODBC/DB2 vector unsigned long long", "[odbc][db2][vector][unsigned][longlong]")
 {
     const std::size_t num_recs = 100;
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     table_creator_bigint table(sql);
 
     {

--- a/tests/odbc/test-odbc-mssql.cpp
+++ b/tests/odbc/test-odbc-mssql.cpp
@@ -39,7 +39,7 @@ namespace boost {
 // DDL Creation objects for common tests
 struct table_creator_one : public table_creator_base
 {
-    table_creator_one(session & sql)
+    table_creator_one(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(id integer, val integer, c char, "
@@ -52,7 +52,7 @@ struct table_creator_one : public table_creator_base
 
 struct table_creator_two : public table_creator_base
 {
-    table_creator_two(session & sql)
+    table_creator_two(soci::session & sql)
         : table_creator_base(sql)
     {
         sql  << "create table soci_test(num_float float, num_int integer,"
@@ -62,7 +62,7 @@ struct table_creator_two : public table_creator_base
 
 struct table_creator_three : public table_creator_base
 {
-    table_creator_three(session & sql)
+    table_creator_three(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(name varchar(100) not null, "
@@ -72,7 +72,7 @@ struct table_creator_three : public table_creator_base
 
 struct table_creator_for_get_affected_rows : table_creator_base
 {
-    table_creator_for_get_affected_rows(session & sql)
+    table_creator_for_get_affected_rows(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val integer)";
@@ -90,22 +90,22 @@ public:
                 std::string const &connectString)
         : test_context_base(backEnd, connectString) {}
 
-    table_creator_base* table_creator_1(session& s) const
+    table_creator_base* table_creator_1(soci::session& s) const
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base* table_creator_2(session& s) const
+    table_creator_base* table_creator_2(soci::session& s) const
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base* table_creator_3(session& s) const
+    table_creator_base* table_creator_3(soci::session& s) const
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base * table_creator_4(session& s) const
+    table_creator_base * table_creator_4(soci::session& s) const
     {
         return new table_creator_for_get_affected_rows(s);
     }

--- a/tests/odbc/test-odbc-postgresql.cpp
+++ b/tests/odbc/test-odbc-postgresql.cpp
@@ -105,7 +105,7 @@ backend_factory const &backEnd = *soci::factory_odbc();
 // DDL Creation objects for common tests
 struct table_creator_one : public table_creator_base
 {
-    table_creator_one(session & sql)
+    table_creator_one(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(id integer, val integer, c char, "
@@ -118,7 +118,7 @@ struct table_creator_one : public table_creator_base
 
 struct table_creator_two : public table_creator_base
 {
-    table_creator_two(session & sql)
+    table_creator_two(soci::session & sql)
         : table_creator_base(sql)
     {
         sql  << "create table soci_test(num_float float8, num_int integer,"
@@ -128,7 +128,7 @@ struct table_creator_two : public table_creator_base
 
 struct table_creator_three : public table_creator_base
 {
-    table_creator_three(session & sql)
+    table_creator_three(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(name varchar(100) not null, "
@@ -138,7 +138,7 @@ struct table_creator_three : public table_creator_base
 
 struct table_creator_for_get_affected_rows : table_creator_base
 {
-    table_creator_for_get_affected_rows(session & sql)
+    table_creator_for_get_affected_rows(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val integer)";
@@ -160,22 +160,22 @@ public:
         std::cout << "Using ODBC driver version " << m_verDriver << "\n";
     }
 
-    table_creator_base * table_creator_1(session& s) const
+    table_creator_base * table_creator_1(soci::session& s) const
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base * table_creator_2(session& s) const
+    table_creator_base * table_creator_2(soci::session& s) const
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base * table_creator_3(session& s) const
+    table_creator_base * table_creator_3(soci::session& s) const
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base * table_creator_4(session& s) const
+    table_creator_base * table_creator_4(soci::session& s) const
     {
         return new table_creator_for_get_affected_rows(s);
     }

--- a/tests/odbc/test-odbc-postgresql.cpp
+++ b/tests/odbc/test-odbc-postgresql.cpp
@@ -199,7 +199,7 @@ public:
 private:
     odbc_version get_driver_version() const
     {
-        session sql(get_backend_factory(), get_connect_string());
+        soci::session sql(get_backend_factory(), get_connect_string());
         odbc_session_backend* const
             odbc_session = static_cast<odbc_session_backend*>(sql.get_backend());
         if (!odbc_session)

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -39,7 +39,7 @@ namespace boost {
 // Extra tests for date/time
 TEST_CASE("Oracle datetime", "[oracle][datetime]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     {
         std::time_t now = std::time(NULL);
@@ -106,7 +106,7 @@ TEST_CASE("Oracle datetime", "[oracle][datetime]")
 // explicit calls test
 TEST_CASE("Oracle explicit calls", "[oracle]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     statement st(sql);
     st.alloc();
@@ -135,7 +135,7 @@ struct blob_table_creator : public table_creator_base
 
 TEST_CASE("Oracle blob", "[oracle][blob]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     blob_table_creator tableCreator(sql);
 
@@ -199,7 +199,7 @@ struct basic_table_creator : public table_creator_base
 
 TEST_CASE("Oracle nested statement", "[oracle][blob]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     basic_table_creator tableCreator(sql);
 
     int id;
@@ -236,7 +236,7 @@ TEST_CASE("Oracle nested statement", "[oracle][blob]")
 // ROWID test
 TEST_CASE("Oracle rowid", "[oracle][rowid]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     basic_table_creator tableCreator(sql);
 
     sql << "insert into soci_test(id, name) values(7, \'John\')";
@@ -268,7 +268,7 @@ struct procedure_creator : procedure_creator_base
 
 TEST_CASE("Oracle stored procedure", "[oracle][stored-procedure]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     procedure_creator procedure_creator(sql);
 
     std::string in("my message");
@@ -345,7 +345,7 @@ struct returns_null_procedure_creator : public procedure_creator_base
 
 TEST_CASE("Oracle user-defined objects", "[oracle][type_conversion]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     {
         basic_table_creator tableCreator(sql);
 
@@ -366,7 +366,7 @@ TEST_CASE("Oracle user-defined objects", "[oracle][type_conversion]")
 
 TEST_CASE("Oracle user-defined objects in/out", "[oracle][type_conversion]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     // test procedure with user-defined type as in-out parameter
     {
@@ -391,7 +391,7 @@ TEST_CASE("Oracle user-defined objects in/out", "[oracle][type_conversion]")
 
 TEST_CASE("Oracle null user-defined objects in/out", "[oracle][null][type_conversion]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     // test procedure which returns null
     returns_null_procedure_creator procedureCreator(sql);
@@ -406,7 +406,7 @@ TEST_CASE("Oracle null user-defined objects in/out", "[oracle][null][type_conver
 // test bulk insert features
 TEST_CASE("Oracle bulk insert", "[oracle][insert][bulk]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     basic_table_creator tableCreator(sql);
 
@@ -645,7 +645,7 @@ TEST_CASE("Oracle bulk insert", "[oracle][insert][bulk]")
 // more tests for bulk fetch
 TEST_CASE("Oracle bulk fetch", "[oracle][fetch][bulk]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     basic_table_creator tableCreator(sql);
 
@@ -784,7 +784,7 @@ struct times100_procedure_creator : public procedure_creator_base
 
 TEST_CASE("Oracle ORM", "[oracle][orm]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     {
         person_table_creator tableCreator(sql);
@@ -939,7 +939,7 @@ namespace soci
 
 TEST_CASE("Oracle ORM by index", "[oracle][orm]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     person_table_creator tableCreator(sql);
 
@@ -984,7 +984,7 @@ struct long_table_creator : public table_creator_base
 
 TEST_CASE("Oracle large strings as long", "[oracle][compatibility]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     long_table_creator creator(sql);
 
     const std::string::size_type max = 32768;
@@ -1002,7 +1002,7 @@ TEST_CASE("Oracle large strings as long", "[oracle][compatibility]")
 // test for modifiable and const use elements
 TEST_CASE("Oracle const and modifiable parameters", "[oracle][use]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     int i = 7;
     sql << "begin "
@@ -1039,7 +1039,7 @@ struct longlong_table_creator : table_creator_base
 TEST_CASE("Oracle long long", "[oracle][longlong]")
 {
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
 
         longlong_table_creator tableCreator(sql);
 
@@ -1054,7 +1054,7 @@ TEST_CASE("Oracle long long", "[oracle][longlong]")
 
     // vector<long long>
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
 
         longlong_table_creator tableCreator(sql);
 

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -122,7 +122,7 @@ TEST_CASE("Oracle explicit calls", "[oracle]")
 
 struct blob_table_creator : public table_creator_base
 {
-    blob_table_creator(session & sql)
+    blob_table_creator(soci::session & sql)
     : table_creator_base(sql)
     {
         sql <<
@@ -185,7 +185,7 @@ TEST_CASE("Oracle blob", "[oracle][blob]")
 
 struct basic_table_creator : public table_creator_base
 {
-    basic_table_creator(session & sql)
+    basic_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql <<
@@ -256,7 +256,7 @@ TEST_CASE("Oracle rowid", "[oracle][rowid]")
 // Stored procedures
 struct procedure_creator : procedure_creator_base
 {
-    procedure_creator(session & sql)
+    procedure_creator(soci::session & sql)
         : procedure_creator_base(sql)
     {
         sql <<
@@ -325,7 +325,7 @@ namespace soci
 
 struct in_out_procedure_creator : public procedure_creator_base
 {
-    in_out_procedure_creator(session & sql)
+    in_out_procedure_creator(soci::session & sql)
         : procedure_creator_base(sql)
     {
         sql << "create or replace procedure soci_test(s in out varchar2)"
@@ -335,7 +335,7 @@ struct in_out_procedure_creator : public procedure_creator_base
 
 struct returns_null_procedure_creator : public procedure_creator_base
 {
-    returns_null_procedure_creator(session & sql)
+    returns_null_procedure_creator(soci::session & sql)
         : procedure_creator_base(sql)
     {
         sql << "create or replace procedure soci_test(s in out varchar2)"
@@ -763,7 +763,7 @@ namespace soci
 
 struct person_table_creator : public table_creator_base
 {
-    person_table_creator(session & sql)
+    person_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(id numeric(5,0) NOT NULL,"
@@ -774,7 +774,7 @@ struct person_table_creator : public table_creator_base
 
 struct times100_procedure_creator : public procedure_creator_base
 {
-    times100_procedure_creator(session & sql)
+    times100_procedure_creator(soci::session & sql)
         : procedure_creator_base(sql)
     {
         sql << "create or replace procedure soci_test(id in out number)"
@@ -975,7 +975,7 @@ TEST_CASE("Oracle ORM by index", "[oracle][orm]")
 ///
 struct long_table_creator : public table_creator_base
 {
-    long_table_creator(session & sql)
+    long_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(l long)";
@@ -1028,7 +1028,7 @@ TEST_CASE("Oracle const and modifiable parameters", "[oracle][use]")
 
 struct longlong_table_creator : table_creator_base
 {
-    longlong_table_creator(session & sql)
+    longlong_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val number(20))";
@@ -1085,7 +1085,7 @@ TEST_CASE("Oracle long long", "[oracle][longlong]")
 
 struct table_creator_one : public table_creator_base
 {
-    table_creator_one(session & sql)
+    table_creator_one(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(id number(10,0), val number(4,0), c char, "
@@ -1097,7 +1097,7 @@ struct table_creator_one : public table_creator_base
 
 struct table_creator_two : public table_creator_base
 {
-    table_creator_two(session & sql)
+    table_creator_two(soci::session & sql)
         : table_creator_base(sql)
     {
         sql  << "create table soci_test(num_float number, num_int numeric(4,0),"
@@ -1107,7 +1107,7 @@ struct table_creator_two : public table_creator_base
 
 struct table_creator_three : public table_creator_base
 {
-    table_creator_three(session & sql)
+    table_creator_three(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(name varchar2(100) not null, "
@@ -1117,7 +1117,7 @@ struct table_creator_three : public table_creator_base
 
 struct table_creator_four : public table_creator_base
 {
-    table_creator_four(session & sql)
+    table_creator_four(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val number)";
@@ -1131,22 +1131,22 @@ public:
                 std::string const &connectString)
         : test_context_base(backEnd, connectString) {}
 
-    table_creator_base* table_creator_1(session& s) const
+    table_creator_base* table_creator_1(soci::session& s) const
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base* table_creator_2(session& s) const
+    table_creator_base* table_creator_2(soci::session& s) const
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base* table_creator_3(session& s) const
+    table_creator_base* table_creator_3(soci::session& s) const
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base* table_creator_4(session& s) const
+    table_creator_base* table_creator_4(soci::session& s) const
     {
         return new table_creator_four(s);
     }

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -59,7 +59,7 @@ struct oid_table_creator : public table_creator_base
 // whatever that means.
 TEST_CASE("PostgreSQL ROWID", "[postgresql][rowid][oid]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     oid_table_creator tableCreator(sql);
 
@@ -95,7 +95,7 @@ TEST_CASE("PostgreSQL ROWID", "[postgresql][rowid][oid]")
 
 TEST_CASE("PostgreSQL prepare error", "[postgresql][exception]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     // Must not cause the application to crash.
     statement st(sql);
@@ -146,7 +146,7 @@ protected:
 
 TEST_CASE("PostgreSQL function call", "[postgresql][function]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     function_creator functionCreator(sql);
 
@@ -212,7 +212,7 @@ struct blob_table_creator : public table_creator_base
 
 TEST_CASE("PostgreSQL blob", "[postgresql][blob]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     blob_table_creator tableCreator(sql);
 
@@ -261,7 +261,7 @@ struct longlong_table_creator : table_creator_base
 // long long test
 TEST_CASE("PostgreSQL long long", "[postgresql][longlong]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     longlong_table_creator tableCreator(sql);
 
@@ -277,7 +277,7 @@ TEST_CASE("PostgreSQL long long", "[postgresql][longlong]")
 // vector<long long>
 TEST_CASE("PostgreSQL vector long long", "[postgresql][vector][longlong]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     longlong_table_creator tableCreator(sql);
 
@@ -304,7 +304,7 @@ TEST_CASE("PostgreSQL vector long long", "[postgresql][vector][longlong]")
 // unsigned long long test
 TEST_CASE("PostgreSQL unsigned long long", "[postgresql][unsigned][longlong]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     longlong_table_creator tableCreator(sql);
 
@@ -328,7 +328,7 @@ struct boolean_table_creator : table_creator_base
 
 TEST_CASE("PostgreSQL boolean", "[postgresql][boolean]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     boolean_table_creator tableCreator(sql);
 
@@ -351,7 +351,7 @@ TEST_CASE("PostgreSQL dynamic backend", "[postgresql][backend][.]")
 {
     try
     {
-        session sql("nosuchbackend://" + connectString);
+        soci::session sql("nosuchbackend://" + connectString);
         FAIL("expected exception not thrown");
     }
     catch (soci_error const & e)
@@ -368,7 +368,7 @@ TEST_CASE("PostgreSQL dynamic backend", "[postgresql][backend][.]")
         CHECK(backends[0] == "pgsql");
 
         {
-            session sql("pgsql://" + connectString);
+            soci::session sql("pgsql://" + connectString);
         }
 
         dynamic_backends::unload("pgsql");
@@ -378,13 +378,13 @@ TEST_CASE("PostgreSQL dynamic backend", "[postgresql][backend][.]")
     }
 
     {
-        session sql("postgresql://" + connectString);
+        soci::session sql("postgresql://" + connectString);
     }
 }
 
 TEST_CASE("PostgreSQL literals", "[postgresql][into]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     int i;
     sql << "select 123", into(i);
@@ -405,7 +405,7 @@ TEST_CASE("PostgreSQL literals", "[postgresql][into]")
 
 TEST_CASE("PostgreSQL backend name", "[postgresql][backend]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     CHECK(sql.get_backend_name() == "postgresql");
 }
@@ -413,7 +413,7 @@ TEST_CASE("PostgreSQL backend name", "[postgresql][backend]")
 // test for double-colon cast in SQL expressions
 TEST_CASE("PostgreSQL double colon cast", "[postgresql][cast]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     int a = 123;
     int b = 0;
@@ -424,7 +424,7 @@ TEST_CASE("PostgreSQL double colon cast", "[postgresql][cast]")
 // test for date, time and timestamp parsing
 TEST_CASE("PostgreSQL datetime", "[postgresql][datetime]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     std::string someDate = "2009-06-17 22:51:03.123";
     std::tm t1, t2, t3;
@@ -470,7 +470,7 @@ struct table_creator_for_test11 : table_creator_base
 
 TEST_CASE("PostgreSQL get affected rows", "[postgresql][affected-rows]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     table_creator_for_test11 tableCreator(sql);
 
@@ -505,7 +505,7 @@ struct table_creator_for_test12 : table_creator_base
 
 TEST_CASE("PostgreSQL insert into ... returning", "[postgresql]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     table_creator_for_test12 tableCreator(sql);
 
@@ -535,7 +535,7 @@ struct bytea_table_creator : public table_creator_base
 
 TEST_CASE("PostgreSQL bytea", "[postgresql][bytea]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     // PostgreSQL supports two different output formats for bytea values:
     // historical "escape" format, which is the only one supported until
@@ -609,7 +609,7 @@ server_version get_postgresql_version(session& sql)
 // Test JSON. Only valid for PostgreSQL Server 9.2++
 TEST_CASE("PostgreSQL JSON", "[postgresql][json]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     server_version version = get_postgresql_version(sql);
     if ( version >= server_version(9,2))
     {
@@ -649,7 +649,7 @@ struct table_creator_text : public table_creator_base
 // https://github.com/SOCI/soci/issues/116
 TEST_CASE("PostgreSQL statement prepare failure", "[postgresql][prepare]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     table_creator_text tableCreator(sql);
 
     try
@@ -674,7 +674,7 @@ TEST_CASE("PostgreSQL statement prepare failure", "[postgresql][prepare]")
 // Test the support of PostgreSQL-style casts with ORM
 TEST_CASE("PostgreSQL ORM cast", "[postgresql][orm]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     values v;
     v.set("a", 1);
     sql << "select :a::int", use(v); // Must not throw an exception!

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -43,7 +43,7 @@ backend_factory const &backEnd = *soci::factory_postgresql();
 
 struct oid_table_creator : public table_creator_base
 {
-    oid_table_creator(session& sql)
+    oid_table_creator(soci::session& sql)
     : table_creator_base(sql)
     {
         sql << "create table soci_test ("
@@ -107,7 +107,7 @@ class function_creator : function_creator_base
 {
 public:
 
-    function_creator(session & sql)
+    function_creator(soci::session & sql)
     : function_creator_base(sql)
     {
         // before a language can be used it must be defined
@@ -199,7 +199,7 @@ TEST_CASE("PostgreSQL function call", "[postgresql][function]")
 // BLOB test
 struct blob_table_creator : public table_creator_base
 {
-    blob_table_creator(session & sql)
+    blob_table_creator(soci::session & sql)
     : table_creator_base(sql)
     {
         sql <<
@@ -251,7 +251,7 @@ TEST_CASE("PostgreSQL blob", "[postgresql][blob]")
 
 struct longlong_table_creator : table_creator_base
 {
-    longlong_table_creator(session & sql)
+    longlong_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val int8)";
@@ -319,7 +319,7 @@ TEST_CASE("PostgreSQL unsigned long long", "[postgresql][unsigned][longlong]")
 
 struct boolean_table_creator : table_creator_base
 {
-    boolean_table_creator(session & sql)
+    boolean_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val boolean)";
@@ -461,7 +461,7 @@ TEST_CASE("PostgreSQL datetime", "[postgresql][datetime]")
 
 struct table_creator_for_test11 : table_creator_base
 {
-    table_creator_for_test11(session & sql)
+    table_creator_for_test11(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val integer)";
@@ -496,7 +496,7 @@ TEST_CASE("PostgreSQL get affected rows", "[postgresql][affected-rows]")
 
 struct table_creator_for_test12 : table_creator_base
 {
-    table_creator_for_test12(session & sql)
+    table_creator_for_test12(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(sid serial, txt text)";
@@ -525,7 +525,7 @@ TEST_CASE("PostgreSQL insert into ... returning", "[postgresql]")
 
 struct bytea_table_creator : public table_creator_base
 {
-    bytea_table_creator(session& sql)
+    bytea_table_creator(soci::session& sql)
         : table_creator_base(sql)
     {
         sql << "drop table if exists soci_test;";
@@ -583,7 +583,7 @@ TEST_CASE("PostgreSQL bytea", "[postgresql][bytea]")
 // json
 struct table_creator_json : public table_creator_base
 {
-    table_creator_json(session& sql)
+    table_creator_json(soci::session& sql)
     : table_creator_base(sql)
     {
         sql << "drop table if exists soci_json_test;";
@@ -594,7 +594,7 @@ struct table_creator_json : public table_creator_base
 // Return 9,2 for 9.2.3
 typedef std::pair<int,int> server_version;
 
-server_version get_postgresql_version(session& sql)
+server_version get_postgresql_version(soci::session& sql)
 {
     std::string version;
     std::pair<int,int> result;
@@ -637,7 +637,7 @@ TEST_CASE("PostgreSQL JSON", "[postgresql][json]")
 
 struct table_creator_text : public table_creator_base
 {
-    table_creator_text(session& sql) : table_creator_base(sql)
+    table_creator_text(soci::session& sql) : table_creator_base(sql)
     {
         sql << "drop table if exists soci_test;";
         sql << "create table soci_test(name varchar(20))";
@@ -687,7 +687,7 @@ TEST_CASE("PostgreSQL ORM cast", "[postgresql][orm]")
 // DDL Creation objects for common tests
 struct table_creator_one : public table_creator_base
 {
-    table_creator_one(session & sql)
+    table_creator_one(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(id integer, val integer, c char, "
@@ -700,7 +700,7 @@ struct table_creator_one : public table_creator_base
 
 struct table_creator_two : public table_creator_base
 {
-    table_creator_two(session & sql)
+    table_creator_two(soci::session & sql)
         : table_creator_base(sql)
     {
         sql  << "create table soci_test(num_float float8, num_int integer,"
@@ -710,7 +710,7 @@ struct table_creator_two : public table_creator_base
 
 struct table_creator_three : public table_creator_base
 {
-    table_creator_three(session & sql)
+    table_creator_three(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(name varchar(100) not null, "
@@ -720,7 +720,7 @@ struct table_creator_three : public table_creator_base
 
 struct table_creator_for_get_affected_rows : table_creator_base
 {
-    table_creator_for_get_affected_rows(session & sql)
+    table_creator_for_get_affected_rows(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val integer)";
@@ -735,22 +735,22 @@ public:
         : test_context_base(backEnd, connectString)
     {}
 
-    table_creator_base* table_creator_1(session& s) const
+    table_creator_base* table_creator_1(soci::session& s) const
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base* table_creator_2(session& s) const
+    table_creator_base* table_creator_2(soci::session& s) const
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base* table_creator_3(session& s) const
+    table_creator_base* table_creator_3(soci::session& s) const
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base* table_creator_4(session& s) const
+    table_creator_base* table_creator_4(soci::session& s) const
     {
         return new table_creator_for_get_affected_rows(s);
     }

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -42,7 +42,7 @@ backend_factory const &backEnd = *soci::factory_sqlite3();
 // In sqlite3 the row id can be called ROWID, _ROWID_ or oid
 TEST_CASE("SQLite rowid", "[sqlite][rowid][oid]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     try { sql << "drop table test1"; }
     catch (soci_error const &) {} // ignore if error
@@ -86,7 +86,7 @@ struct blob_table_creator : public table_creator_base
 
 TEST_CASE("SQLite blob", "[sqlite][blob]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     blob_table_creator tableCreator(sql);
 
@@ -136,7 +136,7 @@ struct test3_table_creator : table_creator_base
 
 TEST_CASE("SQLite use and vector into", "[sqlite][use][into][vector]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     test3_table_creator tableCreator(sql);
 
@@ -182,7 +182,7 @@ struct test4_table_creator : table_creator_base
 TEST_CASE("SQLite select from sequence", "[sqlite][sequence]")
 {
     // we need to have an table that uses autoincrement to test this.
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     test4_table_creator tableCreator(sql);
 
@@ -215,7 +215,7 @@ struct longlong_table_creator : table_creator_base
 // long long test
 TEST_CASE("SQLite long long", "[sqlite][longlong]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     longlong_table_creator tableCreator(sql);
 
@@ -230,7 +230,7 @@ TEST_CASE("SQLite long long", "[sqlite][longlong]")
 
 TEST_CASE("SQLite vector long long", "[sqlite][vector][longlong]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
 
     longlong_table_creator tableCreator(sql);
 
@@ -267,7 +267,7 @@ struct table_creator_for_get_last_insert_id : table_creator_base
 
 TEST_CASE("SQLite last insert id", "[sqlite][last-insert-id]")
 {
-    session sql(backEnd, connectString);
+    soci::session sql(backEnd, connectString);
     table_creator_for_get_last_insert_id tableCreator(sql);
     sql << "insert into soci_test default values";
     long id;

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -73,7 +73,7 @@ TEST_CASE("SQLite rowid", "[sqlite][rowid][oid]")
 // BLOB test
 struct blob_table_creator : public table_creator_base
 {
-    blob_table_creator(session & sql)
+    blob_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql <<
@@ -128,7 +128,7 @@ TEST_CASE("SQLite blob", "[sqlite][blob]")
 
 struct test3_table_creator : table_creator_base
 {
-    test3_table_creator(session & sql) : table_creator_base(sql)
+    test3_table_creator(soci::session & sql) : table_creator_base(sql)
     {
         sql << "create table soci_test( id integer, name varchar, subname varchar);";
     }
@@ -173,7 +173,7 @@ TEST_CASE("SQLite use and vector into", "[sqlite][use][into][vector]")
 
 struct test4_table_creator : table_creator_base
 {
-    test4_table_creator(session & sql) : table_creator_base(sql)
+    test4_table_creator(soci::session & sql) : table_creator_base(sql)
     {
         sql << "create table soci_test (col INTEGER PRIMARY KEY AUTOINCREMENT, name char)";
     }
@@ -205,7 +205,7 @@ TEST_CASE("SQLite select from sequence", "[sqlite][sequence]")
 
 struct longlong_table_creator : table_creator_base
 {
-    longlong_table_creator(session & sql)
+    longlong_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val number(20))";
@@ -256,7 +256,7 @@ TEST_CASE("SQLite vector long long", "[sqlite][vector][longlong]")
 
 struct table_creator_for_get_last_insert_id : table_creator_base
 {
-    table_creator_for_get_last_insert_id(session & sql)
+    table_creator_for_get_last_insert_id(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(id integer primary key autoincrement)";
@@ -279,7 +279,7 @@ TEST_CASE("SQLite last insert id", "[sqlite][last-insert-id]")
 // DDL Creation objects for common tests
 struct table_creator_one : public table_creator_base
 {
-    table_creator_one(session & sql)
+    table_creator_one(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(id integer, val integer, c char, "
@@ -292,7 +292,7 @@ struct table_creator_one : public table_creator_base
 
 struct table_creator_two : public table_creator_base
 {
-    table_creator_two(session & sql)
+    table_creator_two(soci::session & sql)
         : table_creator_base(sql)
     {
         sql  << "create table soci_test(num_float float, num_int integer,"
@@ -302,7 +302,7 @@ struct table_creator_two : public table_creator_base
 
 struct table_creator_three : public table_creator_base
 {
-    table_creator_three(session & sql)
+    table_creator_three(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(name varchar(100) not null, "
@@ -317,7 +317,7 @@ struct table_creator_three : public table_creator_base
 // Implement get_affected_rows for SQLite3 backend
 struct table_creator_for_get_affected_rows : table_creator_base
 {
-    table_creator_for_get_affected_rows(session & sql)
+    table_creator_for_get_affected_rows(soci::session & sql)
         : table_creator_base(sql)
     {
         sql << "create table soci_test(val integer)";
@@ -335,22 +335,22 @@ public:
                 std::string const &connectString)
         : test_context_base(backEnd, connectString) {}
 
-    table_creator_base* table_creator_1(session& s) const
+    table_creator_base* table_creator_1(soci::session& s) const
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base* table_creator_2(session& s) const
+    table_creator_base* table_creator_2(soci::session& s) const
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base* table_creator_3(session& s) const
+    table_creator_base* table_creator_3(soci::session& s) const
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base* table_creator_4(session& s) const
+    table_creator_base* table_creator_4(soci::session& s) const
     {
         return new table_creator_for_get_affected_rows(s);
     }


### PR DESCRIPTION
This should solve compilation errors on OSX where `struct session` defined in global namespace in `/usr/include/sys/proc.h` conflicts with unqualified uses of `soci::session`.

Fixes #340