### PR TITLE
Improve ODBC error messages.

### DIFF
--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -354,8 +354,6 @@ public:
 private:
     std::string interpret_odbc_error(SQLSMALLINT htype, SQLHANDLE hndl, std::string const& msg)
     {
-        std::ostringstream ss(msg, std::ostringstream::app);
-
         const char* socierror = NULL;
 
         SQLSMALLINT length, i = 1;
@@ -399,7 +397,8 @@ private:
             sqlcode_ = 0;
         }
 
-        ss << ": " << message_ << " (" << sqlstate_ << ")";
+        std::ostringstream ss;
+        ss << "Error " << msg << ": " << message_ << " (" << sqlstate_ << ")";
 
         return ss.str();
     }

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -398,7 +398,7 @@ private:
         }
 
         std::ostringstream ss;
-        ss << "Error " << msg << ": " << message_ << " (" << sqlstate_ << ")";
+        ss << "Error " << msg << ": " << message_ << " (SQL state " << sqlstate_ << ")";
 
         return ss.str();
     }

--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -33,8 +33,7 @@ odbc_session_backend::odbc_session_backend(
     rc = SQLSetEnvAttr(henv_, SQL_ATTR_ODBC_VERSION, (void*)SQL_OV_ODBC3, 0);
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_ENV, henv_,
-                         "Setting ODBC version");
+        throw odbc_soci_error(SQL_HANDLE_ENV, henv_, "setting ODBC version 3");
     }
 
     // Allocate connection handle
@@ -42,7 +41,7 @@ odbc_session_backend::odbc_session_backend(
     if (is_odbc_error(rc))
     {
         throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_,
-                         "Allocating connection handle");
+                              "allocating connection handle");
     }
 
     SQLCHAR outConnString[1024];
@@ -81,8 +80,7 @@ odbc_session_backend::odbc_session_backend(
 
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_,
-                         "Error Connecting to database");
+        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_, "connecting to database");
     }
 
     connection_string_.assign((const char*)outConnString, strLength);
@@ -107,7 +105,7 @@ void odbc_session_backend::configure_connection()
         if (is_odbc_error(rc))
         {
             throw odbc_soci_error(SQL_HANDLE_DBC, henv_,
-                                  "SQLGetInfo(SQL_DBMS_VER)");
+                                  "getting PostgreSQL ODBC driver version");
         }
 
         // The returned string is of the form "##.##.#### ...", but we don't
@@ -132,7 +130,7 @@ void odbc_session_backend::configure_connection()
         if (is_odbc_error(rc))
         {
             throw odbc_soci_error(SQL_HANDLE_DBC, henv_,
-                                  "Setting extra_float_digits for PostgreSQL");
+                                  "setting extra_float_digits for PostgreSQL");
         }
     }
 }
@@ -148,8 +146,7 @@ void odbc_session_backend::begin()
                     (SQLPOINTER)SQL_AUTOCOMMIT_OFF, 0 );
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_,
-                         "Begin Transaction");
+        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_, "beginning transaction");
     }
 }
 
@@ -158,8 +155,7 @@ void odbc_session_backend::commit()
     SQLRETURN rc = SQLEndTran(SQL_HANDLE_DBC, hdbc_, SQL_COMMIT);
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_,
-                         "Committing");
+        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_, "committing transaction");
     }
     reset_transaction();
 }
@@ -169,8 +165,7 @@ void odbc_session_backend::rollback()
     SQLRETURN rc = SQLEndTran(SQL_HANDLE_DBC, hdbc_, SQL_ROLLBACK);
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_,
-                         "Rolling back");
+        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_, "rolling back transaction");
     }
     reset_transaction();
 }
@@ -263,8 +258,7 @@ void odbc_session_backend::reset_transaction()
                     (SQLPOINTER)SQL_AUTOCOMMIT_ON, 0 );
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_,
-                            "Set Auto Commit");
+        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_, "enabling auto commit");
     }
 }
 
@@ -274,22 +268,19 @@ void odbc_session_backend::clean_up()
     SQLRETURN rc = SQLDisconnect(hdbc_);
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_,
-                            "SQLDisconnect");
+        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_, "disconnecting");
     }
 
     rc = SQLFreeHandle(SQL_HANDLE_DBC, hdbc_);
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_,
-                            "SQLFreeHandle DBC");
+        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_, "freeing connection");
     }
 
     rc = SQLFreeHandle(SQL_HANDLE_ENV, henv_);
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_ENV, henv_,
-                            "SQLFreeHandle ENV");
+        throw odbc_soci_error(SQL_HANDLE_ENV, henv_, "freeing environment");
     }
 }
 
@@ -321,7 +312,7 @@ odbc_session_backend::get_database_product()
     if (is_odbc_error(rc))
     {
         throw odbc_soci_error(SQL_HANDLE_DBC, henv_,
-                            "SQLGetInfo(SQL_DBMS_NAME)");
+                              "getting ODBC driver name");
     }
 
     if (strcmp(product_name, "Firebird") == 0)

--- a/src/backends/odbc/standard-into-type.cpp
+++ b/src/backends/odbc/standard-into-type.cpp
@@ -103,8 +103,9 @@ void odbc_standard_into_type_backend::define_by_pos(
         static_cast<SQLUSMALLINT>(odbcType_), data, size, &valueLen_);
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_STMT, statement_.hstmt_,
-                            "into type pre_fetch");
+        std::ostringstream ss;
+        ss << "binding output column #" << position_;
+        throw odbc_soci_error(SQL_HANDLE_STMT, statement_.hstmt_, ss.str());
     }
 }
 

