### PR TITLE
Name struct to avoid clang error/warning (issue #374)

### DIFF
--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -157,6 +157,16 @@ struct sqlite3_vector_use_type_backend : details::vector_use_type_backend
     std::string name_;
 };
 
+struct sqlite3_column_buffer
+{
+    std::size_t size_;
+    union
+    {
+        const char *constData_;
+        char *data_;
+    };
+};
+
 struct sqlite3_column
 {
     bool isNull_;
@@ -164,16 +174,7 @@ struct sqlite3_column
 
     union
     {
-        struct
-        {
-            std::size_t size_;
-            union
-            {
-                const char *constData_;
-                char *data_;
-            };
-        } buffer_;
-
+        sqlite3_column_buffer buffer_;
         int int32_;
         sqlite_api::sqlite3_int64 int64_;
         double double_;


### PR DESCRIPTION
This is just a partial commit for issue #374. On my environment clang makes error and no warning.

So the following errors/warnings remains:
`soci4/include/soci/bind-values.h:91:39: error: C++98 requires an accessible copy constructor for class 'soci::details::use_type_vector::use_sequence<boost::fusion::vector<double, boost::optional<MyInt>, std::basic_string<char>, boost::fusion::void_,
      boost::fusion::void_, boost::fusion::void_, boost::fusion::void_, boost::fusion::void_, boost::fusion::void_, boost::fusion::void_>, void>' when binding a reference to a temporary; was private [-Werror,-Wbind-to-temporary-copy]`

and

`soci4/include/soci/type-conversion.h:91:68: error: field 'ownInd_' is uninitialized when used here [-Werror,-Wuninitialized]
        : use_type<base_type>(details::base_value_holder<T>::val_, ownInd_, name)`

