### PR TITLE
"use" parameters additional functionality

### DIFF
--- a/include/soci/bind-values.h
+++ b/include/soci/bind-values.h
@@ -97,6 +97,10 @@ private:
     void exchange_(use_container<T, Indicator> const &uc, ...)
     { exchange(do_use(uc.t, uc.ind, uc.name, typename details::exchange_traits<T>::type_family())); }
 
+    template <typename T, typename Indicator>
+    void exchange_(use_container<T, const Indicator> const &uc, ...)
+    { exchange(do_use(uc.t, uc.ind, uc.name, typename details::exchange_traits<T>::type_family())); }
+
     template <typename T>
     void exchange_(use_container<T, details::no_indicator> const &uc, ...)
     { exchange(do_use(uc.t, uc.name, typename details::exchange_traits<T>::type_family())); }
@@ -104,6 +108,11 @@ private:
     template <typename T, typename Indicator>
     void exchange_(use_container<const T, Indicator> const &uc, ...)
     { exchange(do_use(uc.t, uc.ind, uc.name, typename details::exchange_traits<T>::type_family())); }
+
+    template <typename T, typename Indicator>
+    void exchange_(use_container<const T, const Indicator> const &uc, ...)
+    { exchange(do_use(uc.t, uc.ind, uc.name, typename details::exchange_traits<T>::type_family())); }
+
 
     template <typename T>
     void exchange_(use_container<const T, details::no_indicator> const &uc, ...)

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -144,7 +144,7 @@ struct odbc_standard_use_type_backend : details::standard_use_type_backend,
 {
     odbc_standard_use_type_backend(odbc_statement_backend &st)
         : odbc_standard_type_backend_base(st),
-          position_(-1), data_(0), buf_(0), indHolder_(0) {}
+        position_(-1), data_(0), buf_(0), indHolder_(0),readOnly_(false) {}
 
     virtual void bind_by_pos(int &position,
         void *data, details::exchange_type type, bool readOnly);
@@ -168,6 +168,7 @@ struct odbc_standard_use_type_backend : details::standard_use_type_backend,
     void *data_;
     details::exchange_type type_;
     char *buf_;
+    bool readOnly_;
     SQLLEN indHolder_;
 };
 

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -168,8 +168,8 @@ struct odbc_standard_use_type_backend : details::standard_use_type_backend,
     void *data_;
     details::exchange_type type_;
     char *buf_;
-    bool readOnly_;
     SQLLEN indHolder_;
+    bool readOnly_;
 };
 
 struct odbc_vector_use_type_backend : details::vector_use_type_backend,

--- a/include/soci/type-conversion.h
+++ b/include/soci/type-conversion.h
@@ -120,7 +120,29 @@ public:
         //convert_to_base();
     }
 
+    conversion_use_type(T & value, indicator const & ind,
+            std::string const & name = std::string())
+        : use_type<base_type>(details::base_value_holder<T>::val_, ind, name)
+        , value_(value)
+        , ind_(ind)
+        , readOnly_(true) //notice const indicator
+    {
+        // TODO: likely to be removed (SHA: c166625a28f7c907318134f625ff5acea7d9a1f8)
+        //convert_to_base();
+    }
+
     conversion_use_type(T const & value, indicator & ind,
+            std::string const & name = std::string())
+        : use_type<base_type>(details::base_value_holder<T>::val_, ind, name)
+        , value_(const_cast<T &>(value))
+        , ind_(ind)
+        , readOnly_(true)
+    {
+        // TODO: likely to be removed (SHA: c166625a28f7c907318134f625ff5acea7d9a1f8)
+        //convert_to_base();
+    }
+
+    conversion_use_type(T const & value, indicator const & ind,
             std::string const & name = std::string())
         : use_type<base_type>(details::base_value_holder<T>::val_, ind, name)
         , value_(const_cast<T &>(value))
@@ -351,7 +373,21 @@ use_type_ptr do_use(T & t, indicator & ind,
 }
 
 template <typename T>
+use_type_ptr do_use(T & t, indicator const & ind,
+    std::string const & name, user_type_tag)
+{
+    return use_type_ptr(new conversion_use_type<T>(t, ind, name));
+}
+
+template <typename T>
 use_type_ptr do_use(T const & t, indicator & ind,
+    std::string const & name, user_type_tag)
+{
+    return use_type_ptr(new conversion_use_type<T>(t, ind, name));
+}
+
+template <typename T>
+use_type_ptr do_use(T const & t, indicator const & ind,
     std::string const & name, user_type_tag)
 {
     return use_type_ptr(new conversion_use_type<T>(t, ind, name));

--- a/include/soci/use.h
+++ b/include/soci/use.h
@@ -59,6 +59,13 @@ private:
 
 } // namespace details
 
+// use_null support
+inline details::use_container<const int, const indicator> use_null(const std::string &name = std::string()) 
+{
+    static const soci::indicator null_indicator = soci::i_null;
+    return details::use_container<const int, const indicator>(0,null_indicator, name); 
+}
+
 template <typename T>
 details::use_container<T, details::no_indicator> use(T &t, const std::string &name = std::string())
 { return details::use_container<T, details::no_indicator>(t, name); }

--- a/include/soci/use.h
+++ b/include/soci/use.h
@@ -44,6 +44,19 @@ private:
     SOCI_NOT_ASSIGNABLE(use_container)
 };
 
