### PR TITLE
Set CMake variable SOCI_CORE_TARGET at PARENT_SCOPE

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -31,6 +31,8 @@ source_group("CMake Files" FILES CMakeLists.txt)
 
 # Core targets configuration
 string(TOLOWER "${PROJECT_NAME}" PROJECTNAMEL)
+#this command will update parent scope variable
+set(SOCI_CORE_TARGET ${PROJECTNAMEL}_core PARENT_SCOPE)
 set(SOCI_CORE_TARGET ${PROJECTNAMEL}_core)
 
 soci_target_output_name(${SOCI_CORE_TARGET} SOCI_CORE_TARGET_OUTPUT_NAME)


### PR DESCRIPTION
@mloskot as agreed in #351 I'm opening another PR.

CMake bug fix when building with MSVC with SHARED option enabled. 

SOCI_CORE_TARGET was not visible to backend so VS projects were not generated correctly producing linker errors.