### PR TITLE
Memory leak fix in sqlite3 backend

### DIFF
--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -42,6 +42,7 @@ void check_sqlite_err(sqlite_api::sqlite3* conn, int res, char const* const errM
 {
     if (SQLITE_OK != res)
     {
+        sqlite3_close(conn);
         const char *zErrMsg = sqlite3_errmsg(conn);
         std::ostringstream ss;
         ss << errMsg << zErrMsg;


### PR DESCRIPTION
This PR fixes memory leak found in SQLite3 backend.  ```check_sqlite_err``` lacked the call to ```sqlite3_close(conn)``` whenever ```sqlite3_session_backend``` failed.

Note: here probably ```sqlite3_close_v2``` should be called since ```sqlite3_open_v2``` is used but currently Travis fails in that case.