+// Second specialiation for const indicator
+template <typename T>
+struct use_container<T, const no_indicator>
+{
+    use_container(T &_t, const std::string &_name)
+        : t(_t), name(_name) {}
+
+    T &t;
+    const std::string &name;
+private:
+    SOCI_NOT_ASSIGNABLE(use_container)
+};
+
 } // namespace details
 
 template <typename T>
@@ -59,8 +72,17 @@ details::use_container<T, indicator> use(T &t, indicator & ind, std::string cons
 { return details::use_container<T, indicator>(t, ind, name); }
 
 template <typename T>
+details::use_container<T, const indicator> use(T &t, indicator const & ind, std::string const &name = std::string())
+{ return details::use_container<T, const indicator>(t, ind, name); }
+
+template <typename T>
 details::use_container<const T, indicator> use(T const &t, indicator & ind, std::string const &name = std::string())
 { return details::use_container<const T, indicator>(t, ind, name); }
+
+template <typename T>
+details::use_container<const T, const indicator> use(T const &t, indicator const & ind, std::string const &name = std::string())
+{ return details::use_container<const T, const indicator>(t, ind, name); }
+
 
 // vector containers
 template <typename T>

--- a/src/backends/odbc/standard-use-type.cpp
+++ b/src/backends/odbc/standard-use-type.cpp
@@ -154,8 +154,9 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
 }
 
 void odbc_standard_use_type_backend::bind_by_pos(
-    int &position, void *data, exchange_type type, bool /* readOnly */)
+    int &position, void *data, exchange_type type, bool  readOnly )
 {
+    readOnly_ = readOnly;
     if (statement_.boundByName_)
     {
         throw soci_error(
@@ -170,8 +171,9 @@ void odbc_standard_use_type_backend::bind_by_pos(
 }
 
 void odbc_standard_use_type_backend::bind_by_name(
-    std::string const &name, void *data, exchange_type type, bool /* readOnly */)
+    std::string const &name, void *data, exchange_type type, bool  readOnly )
 {
+    readOnly_ = readOnly;
     if (statement_.boundByPos_)
     {
         throw soci_error(
@@ -237,7 +239,7 @@ void odbc_standard_use_type_backend::pre_use(indicator const *ind)
 
 void odbc_standard_use_type_backend::post_use(bool gotData, indicator *ind)
 {
-    if (ind != NULL)
+    if (ind != NULL && !readOnly_)
     {
         if (gotData)
         {

--- a/src/backends/oracle/standard-use-type.cpp
+++ b/src/backends/oracle/standard-use-type.cpp
@@ -449,7 +449,7 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
         }
     }
 
-    if (ind != NULL)
+    if (ind != NULL && !readOnly_)
     {
         if (gotData)
         {

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -637,6 +637,46 @@ TEST_CASE_METHOD(common_tests, "Use and into", "[core][into]")
         CHECK(ind == i_ok);
     }
 
+    SECTION("Const Indicator and use_null")
+    {
+        int i;
+        indicator ind;
+
+        // Check const indicator support
+        sql << "insert into soci_test(id) values(:id)",
+            use(3,i_ok);
+        sql << "select id from soci_test", into(i, ind);
+        CHECK(ind == i_ok);
+        CHECK(i == 3);
+        sql << "delete from soci_test";
+
+        // Check const indicator null
+        i=0;
+        ind = i_ok;
+        sql << "insert into soci_test(id) values(:id)",
+            use(2,i_null);
+        sql << "select id from soci_test", into(i, ind);
+        CHECK(ind == i_null);
+        CHECK(i != 2);
+        sql << "delete from soci_test";
+
+        // use_null test
+        ind = i_ok;
+        sql << "insert into soci_test(id) values(:id)",
+            use_null();
+        sql << "select id from soci_test", into(i, ind);
+        CHECK(ind == i_null);
+        sql << "delete from soci_test";
+
+        // use_null test by value
+        ind = i_ok;
+        sql << "insert into soci_test(id) values(:id)",
+            use_null("id");
+        sql << "select id from soci_test", into(i, ind);
+        CHECK(ind == i_null);
+        sql << "delete from soci_test";
+    }
+
     SECTION("Indicators work correctly more generally")
     {
         sql << "insert into soci_test(id,tm) values(NULL,NULL)";


### PR DESCRIPTION
When developing with soci I tried to use the following:

``` c++
//tried to insert null as second parameter
sql << "insert into test values( :int, :str )", use(1), use("",i_null); 
```

which was not supported because use indicator was only implemented for non const scenario.

I have also tried to call use with const char instead of std::string:

``` c++
 //This was also not supported
sql << "insert into test values( :str )", use("Hello");
```

So I wrote some additional templates and functions in use.h to support the following cases:
1.) dbNull() function to use whenever we need to insert null value into database
2.) Support for const char\* type
3.) Support for const char[N] type

In order to enable the following scenarios I needed to modify `use_container` template to support some additional cases so `bool isDataOwner` template argument is added in order to detect whether use_container holds a referenced value or holds a copy of the value passed to use function. 

With this PR additional use scenarios are possible:

``` c++
//use const char[N] directly 
sql << "insert into test values(:str)", use("Hello");

//use const char* directly
const char* value = "Hello";
sql << "insert into test values(:str)", use(value);

// use dbNull() instead of explicit indicator
sql << "insert into test values(:str)", dbNull();
// alternative to dbNull( value type is ignored in this case)
sql << "insert into test values(:str)", use("",i_null);
```
