### PR TITLE
mingw: warnings cleanup

### DIFF
--- a/cmake/SociConfig.cmake
+++ b/cmake/SociConfig.cmake
@@ -69,7 +69,7 @@ else()
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
         elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
             # We need to disable the warnings for using %I64d with MinGW.
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pedantic-ms-format")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pedantic-ms-format -Wno-format")
         else()
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-variadic-macros")
         endif()

--- a/src/backends/odbc/standard-use-type.cpp
+++ b/src/backends/odbc/standard-use-type.cpp
@@ -209,9 +209,9 @@ void odbc_standard_use_type_backend::bind_by_name(
 void odbc_standard_use_type_backend::pre_use(indicator const *ind)
 {
     // first deal with data
-    SQLSMALLINT sqlType;
-    SQLSMALLINT cType;
-    SQLLEN size;
+    SQLSMALLINT sqlType(0);
+    SQLSMALLINT cType(0);
+    SQLLEN size(0);
 
     void* const sqlData = prepare_for_bind(size, sqlType, cType);
 

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -215,9 +215,9 @@ void odbc_vector_use_type_backend::bind_helper(int &position, void *data, exchan
     data_ = data; // for future reference
     type_ = type; // for future reference
 
-    SQLSMALLINT sqlType;
-    SQLSMALLINT cType;
-    SQLUINTEGER size;
+    SQLSMALLINT sqlType(0);
+    SQLSMALLINT cType(0);
+    SQLUINTEGER size(0);
 
     prepare_for_bind(data, size, sqlType, cType);
 

--- a/src/core/connection-pool.cpp
+++ b/src/core/connection-pool.cpp
@@ -83,27 +83,6 @@ connection_pool::~connection_pool()
     delete pimpl_;
 }
 
-session & connection_pool::at(std::size_t pos)
-{
-    if (pos >= pimpl_->sessions_.size())
-    {
-        throw soci_error("Invalid pool position");
-    }
-
-    return *(pimpl_->sessions_[pos].second);
-}
-
-std::size_t connection_pool::lease()
-{
-    // dummy default value avoids compiler warning, never leaks to client
-    std::size_t pos(0);
-
-    // no timeout, so can't fail
-    try_lease(pos, -1);
-
-    return pos;
-}
-
 bool connection_pool::try_lease(std::size_t & pos, int timeout)
 {
     struct timespec tm;
@@ -267,26 +246,6 @@ connection_pool::~connection_pool()
     delete pimpl_;
 }
 
-session & connection_pool::at(std::size_t pos)
-{
-    if (pos >= pimpl_->sessions_.size())
-    {
-        throw soci_error("Invalid pool position");
-    }
-
-    return *(pimpl_->sessions_[pos].second);
-}
-
-std::size_t connection_pool::lease()
-{
-    std::size_t pos;
-
-    // no timeout, allow unlimited blocking
-    try_lease(pos, -1);
-
-    return pos;
-}
-
 bool connection_pool::try_lease(std::size_t & pos, int timeout)
 {
     DWORD cc = WaitForSingleObject(pimpl_->sem_,
@@ -342,3 +301,26 @@ void connection_pool::give_back(std::size_t pos)
 }
 
 #endif // _WIN32
+
+session & connection_pool::at(std::size_t pos)
+{
+    if (pos >= pimpl_->sessions_.size())
+    {
+        throw soci_error("Invalid pool position");
+    }
+
+    return *(pimpl_->sessions_[pos].second);
+}
+
+std::size_t connection_pool::lease()
+{
+    // dummy default value avoids compiler warning, never leaks to client
+    std::size_t pos(0);
+
+    // no timeout, so can't fail
+    try_lease(pos, -1);
+
+    return pos;
+}
+
+


### PR DESCRIPTION
Moved common code out of #ifdefs to reduce duplication.
Added default initialization for local values. 

[![Build status](https://ci.appveyor.com/api/projects/status/501lgp66lf76b0ps?svg=true)](https://ci.appveyor.com/project/snikulov/soci)