### PR TITLE
Make it easier to override SOCI_LIBDIR.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,10 +119,12 @@ set_property(DIRECTORY ${CMAKE_SOURCE_DIR}
 # Installation
 ###############################################################################
 
-if(APPLE OR CMAKE_SIZEOF_VOID_P EQUAL 4)
-  set(SOCI_LIBDIR "lib")
-else()
-  set(SOCI_LIBDIR "lib64")
+if(NOT DEFINED SOCI_LIBDIR)
+  if(APPLE OR CMAKE_SIZEOF_VOID_P EQUAL 4)
+    set(SOCI_LIBDIR "lib")
+  else()
+    set(SOCI_LIBDIR "lib64")
+  endif()
 endif()
 
 set(BINDIR "bin" CACHE PATH "The directory to install binaries into.")


### PR DESCRIPTION
Not all packaging environments want to distingish between lib and lib64,
so don't force it.