### PR TITLE
CMake debug postfix

### DIFF
--- a/cmake/SociBackend.cmake
+++ b/cmake/SociBackend.cmake
@@ -333,20 +333,25 @@ macro(soci_backend_test)
     endif()
     boost_report_value(${TEST_CONNSTR_VAR})
 
-    # Shared libraries test
-    add_executable(${TEST_TARGET} ${THIS_TEST_SOURCE})
+    if( SOCI_SHARED )
+      # Shared libraries test
+      add_executable(${TEST_TARGET} ${THIS_TEST_SOURCE})
 
-    target_link_libraries(${TEST_TARGET}
-      ${SOCI_CORE_DEPS_LIBS}
-      ${THIS_TEST_DEPENDS_LIBRARIES}
-      soci_core
-      soci_${BACKENDL})
+      target_link_libraries(${TEST_TARGET}
+        ${SOCI_CORE_DEPS_LIBS}
+        ${THIS_TEST_DEPENDS_LIBRARIES}
+        soci_core
+        soci_${BACKENDL})
 
-    add_test(${TEST_TARGET}
-      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET}
-      ${${TEST_CONNSTR_VAR}})
+      add_test(${TEST_TARGET}
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET}
+        ${${TEST_CONNSTR_VAR}})
 
-    soci_backend_test_create_vcxproj_user(${TEST_TARGET} "\"${${TEST_CONNSTR_VAR}}\"")
+      soci_backend_test_create_vcxproj_user(${TEST_TARGET} "\"${${TEST_CONNSTR_VAR}}\"")
+
+      # Ask make check to try to build tests first before executing them
+      add_dependencies(check ${TEST_TARGET})
+    endif(SOCI_SHARED)
 
     # Static libraries test
     if(SOCI_STATIC)
@@ -365,10 +370,12 @@ macro(soci_backend_test)
         ${${TEST_CONNSTR_VAR}})
 
       soci_backend_test_create_vcxproj_user(${TEST_TARGET_STATIC} "\"${${TEST_CONNSTR_VAR}}\"")
+
+      # Ask make check to try to build tests first before executing them
+      add_dependencies(check ${TEST_TARGET_STATIC})
     endif(SOCI_STATIC)
 
-    # Ask make check to try to build tests first before executing them
-    add_dependencies(check ${TEST_TARGET} ${TEST_TARGET_STATIC})
+    
 
     # Group source files for IDE source explorers (e.g. Visual Studio)
     source_group("Source Files" FILES ${THIS_TEST_SOURCE})

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -62,8 +62,10 @@ if (SOCI_SHARED)
   endif()
 endif()
 
+# This adds definitions to all build configurations. SOCI_DEBUG_POSTFIX is passed to soci library
 add_definitions(-DSOCI_LIB_PREFIX="${CMAKE_SHARED_LIBRARY_PREFIX}soci_"
-                -DSOCI_LIB_SUFFIX="${CMAKE_DEBUG_POSTFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+                -DSOCI_LIB_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}"
+                -DSOCI_DEBUG_POSTFIX="${CMAKE_DEBUG_POSTFIX}")
 
 #
 # Core static library

--- a/src/core/backend-loader.cpp
+++ b/src/core/backend-loader.cpp
@@ -42,7 +42,11 @@ typedef HMODULE soci_handler_t;
 #define DLSYM(x, y) GetProcAddress(x, y)
 
 #ifdef SOCI_ABI_VERSION
-#define LIBNAME(x) (SOCI_LIB_PREFIX + x + "_" SOCI_ABI_VERSION SOCI_LIB_SUFFIX)
+  #ifndef NDEBUG
+    #define LIBNAME(x) (SOCI_LIB_PREFIX + x + "_" SOCI_ABI_VERSION SOCI_DEBUG_POSTFIX SOCI_LIB_SUFFIX)
+  #else
+    #define LIBNAME(x) (SOCI_LIB_PREFIX + x + "_" SOCI_ABI_VERSION SOCI_LIB_SUFFIX)
+  #endif
 #else
 #define LIBNAME(x) (SOCI_LIB_PREFIX + x + SOCI_LIB_SUFFIX)
 #endif // SOCI_ABI_VERSION


### PR DESCRIPTION
In my previous PR #368 CMake debug postfix support was added but it does not work correctly in release because CMAKE_DEBUG_POSTFIX is set to all configurations instead of just debug build. This cause backend loader to fail in release mode.

I have made the following changes:
1.) Instead of combining prefix in CMake I pass forward preprocessor definition SOCI_DEBUG_POSTFIX
2.) In backend-loader.cpp additional macro is set for non-release mode which concatenates correct module name by including SOCI_DEBUG_POSTFIX. CMake generates NDEBUG for non-debug modes so this should work on all platforms.

There is also an altenative pure CMake approach by setting SOCI_LIB_SUFFIX specifically to each build configuration but I found this approach too messy in CMake. Something like this will also solve postfix for shared mode( static mode need addtional four lines ):

```CMake
# For debug mode set include also CMAKE_DEBUG_POSTFIX in suffix
set_property(TARGET ${SOCI_CORE_TARGET} APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:SOCI_LIB_SUFFIX="${CMAKE_DEBUG_POSTFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}">)
set_property(TARGET ${SOCI_CORE_TARGET}  APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Release>:SOCI_LIB_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}">)
set_property(TARGET ${SOCI_CORE_TARGET}  APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:MinSizeRel>:SOCI_LIB_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}">)
set_property(TARGET ${SOCI_CORE_TARGET}  APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:RelWithDebInfo>:SOCI_LIB_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}">)
```

The second change(commit) is a minor CMake fix which checks if shared mode is on before adding shared tests. 
When I set static mode only and test and set off shared mode then also shared test appeared in solution. This fix resolves the issue.