### PR TITLE
MSVC warnings removal and fixes

### DIFF
--- a/include/private/firebird/common.h
+++ b/include/private/firebird/common.h
@@ -19,6 +19,11 @@
 #include <vector>
 #include <algorithm>
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4127)
+#endif
+
+
 namespace soci
 {
 
@@ -65,7 +70,7 @@ const char *str2dec(const char * s, IntType &out, int &scale)
         int d = *s - '0';
         if (d < 0 || d > 9)
             return s;
-        res = res * 10 + d * sign;
+        res = res * 10 + (IntType)(d * sign);
         if (1 == sign)
         {
             if (res < out)
@@ -101,7 +106,7 @@ template<typename T1>
 void to_isc(void * val, XSQLVAR * var, int x_scale = 0)
 {
     T1 value = *reinterpret_cast<T1*>(val);
-    short scale = var->sqlscale + x_scale;
+    short scale = var->sqlscale + (short)x_scale;
     short type = var->sqltype & ~1;
     long long divisor = 1, multiplier = 1;
 

--- a/include/private/soci-cstrtod.h
+++ b/include/private/soci-cstrtod.h
@@ -13,6 +13,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
+
 namespace soci
 {
 
@@ -76,5 +82,9 @@ double cstring_to_double(char const* s)
 } // namespace details
 
 } // namespace soci
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #endif // SOCI_PRIVATE_SOCI_CSTRTOD_H_INCLUDED

--- a/include/private/soci-dtocstr.h
+++ b/include/private/soci-dtocstr.h
@@ -13,6 +13,11 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
 namespace soci
 {
 
@@ -53,5 +58,10 @@ std::string double_to_cstring(double d)
 } // namespace details
 
 } // namespace soci
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
 
 #endif // SOCI_PRIVATE_SOCI_DTOCSTR_H_INCLUDED

--- a/include/soci/into.h
+++ b/include/soci/into.h
@@ -27,6 +27,9 @@ namespace details
 template <typename T, typename Indicator>
 struct into_container
 {
+private:
+    into_container& operator=(const into_container&); //supress compiler warning: assignment operator could not be generated
+public:
     into_container(T &_t, Indicator &_ind)
         : t(_t), ind(_ind) {}
 
@@ -38,6 +41,9 @@ typedef void no_indicator;
 template <typename T>
 struct into_container<T, no_indicator>
 {
+private:
+    into_container& operator=(const into_container&); //supress compiler warning: assignment operator could not be generated
+public:
     into_container(T &_t)
         : t(_t) {}
 

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -33,6 +33,13 @@
 #include <sqlext.h> // ODBC
 #include <string.h> // strcpy()
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
+
+
 namespace soci
 {
 
@@ -60,6 +67,8 @@ struct odbc_statement_backend;
 // Helper of into and use backends.
 class odbc_standard_type_backend_base
 {
+private:
+    odbc_standard_type_backend_base& operator=(const odbc_standard_type_backend_base&); //supress compiler warning about assignment operator
 protected:
     odbc_standard_type_backend_base(odbc_statement_backend &st)
         : statement_(st) {}
@@ -449,4 +458,10 @@ SOCI_ODBC_DECL void register_factory_odbc();
 
 } // namespace soci
 
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+
 #endif // SOCI_EMPTY_H_INCLUDED
+

--- a/src/backends/db2/standard-into-type.cpp
+++ b/src/backends/db2/standard-into-type.cpp
@@ -39,7 +39,7 @@ void db2_standard_into_type_backend::define_by_pos(
         cType = SQL_C_CHAR;
         // Patch: set to min between column size and 100MB (used ot be 32769)
         // Column size for text data type can be too large for buffer allocation
-        size = statement_.column_size(this->position);
+        size = (SQLUINTEGER)statement_.column_size(this->position);
         size = size > details::db2::cli_max_buffer ? details::db2::cli_max_buffer : size;
         size++;
         buf = new char[size];

--- a/src/backends/db2/standard-use-type.cpp
+++ b/src/backends/db2/standard-use-type.cpp
@@ -14,6 +14,10 @@
 #include <ctime>
 #include <sstream>
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4996)
+#endif
+
 using namespace soci;
 using namespace soci::details;
 
@@ -68,7 +72,7 @@ void *db2_standard_use_type_backend::prepare_for_bind(
         std::string const& s = exchange_type_cast<x_stdstring>(data);
         sqlType = SQL_LONGVARCHAR;
         cType = SQL_C_CHAR;
-        size = s.size() + 1;
+        size = (SQLUINTEGER)s.size() + 1;
         buf = new char[size];
         strncpy(buf, s.c_str(), size);
         ind = SQL_NTS;

--- a/src/backends/db2/vector-use-type.cpp
+++ b/src/backends/db2/vector-use-type.cpp
@@ -19,6 +19,7 @@
 // warning, but odbc requires the value to be converted on this line
 // SQLSetStmtAttr(statement_.hstmt_, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)arraySize, 0);
 #pragma warning(disable:4312)
+#pragma warning(disable:4996)
 #endif
 
 

--- a/src/backends/firebird/common.cpp
+++ b/src/backends/firebird/common.cpp
@@ -15,6 +15,10 @@
 #include <iostream>
 #include <string>
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4996)
+#endif
+
 namespace soci
 {
 

--- a/src/backends/firebird/row-id.cpp
+++ b/src/backends/firebird/row-id.cpp
@@ -10,6 +10,10 @@
 
 using namespace soci;
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4702)
+#endif
+
 firebird_rowid_backend::firebird_rowid_backend(firebird_session_backend & /* session */)
 {
     // Unsupported in Firebird backend

--- a/src/backends/firebird/statement.cpp
+++ b/src/backends/firebird/statement.cpp
@@ -33,7 +33,7 @@ void firebird_statement_backend::prepareSQLDA(XSQLDA ** sqldap, int size)
         *sqldap = reinterpret_cast<XSQLDA*>(malloc(XSQLDA_LENGTH(size)));
     }
 
-    (*sqldap)->sqln = size;
+    (*sqldap)->sqln = (ISC_SHORT)size;
     (*sqldap)->version = 1;
 }
 
@@ -165,7 +165,7 @@ namespace
         if (res_buffer[0] == isc_info_sql_stmt_type)
         {
             length = isc_vax_integer(res_buffer+1, 2);
-            stype = isc_vax_integer(res_buffer+3, length);
+            stype = isc_vax_integer(res_buffer+3, (short)length);
         }
         else
         {
@@ -611,7 +611,7 @@ long long firebird_statement_backend::get_affected_rows()
                     int len = isc_vax_integer(p, 2);
                     p += 2;
 
-                    row_count += isc_vax_integer(p, len);
+                    row_count += isc_vax_integer(p, (short)len);
                     p += len;
                 }
                 break;

--- a/src/backends/mysql/standard-use-type.cpp
+++ b/src/backends/mysql/standard-use-type.cpp
@@ -20,6 +20,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(disable:4355)
+#pragma warning(disable:4996)
 #endif
 
 using namespace soci;
@@ -65,7 +66,7 @@ void mysql_standard_use_type_backend::pre_use(indicator const *ind)
             {
                 std::string const& s = exchange_type_cast<x_stdstring>(data_);
                 buf_ = quote(statement_.session_.conn_,
-                             s.c_str(), s.size());
+                             s.c_str(), (int)s.size());
             }
             break;
         case x_short:

--- a/src/backends/mysql/statement.cpp
+++ b/src/backends/mysql/statement.cpp
@@ -237,7 +237,7 @@ mysql_statement_backend::execute(int number)
                     // bulk operation
                     //std::cerr << "bulk operation:\n" << query << std::endl;
                     if (0 != mysql_real_query(session_.conn_, query.c_str(),
-                            query.size()))
+                            (unsigned long)query.size()))
                     {
                         // preserve the number of rows affected so far.
                         rowsAffectedBulk_ = rowsAffectedBulkTemp;
@@ -270,7 +270,7 @@ mysql_statement_backend::execute(int number)
 
         //std::cerr << query << std::endl;
         if (0 != mysql_real_query(session_.conn_, query.c_str(),
-                query.size()))
+                (unsigned long)query.size()))
         {
             throw mysql_soci_error(mysql_error(session_.conn_),
                 mysql_errno(session_.conn_));

--- a/src/backends/mysql/vector-use-type.cpp
+++ b/src/backends/mysql/vector-use-type.cpp
@@ -24,6 +24,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(disable:4355)
+#pragma warning(disable:4996)
 #endif
 
 using namespace soci;
@@ -82,7 +83,7 @@ void mysql_vector_use_type_backend::pre_use(indicator const *ind)
                     std::vector<std::string> &v = *pv;
 
                     buf = quote(statement_.session_.conn_,
-                        v[i].c_str(), v[i].size());
+                        v[i].c_str(), (int)v[i].size());
                 }
                 break;
             case x_short:

