### PR TITLE
initial integration with AppVeyor-CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Travis CI service at https://travis-ci.org/SOCI/soci
 
 [![Build Status](https://api.travis-ci.org/SOCI/soci.png)](https://travis-ci.org/SOCI/soci)
 
+AppVeyor CI service at https://ci.appveyor.com/project/snikulov/soci
+
+[![Build status](https://ci.appveyor.com/api/projects/status/501lgp66lf76b0ps?svg=true)](https://ci.appveyor.com/project/snikulov/soci)
+
+
+
 License
 -------
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+version: 4.0.0.{build}
+
+environment:
+    MINGW_ARCHIVE: C:\projects\mingw\x86_64-4.8.3-release-posix-seh-rt_v3-rev2.7z
+#    MINGW_URL: http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/4.8.3/threads-posix/seh/x86_64-4.8.3-release-posix-seh-rt_v3-rev2.7z/download
+    MINGW_URL: http://iweb.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/4.8.3/threads-posix/seh/x86_64-4.8.3-release-posix-seh-rt_v3-rev2.7z
+    matrix:
+      - PRJ_GEN: "Visual Studio 11 2012 Win64"
+        BDIR: msvc2012
+        PRJ_CFG: Release
+        SOCI_MYSQL: OFF
+      - PRJ_GEN: "Visual Studio 12 2013 Win64"
+        BDIR: msvc2013
+        PRJ_CFG: Release
+        SOCI_MYSQL: OFF
+      - PRJ_GEN: "Visual Studio 14 2015 Win64"
+        BDIR: msvc2015
+        PRJ_CFG: Release
+        SOCI_MYSQL: OFF
+      - PRJ_GEN: "MinGW Makefiles"
+        BDIR: gcc483
+        PRJ_CFG: Release
+        SOCI_MYSQL: OFF
+        MINGW_ROOT: C:\projects\mingw\4.8.3\mingw64\bin
+
+cache:
+    - C:\projects\mingw
+
+install:
+    - ps: if (!(Test-Path C:\projects\mingw)) { mkdir C:\projects\mingw }
+    - ps: if (!(Test-Path $env:MINGW_ARCHIVE)) {(new-object net.webclient).DownloadFile("$env:MINGW_URL", "$env:MINGW_ARCHIVE")}
+    - 7z x -y -oC:\projects\mingw\4.8.3\ C:\projects\mingw\x86_64-4.8.3-release-posix-seh-rt_v3-rev2.7z > nul
+
+build_script:
+    # dirty little hack - remove sh from Git to make generator happy
+    - del /Q "%ProgramFiles(x86)%\Git\bin\sh.exe"
+    - set PATH=%MINGW_ROOT%;%PATH%
+    - mkdir build.%BDIR%
+    - cd build.%BDIR%
+    - cmake .. -G"%PRJ_GEN%" -DCMAKE_BUILD_TYPE=%PRJ_CFG% -DWITH_MYSQL=%SOCI_MYSQL%
+    - cmake --build . --config %PRJ_CFG% --clean-first
+

--- a/cmake/modules/FindODBC.cmake
+++ b/cmake/modules/FindODBC.cmake
@@ -20,20 +20,22 @@ set(ODBC_FOUND FALSE)
 include(CheckIncludeFiles)
 check_include_files("windows.h;sqlext.h" HAVE_SQLEXT_H)
 
-find_path(ODBC_INCLUDE_DIR sqlext.h
-  /usr/include
-  /usr/include/odbc
-  /usr/local/include
-  /usr/local/include/odbc
-  /usr/local/odbc/include
-  "C:/Program Files (x86)/Windows Kits/8.0/include/um"
-  "C:/Program Files (x86)/Microsoft SDKs/Windows/v7.0A/Include"
-  "C:/Program Files/ODBC/include"
-  "C:/Program Files/Microsoft SDKs/Windows/v7.0/include"
-  "C:/Program Files/Microsoft SDKs/Windows/v6.0a/include"
-  "C:/ODBC/include"
-  DOC "Specify the directory containing sql.h."
-)
+if(NOT HAVE_SQLEXT_H)
+  find_path(ODBC_INCLUDE_DIR sqlext.h
+    /usr/include
+    /usr/include/odbc
+    /usr/local/include
+    /usr/local/include/odbc
+    /usr/local/odbc/include
+    "C:/Program Files (x86)/Windows Kits/8.0/include/um"
+    "C:/Program Files (x86)/Microsoft SDKs/Windows/v7.0A/Include"
+    "C:/Program Files/ODBC/include"
+    "C:/Program Files/Microsoft SDKs/Windows/v7.0/include"
+    "C:/Program Files/Microsoft SDKs/Windows/v6.0a/include"
+    "C:/ODBC/include"
+    DOC "Specify the directory containing sql.h."
+  )
+endif()
 
 if(MSVC)
     # msvc knows where to find sdk libs


### PR DESCRIPTION
Hello All,

I've created preliminary integration with AppVeyor-CI (https://ci.appveyor.com) engine for Windows builds.

Currently, it supported following build matrix:

- "Visual Studio 11 2012 Win64"
- "Visual Studio 12 2013 Win64"
- "Visual Studio 14 2015 Win64"
- "MinGW Makefiles" for g++ v4.8.3

without tests and Boost. 

[![Build status](https://ci.appveyor.com/api/projects/status/501lgp66lf76b0ps?svg=true)](https://ci.appveyor.com/project/snikulov/soci)

I expecting that somebody from project admins will add project under correct url and update README.md accordingly.

Thank you.
