### PR TITLE
Updated classic Makefile for PostgreSQL backend.

### DIFF
--- a/src/backends/postgresql/Makefile.basic
+++ b/src/backends/postgresql/Makefile.basic
@@ -1,7 +1,7 @@
 # The following variable is specific to this backend and its correct
 # values might depend on your environment - feel free to set it accordingly.
 
-PGSQLINCLUDEDIR = -I/usr/include
+PGSQLINCLUDEDIR = -I/usr/include/postgresql
 PGSQLLIBDIR = -L/usr/lib
 PGSQLLIBS = -lpq
 
@@ -10,7 +10,7 @@ PGSQLLIBS = -lpq
 COMPILER = g++
 CXXFLAGS = -Wall -pedantic -Wno-long-long
 SHARED_CXXFLAGS = ${CXXFLAGS} -fPIC
-INCLUDEDIRS = -I../../core ${PGSQLINCLUDEDIR}
+INCLUDEDIRS = -I../../../include -I../../../include/private ${PGSQLINCLUDEDIR}
 
 SHARED_LIBDIRS = ${PGSQLLIBDIR}
 SHARED_LIBS = ${PGSQLLIBS} ../../core/libsoci_core.a

--- a/tests/postgresql/Makefile.basic
+++ b/tests/postgresql/Makefile.basic
@@ -1,0 +1,12 @@
+COMPILER = g++
+CXXFLAGS = -Wall -pedantic -Wno-long-long
+INCLUDEDIRS = -I../../include -I../../include/private -I.. -I/usr/include/postgresql
+LIBDIRS = -L../../src/core -L../../src/backends/postgresql -L/usr/lib/x86_64-linux-gnu
+LIBS = -lsoci_postgresql -lsoci_core -ldl -lpq
+
+test-postgresql : test-postgresql.cpp
+	${COMPILER} $? -o $@ ${INCLUDEDIRS} ${LIBDIRS} ${LIBS}
+
+
+clean :
+	rm -f test-postgresql


### PR DESCRIPTION
The updated Makefile.basic takes into account recent project structure changes and allows to compile the PostgreSQL backend the "old way".