### PR TITLE
Travis-CI: added valgrind check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,13 @@ env:
         - SOCI_TRAVIS_BACKEND=postgresql
         - SOCI_TRAVIS_BACKEND=postgression
         - SOCI_TRAVIS_BACKEND=sqlite3
+        - SOCI_TRAVIS_BACKEND=valgrind
 
 matrix:
     fast_finish: true
     allow_failures:
         - env: SOCI_TRAVIS_BACKEND=postgression
+        - env: SOCI_TRAVIS_BACKEND=valgrind
         - compiler: clang
 
 addons:

--- a/bin/ci/before_install.sh
+++ b/bin/ci/before_install.sh
@@ -10,7 +10,7 @@ sudo add-apt-repository -y ppa:apt-fast/stable
 sudo apt-get update -qq -y
 sudo apt-get install -qq -y apt-fast
 sudo apt-fast update -qq -y
-sudo apt-fast install -qq -y libboost-dev libboost-date-time-dev
+sudo apt-fast install -qq -y libboost-dev libboost-date-time-dev valgrind
 
 before_install="${TRAVIS_BUILD_DIR}/bin/ci/before_install_${SOCI_TRAVIS_BACKEND}.sh"
 if [ -x ${before_install} ]; then

--- a/bin/ci/before_script_valgrind.sh
+++ b/bin/ci/before_script_valgrind.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+# Sets up environment for SOCI backend at travis-ci.org
+#
+# Copyright (c) 2013 Mateusz Loskot <mateusz@loskot.net>
+# Copyright (c) 2015 Sergei Nikulov <sergey.nikulov@gmail.com>
+#
+source ${TRAVIS_BUILD_DIR}/bin/ci/common.sh
+
+mysql --version
+mysql -e 'create database soci_test;'
+psql --version
+psql -c 'create database soci_test;' -U postgres

--- a/bin/ci/common.sh
+++ b/bin/ci/common.sh
@@ -32,3 +32,8 @@ run_test()
 {
     ctest -V --output-on-failure "$@" .
 }
+
+run_test_memcheck()
+{
+    valgrind --leak-check=full --error-exitcode=1 --trace-children=yes ctest -V --output-on-failure "$@" .
+}

--- a/bin/ci/script_valgrind.sh
+++ b/bin/ci/script_valgrind.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+# Builds and tests SOCI at travis-ci.org
+#
+# Copyright (c) 2013 Mateusz Loskot <mateusz@loskot.net>
+# Copyright (c) 2015 Sergei Nikulov <sergey.nikulov@gmail.com>
+#
+source ${TRAVIS_BUILD_DIR}/bin/ci/common.sh
+
+cmake \
+    -DCMAKE_VERBOSE_MAKEFILE=ON \
+    -DSOCI_TESTS=ON \
+    -DSOCI_STATIC=OFF \
+    -DCMAKE_BUILD_TYPE=Debug \
+    ..
+
+run_make
+run_test_memcheck


### PR DESCRIPTION
Added memcheck with valgrind on Travis-CI.
Currently, allows failure.