### PR TITLE
Include SOCI_CXX_VERSION_FLAGS when compiling with Clang

### DIFF
--- a/cmake/SociConfig.cmake
+++ b/cmake/SociConfig.cmake
@@ -74,7 +74,7 @@ else()
 
   elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER}" MATCHES "clang")
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SOCI_GCC_CLANG_COMMON_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SOCI_GCC_CLANG_COMMON_FLAGS} ${SOCI_CXX_VERSION_FLAGS}")
 
   else()
 	message(WARNING "Unknown toolset - using default flags to build SOCI")


### PR DESCRIPTION
Hi,

When compiling with Clang, SOCI_CXX_C11 is ignored whether it is ON or OFF due to SOCI_CXX_VERSION_FLAGS being set but never used.