### PR TITLE
sqlite3_close moved after sqlite3_errmsg is called.

### DIFF
--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -42,10 +42,10 @@ void check_sqlite_err(sqlite_api::sqlite3* conn, int res, char const* const errM
 {
     if (SQLITE_OK != res)
     {
-        sqlite3_close(conn);
         const char *zErrMsg = sqlite3_errmsg(conn);
         std::ostringstream ss;
         ss << errMsg << zErrMsg;
+        sqlite3_close(conn); // connection must be closed here
         throw sqlite3_soci_error(ss.str(), res);
     }
 }


### PR DESCRIPTION
 #378 resolved memory leak but produced another bug  in sqlite session constructor resulting in invalid exception message. I have totally overlooked the call to ```sqlite3_errmsg``` after ```sqlite3_close``` in my previous PR.

Now ```sqlite3_close``` is moved right before throw so exception message is safely retrieved before connection is closed.