### PR TITLE
connection-pool: moved common part out of #ifdef

### DIFF
--- a/src/core/connection-pool.cpp
+++ b/src/core/connection-pool.cpp
@@ -83,27 +83,6 @@ connection_pool::~connection_pool()
     delete pimpl_;
 }
 
-session & connection_pool::at(std::size_t pos)
-{
-    if (pos >= pimpl_->sessions_.size())
-    {
-        throw soci_error("Invalid pool position");
-    }
-
-    return *(pimpl_->sessions_[pos].second);
-}
-
-std::size_t connection_pool::lease()
-{
-    // dummy default value avoids compiler warning, never leaks to client
-    std::size_t pos(0);
-
-    // no timeout, so can't fail
-    try_lease(pos, -1);
-
-    return pos;
-}
-
 bool connection_pool::try_lease(std::size_t & pos, int timeout)
 {
     struct timespec tm;
@@ -267,26 +246,6 @@ connection_pool::~connection_pool()
     delete pimpl_;
 }
 
-session & connection_pool::at(std::size_t pos)
-{
-    if (pos >= pimpl_->sessions_.size())
-    {
-        throw soci_error("Invalid pool position");
-    }
-
-    return *(pimpl_->sessions_[pos].second);
-}
-
-std::size_t connection_pool::lease()
-{
-    std::size_t pos;
-
-    // no timeout, allow unlimited blocking
-    try_lease(pos, -1);
-
-    return pos;
-}
-
 bool connection_pool::try_lease(std::size_t & pos, int timeout)
 {
     DWORD cc = WaitForSingleObject(pimpl_->sem_,
@@ -342,3 +301,26 @@ void connection_pool::give_back(std::size_t pos)
 }
 
 #endif // _WIN32
+
+session & connection_pool::at(std::size_t pos)
+{
+    if (pos >= pimpl_->sessions_.size())
+    {
+        throw soci_error("Invalid pool position");
+    }
+
+    return *(pimpl_->sessions_[pos].second);
+}
+
+std::size_t connection_pool::lease()
+{
+    // dummy default value avoids compiler warning, never leaks to client
+    std::size_t pos(0);
+
+    // no timeout, so can't fail
+    try_lease(pos, -1);
+
+    return pos;
+}
+
+


### PR DESCRIPTION
During investigation of issue with [MinGW failed build](https://ci.appveyor.com/project/mloskot/soci/build/4.0.0.7/job/g5fjfquicg67eykb) 

```
[  4%] Building CXX object src/core/CMakeFiles/soci_core.dir/connection-pool.cpp.obj
C:\projects\soci\src\core\connection-pool.cpp: In member function 'std::size_t soci::connection_pool::lease()':
C:\projects\soci\src\core\connsection-pool.cpp:287:12: error: 'pos' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     return pos;
            ^
cc1plus.exe: all warnings being treated as errors
src\core\CMakeFiles\soci_core.dir\build.make:126: recipe for target 'src/core/CMakeFiles/soci_core.dir/connection-pool.cpp.obj' failed
```

found that two functions has same code for Windows and Linux.

Following [commit](https://github.com/SOCI/soci/commit/8fe5d2a1df0a747f9990c39e8bcb6700a7723d9e) change function, but it was for #ifndef _WIN32 case.
But MinGW compiles other function, which was not fixed.

So, I move these functions out of preprocessor, to avoid duplication.