--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -11,6 +11,10 @@
 
 #include <cstdio>
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4996)
+#endif
+
 using namespace soci;
 using namespace soci::details;
 
@@ -125,7 +129,7 @@ void odbc_session_backend::configure_connection()
 
         std::string const q(major_ver >= 9 ? "SET extra_float_digits = 3"
                                            : "SET extra_float_digits = 2");
-        rc = SQLExecDirect(st.hstmt_, sqlchar_cast(q), q.size());
+        rc = SQLExecDirect(st.hstmt_, sqlchar_cast(q), (SQLINTEGER)q.size());
 
         st.clean_up();
 

--- a/src/backends/odbc/standard-into-type.cpp
+++ b/src/backends/odbc/standard-into-type.cpp
@@ -13,6 +13,10 @@
 #include <ctime>
 #include <stdio.h>  // sscanf()
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4996)
+#endif
+
 using namespace soci;
 using namespace soci::details;
 
@@ -37,7 +41,7 @@ void odbc_standard_into_type_backend::define_by_pos(
         odbcType_ = SQL_C_CHAR;
         // Patch: set to min between column size and 100MB (used ot be 32769)
         // Column size for text data type can be too large for buffer allocation
-        size = statement_.column_size(position_);
+        size = (SQLINTEGER)statement_.column_size(position_);
         size = size > odbc_max_buffer_length ? odbc_max_buffer_length : size;
         size++;
         buf_ = new char[size];

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -246,7 +246,7 @@ long long odbc_statement_backend::get_affected_rows()
 
 int odbc_statement_backend::get_number_of_rows()
 {
-    return numRowsFetched_;
+    return (int)numRowsFetched_;
 }
 
 std::string odbc_statement_backend::get_parameter_name(int index) const

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -17,6 +17,10 @@
 #include <sstream>
 #include <stdio.h>  // sscanf()
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4996)
+#endif
+
 using namespace soci;
 using namespace soci::details;
 

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -20,6 +20,7 @@
 // warning, but odbc requires the value to be converted on this line
 // SQLSetStmtAttr(statement_.hstmt_, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)arraySize, 0);
 #pragma warning(disable:4312)
