### PR TITLE
Sqlite backend fetch bug

### DIFF
--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -200,8 +200,10 @@ sqlite3_statement_backend::load_rowset(int totalRows)
 statement_backend::exec_fetch_result
 sqlite3_statement_backend::load_one()
 {
-    statement_backend::exec_fetch_result retVal = ef_success;
+    if( !databaseReady_ )
+        return ef_no_data;
 
+    statement_backend::exec_fetch_result retVal = ef_success;
     int const res = sqlite3_step(stmt_);
 
     if (SQLITE_DONE == res)
@@ -218,10 +220,9 @@ sqlite3_statement_backend::load_one()
 
         std::ostringstream ss;
         ss << "sqlite3_statement_backend::loadOne: "
-           << zErrMsg;
+            << zErrMsg;
         throw sqlite3_soci_error(ss.str(), res);
     }
-
     return retVal;
 }
 
@@ -290,7 +291,8 @@ sqlite3_statement_backend::bind_and_execute(int number)
             return load_rowset(number);
         }
 
-        retVal = load_one(); //execute each bound line
+        databaseReady_=true; // Mark sqlite engine is ready to perform sqlite3_step
+        retVal = load_one(); // execute each bound line
         rowsAffectedBulkTemp += get_affected_rows();
     }
 

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -518,6 +518,18 @@ TEST_CASE_METHOD(common_tests, "Basic functionality")
     int id;
     sql << "select id from soci_test", into(id);
     CHECK(id == 123);
+
+    sql << "insert into soci_test (id) values (" << 234 << ")";
+    sql << "insert into soci_test (id) values (" << 345 << ")";
+    // Test prepare, execute, fetch correctness
+    statement st = (sql.prepare << "select id from soci_test", into(id));
+    st.execute();
+    int count = 0;
+    while(st.fetch())
+        count++;
+    CHECK(count == 3 );
+    bool fetchEnd = st.fetch(); // All the data has been read here so additional fetch must return false
+    CHECK(fetchEnd == false);
 }
 
 // "into" tests, type conversions, etc.


### PR DESCRIPTION
I discovered SQLite backend bug when I updated to the latest code and use it in my application. I had some complex code that iterates through query results and call fetch many times not just classic ```while(st.fetch()) ...``` so endless loop occurred and this issue was discovered.

The following code describes the problem:
```c++
int id;
statement st = (sql.prepare << "select id from soci_test", into(id));
st.execute();
int count = 0;
while(st.fetch())
  count++;
// Here sqlite backend returned true
bool fetchEnd = st.fetch();
```

This PR resolves the issue described and also add additional test to common tests to check for this type of error.