### PR TITLE
Fixed ambiguous 'session' reference

### DIFF
--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -361,7 +361,7 @@ public:
         return true;
     }
 
-    virtual bool enable_std_char_padding(session&) const
+    virtual bool enable_std_char_padding(soci::session& s) const
     {
         // SQLite does not support right padded char type.
         return false;


### PR DESCRIPTION
This was causing an error when building with clang.