+#pragma warning(disable:4996)
 #endif
 
 using namespace soci;

--- a/src/backends/postgresql/common.h
+++ b/src/backends/postgresql/common.h
@@ -15,6 +15,12 @@
 #include <ctime>
 #include <vector>
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
+
 namespace soci
 {
 
@@ -128,5 +134,10 @@ std::size_t get_vector_size(void * p)
 } // namespace details
 
 } // namespace soci
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
 
 #endif // SOCI_POSTGRESQL_COMMON_H_INCLUDED

--- a/src/backends/sqlite3/common.h
+++ b/src/backends/sqlite3/common.h
@@ -16,6 +16,11 @@
 #include <vector>
 #include <limits>
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
 namespace soci { namespace details { namespace sqlite3 {
 
 // helper function for parsing datetime values
@@ -83,5 +88,9 @@ T string_to_unsigned_integer(char const * buf)
 }
 
 }}} // namespace soci::details::sqlite3
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #endif // SOCI_SQLITE3_COMMON_H_INCLUDED

--- a/src/core/backend-loader.cpp
+++ b/src/core/backend-loader.cpp
@@ -76,6 +76,10 @@ typedef void * soci_handler_t;
 
 #endif // _WIN32
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4996)
+#endif
+
 
 namespace // unnamed
 {

--- a/src/core/soci-simple.cpp
+++ b/src/core/soci-simple.cpp
@@ -18,6 +18,11 @@
 #include <string>
 #include <vector>
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4996)
+#endif
+
+
 using namespace soci;
 
 namespace // unnamed

