### PR TITLE
Allow setting ORACLE_HOME directly in CMake GUI

### DIFF
--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -5,9 +5,9 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#include "common-tests.h"
 #include "soci/soci.h"
 #include "soci/oracle/soci-oracle.h"
-#include "common-tests.h"
 #include <iostream>
 #include <string>
 #include <cstring>


### PR DESCRIPTION
On windows when using CMake Oracle is not shown as an option so I have changed FindOracle.cmake to first check CMake variable ORACLE_HOME and if not set then checks for environment variable and if exists then uses its value in CMake.

This way we can set ORACLE_HOME directly in CMakeGui without setting environment variable.

I have also removed top condition where Oracle search is performed only when ORACLE_HOME is found. It should be shown in CMakeGUI the same way as all other supported back-ends so user knows that backend is available.

When compiling oracle test there was also error in VS-2012 caused by invalid header inclusion order.