### PR TITLE
Fix issue #349 Mysql backend memory leaks due to mysql_library_init()

### DIFF
--- a/src/backends/mysql/session.cpp
+++ b/src/backends/mysql/session.cpp
@@ -403,6 +403,7 @@ void mysql_session_backend::clean_up()
     if (conn_ != NULL)
     {
         mysql_close(conn_);
+        mysql_library_end();
         conn_ = NULL;
     }
 }


### PR DESCRIPTION
See issue #349 
