### PR TITLE
Appveyor: added build for MySQL backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,9 +86,6 @@ if(NOT MSVC)
     set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES ${DL_INCLUDE_DIR})
     add_definitions(-DHAVE_DL=1)
   endif()
-else() #MSVC
-  # This flag enables multi process compiling for Visual Studio 2005 and above
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 endif()
 
 if(Boost_FOUND)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,28 +8,28 @@ environment:
       - PRJ_GEN: "Visual Studio 11 2012 Win64"
         BDIR: msvc2012
         PRJ_CFG: Release
-        SOCI_MYSQL: OFF
         BOOST_ROOT: C:\Libraries\boost_1_58_0
         POSTGRESQL_ROOT: C:\Program Files\PostgreSQL\9.4
+        MYSQL_DIR: C:\Program Files\MySql\MySQL Server 5.6
       - PRJ_GEN: "Visual Studio 12 2013 Win64"
         BDIR: msvc2013
         PRJ_CFG: Release
-        SOCI_MYSQL: OFF
         BOOST_ROOT: C:\Libraries\boost_1_58_0
         POSTGRESQL_ROOT: C:\Program Files\PostgreSQL\9.4
+        MYSQL_DIR: C:\Program Files\MySql\MySQL Server 5.6
       - PRJ_GEN: "Visual Studio 14 2015 Win64"
         BDIR: msvc2015
         PRJ_CFG: Release
-        SOCI_MYSQL: OFF
         BOOST_ROOT: C:\Libraries\boost_1_59_0
         POSTGRESQL_ROOT: C:\Program Files\PostgreSQL\9.4
+        MYSQL_DIR: C:\Program Files\MySql\MySQL Server 5.6
       - PRJ_GEN: "MinGW Makefiles"
         BDIR: gcc483
         PRJ_CFG: Release
-        SOCI_MYSQL: OFF
         MINGW_ROOT: C:\projects\mingw\4.8.3\mingw64\bin
         BOOST_ROOT: C:\Libraries\boost_1_59_0
         POSTGRESQL_ROOT: C:\Program Files\PostgreSQL\9.4
+        MYSQL_DIR: C:\Program Files\MySql\MySQL Server 5.6
 
 services:
     - mssql2014
@@ -59,12 +59,15 @@ before_build:
     - mkdir build.%BDIR%
     - cd build.%BDIR%
     - set SQLITE_ROOT=C:\projects\sqlite\sqlite.%BDIR%
-    - set PATH=%MINGW_ROOT%;%PATH%;%SQLITE_ROOT%\bin;%POSTGRESQL_ROOT%\bin
+    - set PATH=%MINGW_ROOT%;%PATH%;%SQLITE_ROOT%\bin;%POSTGRESQL_ROOT%\bin;%MYSQL_DIR%\bin;%MYSQL_DIR%\lib
     - echo %PATH%
     - cmake --version
     - set PGUSER=postgres
     - set PGPASSWORD=Password12!
     - createdb soci_test
+    - set MYSQL_PWD=Password12!
+    - set USER=root
+    - mysql -e "create database soci_test;" --user=root
     - cmake .. -G"%PRJ_GEN%" -DCMAKE_BUILD_TYPE=%PRJ_CFG% -DCMAKE_INSTALL_PREFIX=C:\projects\sqlite\sqlite.%BDIR%
     - cmake --build . --config %PRJ_CFG% --target INSTALL
 
@@ -72,11 +75,11 @@ build_script:
     - cd C:\projects\soci
     - mkdir build.%BDIR%
     - cd build.%BDIR%
-    - cmake .. -G"%PRJ_GEN%" -DCMAKE_BUILD_TYPE=%PRJ_CFG% -DWITH_MYSQL=%SOCI_MYSQL% -DCMAKE_VERBOSE_MAKEFILE=ON
+    - cmake .. -G"%PRJ_GEN%" -DCMAKE_BUILD_TYPE=%PRJ_CFG% -DCMAKE_VERBOSE_MAKEFILE=ON
     - cmake --build . --config %PRJ_CFG% --clean-first
 
 test_script:
-    - ctest -V --output-on-failure -E odbc
+    - ctest -V --output-on-failure -E "odbc|mysql"
 
 notifications:
     - provider: Webhook

--- a/cmake/SociConfig.cmake
+++ b/cmake/SociConfig.cmake
@@ -35,12 +35,10 @@ set (SOCI_CXX_C11 OFF CACHE BOOL "Build to the C++11 standard")
 #
 
 if (MSVC)
-  if (MSVC80 OR MSVC90 OR MSVC10)
-    add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-    add_definitions(-D_CRT_NONSTDC_NO_WARNING)
-    add_definitions(-D_SCL_SECURE_NO_WARNINGS)
-  endif()
+  add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  add_definitions(-D_CRT_NONSTDC_NO_WARNING)
+  add_definitions(-D_SCL_SECURE_NO_WARNINGS)
 
   if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
     string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")

--- a/cmake/modules/FindMySQL.cmake
+++ b/cmake/modules/FindMySQL.cmake
@@ -67,7 +67,7 @@ if(WIN32)
       $ENV{SystemDrive}/MySQL/*/lib/opt
       $ENV{ProgramW6432}/MySQL/*/lib
    )
-   find_library(MYSQL_LIBRARIES NAMES mysqlclient libmysql
+   find_library(MYSQL_LIBRARIES NAMES libmysql
       PATHS
       ${MYSQL_LIB_PATHS}
    )


### PR DESCRIPTION
- enabled mysql backend in build.
- disabled mysql tests, because it fails with segfault.