### PR TITLE
CMake changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,9 @@ if(NOT MSVC)
     set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES ${DL_INCLUDE_DIR})
     add_definitions(-DHAVE_DL=1)
   endif()
+else() #MSVC
+  # This flag enables multi process compiling for Visual Studio 2005 and above
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 endif()
 
 if(Boost_FOUND)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -63,7 +63,7 @@ if (SOCI_SHARED)
 endif()
 
 add_definitions(-DSOCI_LIB_PREFIX="${CMAKE_SHARED_LIBRARY_PREFIX}soci_"
-                -DSOCI_LIB_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")
+                -DSOCI_LIB_SUFFIX="${CMAKE_DEBUG_POSTFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}")
 
 #
 # Core static library


### PR DESCRIPTION
When ```CMAKE_DEBUG_POSTFIX``` is used soci did not load backend correctly in backend loader so I added it to ```CMake```.

For example I normally use "d" as debug postfix which results in soci_core_4_0d.dll, soci_empty_4_0d.dll, ... on windows platform. This way distinction is made for debug/release modules.

Second change is added support for MSVC multiprocess compiling( enabled by default ).