--- a/src/core/statement.cpp
+++ b/src/core/statement.cpp
@@ -759,7 +759,7 @@ statement_impl::rethrow_current_exception_with_context(char const* operation)
                     // the query itself, as parsed by the backend.
                     std::string name = u.get_name();
                     if (name.empty())
-                        name = backEnd_->get_parameter_name(i);
+                        name = backEnd_->get_parameter_name((int)i);
 
                     oss << ":";
                     if (!name.empty())

--- a/src/core/use-type.cpp
+++ b/src/core/use-type.cpp
@@ -13,6 +13,11 @@
 
 #include <cstdio>
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4996)
+#endif
+
+
 using namespace soci;
 using namespace soci::details;
 

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -38,6 +38,11 @@
 #include <string>
 #include <typeinfo>
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
 #ifdef HAVE_BOOST
 // It appears later versions of GCC arent happy with this - to be fixed properly
 #if (__GNUC__ == 4 && (__GNUC_MINOR__ > 6)) || (__clang__ == 1)
@@ -3791,7 +3796,7 @@ TEST_CASE_METHOD(common_tests, "Get affected rows", "[core][affected-rows]")
     std::vector<int> v(5, 0);
     for (std::size_t i = 0; i < v.size(); ++i)
     {
-        v[i] = (7 + i);
+        v[i] = (7 + (int)i);
     }
 
     // test affected rows for bulk operations.
@@ -4046,5 +4051,10 @@ TEST_CASE_METHOD(common_tests, "Truncation error", "[core][insert][truncate][exc
 } // namespace tests
 
 } // namespace soci
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
 
 #endif // SOCI_COMMON_TESTS_H_INCLUDED

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -20,6 +20,10 @@
 
 using namespace soci;
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4996)
+#endif
+
 std::string connectString;
 soci::backend_factory const &backEnd = *factory_firebird();
 
@@ -970,7 +974,7 @@ namespace soci
             char count_type = *ptr++;
             int m = isc_vax_integer(ptr, 2);
             ptr += 2;
-            count = isc_vax_integer(ptr, m);
+            count = isc_vax_integer(ptr, (short)m);
 
             if (count_type == type_)
             {

--- a/tests/mysql/test-mysql.cpp
+++ b/tests/mysql/test-mysql.cpp
@@ -21,6 +21,10 @@
 #include <mysqld_error.h>
 #include <errmsg.h>
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4127)
+#endif
+
 std::string connectString;
 backend_factory const &backEnd = *soci::factory_mysql();
 
@@ -799,7 +803,7 @@ std::string escape_string(soci::session& sql, const std::string& s)
     mysql_session_backend* backend = static_cast<mysql_session_backend*>(
         sql.get_backend());
     char* escaped = new char[2 * s.size() + 1];
-    mysql_real_escape_string(backend->conn_, escaped, s.data(), s.size());
+    mysql_real_escape_string(backend->conn_, escaped, s.data(), (unsigned long)s.size());
     std::string retv = escaped;
     delete [] escaped;
     return retv;

--- a/tests/odbc/test-odbc-postgresql.cpp
+++ b/tests/odbc/test-odbc-postgresql.cpp
@@ -14,6 +14,10 @@
 #include <ctime>
 #include <cmath>
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4996)
+#endif
+
 using namespace soci;
 using namespace soci::tests;
 

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -16,6 +16,12 @@
 #include <ctime>
 #include <cstdlib>
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
+
 using namespace soci;
 using namespace soci::tests;
 
@@ -596,7 +602,6 @@ TEST_CASE("PostgreSQL JSON", "[postgresql][json]")
     server_version version = get_postgresql_version(sql);
     if ( version >= server_version(9,2))
     {
-        bool exception = false;
         std::string result;
         std::string valid_input = "{\"tool\":\"soci\",\"result\":42}";
         std::string invalid_input = "{\"tool\":\"other\",\"result\":invalid}";


### PR DESCRIPTION
 I have suppressed all warnings reported during Visual Studio build process using pragmas(as suggested by @mloskot in #351 ). CMake remains unmodified.

