### PR TITLE
Clang: fixed #374

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ env:
         - SOCI_TRAVIS_BACKEND=firebird
         - SOCI_TRAVIS_BACKEND=mysql
         - SOCI_TRAVIS_BACKEND=odbc
-        - SOCI_TRAVIS_BACKEND=oracle CFLAGS=-m32 CXXFLAGS=-m32 WITH_BOOST=OFF
         - SOCI_TRAVIS_BACKEND=postgresql
+        - SOCI_TRAVIS_BACKEND=oracle CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 WITH_BOOST=OFF
         - SOCI_TRAVIS_BACKEND=postgression
         - SOCI_TRAVIS_BACKEND=sqlite3
         - SOCI_TRAVIS_BACKEND=valgrind
@@ -33,7 +33,7 @@ matrix:
     allow_failures:
         - env: SOCI_TRAVIS_BACKEND=postgression
         - env: SOCI_TRAVIS_BACKEND=valgrind
-        - compiler: clang
+        - env: SOCI_TRAVIS_BACKEND=oracle CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 WITH_BOOST=OFF
 
 addons:
     coverity_scan:

--- a/cmake/SociConfig.cmake
+++ b/cmake/SociConfig.cmake
@@ -72,6 +72,12 @@ else()
 
   elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER}" MATCHES "clang")
 
+    # enforce C++11 for Clang
+    set(SOCI_CXX_C11 ON)
+    set(SOCI_CXX_VERSION_FLAGS "-std=c++11")
+    add_definitions(-DSOCI_CXX_C11)
+    add_definitions(-DCATCH_CONFIG_CPP11_NO_IS_ENUM)
+
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SOCI_GCC_CLANG_COMMON_FLAGS} ${SOCI_CXX_VERSION_FLAGS}")
 
   else()

--- a/include/soci/type-conversion.h
+++ b/include/soci/type-conversion.h
@@ -88,9 +88,9 @@ public:
     typedef typename type_conversion<T>::base_type base_type;
 
     conversion_use_type(T & value, std::string const & name = std::string())
-        : use_type<base_type>(details::base_value_holder<T>::val_, ownInd_, name)
+        : use_type<base_type>(details::base_value_holder<T>::val_, ownInd_ = i_ok, name)
         , value_(value)
-        , ownInd_()
+        , ownInd_(i_ok)
         , ind_(ownInd_)
         , readOnly_(false)
     {
@@ -99,9 +99,9 @@ public:
     }
 
     conversion_use_type(T const & value, std::string const & name = std::string())
-        : use_type<base_type>(details::base_value_holder<T>::val_, ownInd_, name)
+        : use_type<base_type>(details::base_value_holder<T>::val_, ownInd_ = i_ok, name)
         , value_(const_cast<T &>(value))
-        , ownInd_()
+        , ownInd_(i_ok)
         , ind_(ownInd_)
         , readOnly_(true)
     {


### PR DESCRIPTION
- fixed uninitialized warnings
- enforced C++11 for Clang
- removed Clang from Travis-CI allow_failures