### PR TITLE
Split Statement::clean_up into bind_clean_up and clean_up

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -274,6 +274,7 @@ The `statement` class encapsulates the prepared statement.
         void exchange(*IT* const & i);
         void exchange(*IT* const & u);
         void clean_up();
+        void bind_clean_up();
 
         void prepare(std::string const & query);
         void define_and_bind();
@@ -303,6 +304,7 @@ This class contains the following members:
 * `bind` function, which is used to bind the `values` object - this is used in the object-relational mapping and normally called automatically.
 * exchange functions for registering the binding of local data - they expect the result of calling the `into` or `use` functions and are normally invoked automatically.
 * `clean_up` function for cleaning up resources, normally called automatically.
+* `bind_clean_up` function for cleaning up any bound references. It allows to keep statement in cache and reuse it later with new references by calling `exchange` for each new bind variable.
 * `prepare` function for preparing the statement for repeated execution.
 * `define_and_bind` function for actually executing the registered bindings, normally called automatically.
 * `execute` function for executing the statement. If its parameter is `false` then there is no data exchange with locally bound variables (this form should be used if later `fetch` of multiple rows is foreseen). Returns `true` if there was at least one row of data returned.

--- a/include/soci/statement.h
+++ b/include/soci/statement.h
@@ -54,7 +54,9 @@ public:
     void exchange(use_container<T, Indicator> const &uc)
     { uses_.exchange(uc); }
 
+
     void clean_up();
+    void bind_clean_up();
 
     void prepare(std::string const & query,
                     statement_type eType = st_repeatable_query);
@@ -200,6 +202,7 @@ public:
     template <typename T, typename Indicator>
     void exchange(details::use_container<T, Indicator>  const &uc) { impl_->exchange(uc); }
     void clean_up()                      { impl_->clean_up(); }
+    void bind_clean_up()                 { impl_->bind_clean_up(); }
 
     void prepare(std::string const & query,
         details::statement_type eType = details::st_repeatable_query)

--- a/src/core/statement.cpp
+++ b/src/core/statement.cpp
@@ -177,6 +177,9 @@ void statement_impl::bind_clean_up()
         delete indicators_[i];
         indicators_[i] = NULL;
     }
+
+    row_ = NULL;
+    alreadyDescribed_ = false;
 }
 
 void statement_impl::clean_up()

--- a/src/core/statement.cpp
+++ b/src/core/statement.cpp
@@ -144,7 +144,7 @@ void statement_impl::bind(values & values)
     }
 }
 
-void statement_impl::clean_up()
+void statement_impl::bind_clean_up()
 {
     // deallocate all bind and define objects
     std::size_t const isize = intos_.size();
@@ -177,7 +177,11 @@ void statement_impl::clean_up()
         delete indicators_[i];
         indicators_[i] = NULL;
     }
+}
 
+void statement_impl::clean_up()
+{
+    bind_clean_up();
     if (backEnd_ != NULL)
     {
         backEnd_->clean_up();


### PR DESCRIPTION
Allow to reuse statement with new references by only cleaning bound values and not the backend statement. 