### PR TITLE
Fix connection-parameters options bug

### DIFF
--- a/include/soci/connection-parameters.h
+++ b/include/soci/connection-parameters.h
@@ -59,7 +59,7 @@ private:
     std::string connectString_;
 
     // We store all the values as strings for simplicity.
-    typedef std::map<const char*, std::string> Options;
+    typedef std::map<std::string, std::string> Options;
     Options options_;
 };
 

--- a/tests/mysql/test-mysql.h
+++ b/tests/mysql/test-mysql.h
@@ -121,12 +121,11 @@ public:
             sql << "SET @@session.sql_mode = 'PAD_CHAR_TO_FULL_LENGTH'";
             return true;
         }
-        catch(const soci_error& e)
+        catch(const soci_error&)
         {
             // Padding cannot be enabled - test will not be performed
             return false;
         }
-        return true;
     }
 };
 


### PR DESCRIPTION
I was developing and testing some additional functionality which uses options instead of connection string in SOCI and found out a bug while searching for an option. 

get_option() failed to find option by name since map matches const char* pointer value instead of option name. By changing the type to std::string the issue is resolved.

This PR also resolves compiler warning fixes in test-mysql.h. ( caused by merge of #356 )