--- a/src/backends/odbc/standard-use-type.cpp
+++ b/src/backends/odbc/standard-use-type.cpp
@@ -220,8 +220,9 @@ void odbc_standard_use_type_backend::pre_use(indicator const *ind)
 
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_STMT, statement_.hstmt_,
-                                "Binding");
+        std::ostringstream ss;
+        ss << "binding input parameter #" << position_;
+        throw odbc_soci_error(SQL_HANDLE_STMT, statement_.hstmt_, ss.str());
     }
 
     // then handle indicators

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -38,7 +38,7 @@ void odbc_statement_backend::alloc()
     if (is_odbc_error(rc))
     {
         throw odbc_soci_error(SQL_HANDLE_DBC, session_.hdbc_,
-            "Allocating statement");
+                              "allocating statement");
     }
 }
 
@@ -134,8 +134,9 @@ void odbc_statement_backend::prepare(std::string const & query,
     SQLRETURN rc = SQLPrepare(hstmt_, sqlchar_cast(query_), (SQLINTEGER)query_.size());
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_STMT, hstmt_,
-                         query_.c_str());
+        std::ostringstream ss;
+        ss << "preparing query \"" << query_ << "\"";
+        throw odbc_soci_error(SQL_HANDLE_STMT, hstmt_, ss.str());
     }
 }
 
@@ -177,8 +178,7 @@ odbc_statement_backend::execute(int number)
             // Move forward to the next result while there are rows processed.
             while (rows_processed > 0 && SQLMoreResults(hstmt_) == SQL_SUCCESS);
         }
-        throw odbc_soci_error(SQL_HANDLE_STMT, hstmt_,
-                         "Statement Execute");
+        throw odbc_soci_error(SQL_HANDLE_STMT, hstmt_, "executing statement");
     }
     else if (hasVectorUseElements_)
     {
@@ -195,7 +195,7 @@ odbc_statement_backend::execute(int number)
             if (is_odbc_error(rc))
             {
                 throw odbc_soci_error(SQL_HANDLE_STMT, hstmt_,
-                                  "Getting number of affected rows");
+                                      "getting number of affected rows");
             }
             rowsAffected_ += res;
         }
@@ -232,8 +232,7 @@ odbc_statement_backend::fetch(int number)
 
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_STMT, hstmt_,
-                         "Statement Fetch");
+        throw odbc_soci_error(SQL_HANDLE_STMT, hstmt_, "fetching data");
     }
 
     return ef_success;
@@ -284,8 +283,9 @@ void odbc_statement_backend::describe_column(int colNum, data_type & type,
 
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_STMT, hstmt_,
-                         "describe Column");
+        std::ostringstream ss;
+        ss << "getting description of column at position " << colNum;
+        throw odbc_soci_error(SQL_HANDLE_STMT, hstmt_, ss.str());
     }
 
     char const *name = reinterpret_cast<char const *>(colNameBuffer);
@@ -338,8 +338,9 @@ std::size_t odbc_statement_backend::column_size(int colNum)
 
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_STMT, hstmt_,
-                         "column size");
+        std::ostringstream ss;
+        ss << "getting size of column at position " << colNum;
+        throw odbc_soci_error(SQL_HANDLE_STMT, hstmt_, ss.str());
     }
 
     return colSize;

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -183,8 +183,9 @@ void odbc_vector_into_type_backend::define_by_pos(
                 odbcType_, static_cast<SQLPOINTER>(data), size, indHolders_);
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_STMT, statement_.hstmt_,
-                            "vector into type define by pos");
+        std::ostringstream ss;
+        ss << "binding output vector column #" << position;
+        throw odbc_soci_error(SQL_HANDLE_STMT, statement_.hstmt_, ss.str());
     }
 }
 

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -230,8 +230,9 @@ void odbc_vector_use_type_backend::bind_helper(int &position, void *data, exchan
 
     if (is_odbc_error(rc))
     {
-        throw odbc_soci_error(SQL_HANDLE_STMT, statement_.hstmt_,
-            "Error while binding value to column");
+        std::ostringstream ss;
+        ss << "binding input vector parameter #" << position;
+        throw odbc_soci_error(SQL_HANDLE_STMT, statement_.hstmt_, ss.str());
     }
 }
 


### PR DESCRIPTION
As mentioned several times in the past, ODBC backend error messages are inconsistent and this PR is an attempt to improve things.

I decided to standardize on "Error doing something" instead of "Failed to do something", for example, as this seems to be the most widely used form but things are so inconsistent right now (not only in the ODBC backend but also between backends) that it's hard to be sure if this is the best choice.

E.g. we have the following error messages for the same error:

 1. `"Error connecting to database"` (DB2)
 1. Nothing, just using the driver message which doesn't necessarily make it clear that the error happened while opening the database connection at all (Firebird, MySQL, Oracle, SQLite3)
 1. `"Error Connecting to database"` (ODBC)
 1. `"Cannot establish connection to the database."` (PostgreSQL)

Clearly more could be done to make things more homogeneous but hopefully this is a step in the right direction...