### PR TITLE
Restore using -pedantic but use -Wno-pedantic-ms-format too

### DIFF
--- a/cmake/SociConfig.cmake
+++ b/cmake/SociConfig.cmake
@@ -51,7 +51,7 @@ if (MSVC)
 else()
 
   set(SOCI_GCC_CLANG_COMMON_FLAGS
-	"-Werror -Wall -Wpointer-arith -Wcast-align -Wcast-qual -Wfloat-equal -Wredundant-decls -Wno-long-long")
+	"-pedantic -Werror -Wall -Wpointer-arith -Wcast-align -Wcast-qual -Wfloat-equal -Wredundant-decls -Wno-long-long")
 
 
   if (SOCI_CXX_C11)
@@ -67,6 +67,9 @@ else()
     if (CMAKE_COMPILER_IS_GNUCXX)
         if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+            # We need to disable the warnings for using %I64d with MinGW.
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pedantic-ms-format")
         else()
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-variadic-macros")
         endif()


### PR DESCRIPTION
This reverts commit e607b1c731eb9058e8c627991e03c13a78ea5408 and replaces it
with the addition of -Wno-pedantic-ms-format option for MinGW as it suppresses
the warnings for using "%I64d" in format strings while still allowing us to
use -pedantic to detect other problems in the code.

See #369.