### PR TITLE
Fixed Coverity issues for SQLite3: 12644, 12645, 12646

### DIFF
--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -71,7 +71,9 @@ struct sqlite3_statement_backend;
 struct sqlite3_standard_into_type_backend : details::standard_into_type_backend
 {
     sqlite3_standard_into_type_backend(sqlite3_statement_backend &st)
-        : statement_(st) {}
+        : statement_(st), data_(0), type_(), position_(0)
+    {
+    }
 
     virtual void define_by_pos(int &position,
                              void *data, details::exchange_type type);
@@ -92,7 +94,9 @@ struct sqlite3_standard_into_type_backend : details::standard_into_type_backend
 struct sqlite3_vector_into_type_backend : details::vector_into_type_backend
 {
     sqlite3_vector_into_type_backend(sqlite3_statement_backend &st)
-        : statement_(st) {}
+        : statement_(st), data_(0), type_(), position_(0)
+    {
+    }
 
     void define_by_pos(int& position, void* data, details::exchange_type type);
 
@@ -136,7 +140,9 @@ struct sqlite3_standard_use_type_backend : details::standard_use_type_backend
 struct sqlite3_vector_use_type_backend : details::vector_use_type_backend
 {
     sqlite3_vector_use_type_backend(sqlite3_statement_backend &st)
-        : statement_(st) {}
+        : statement_(st), data_(0), type_(), position_(0)
+    {
+    }
 
     virtual void bind_by_pos(int &position,
                            void *data, details::exchange_type type);

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -1898,7 +1898,7 @@ TEST_CASE_METHOD(common_tests, "Transactions", "[core][transaction]")
 
 std::tm  generate_tm()
 {
-    std::tm t = {0};
+    std::tm t = std::tm();
     t.tm_year = 105;
     t.tm_mon = 10;
     t.tm_mday = 15;
@@ -1927,7 +1927,7 @@ TEST_CASE_METHOD(common_tests, "Use with indicators", "[core][use][indicator]")
     id = 2;
     val = 11;
     ind2 = i_null;
-    std::tm tm = {0};
+    std::tm tm = std::tm();
     ind3 = i_null;
 
     sql << "insert into soci_test(id, val, tm) values(:id, :val, :tm)",
@@ -2027,7 +2027,7 @@ TEST_CASE_METHOD(common_tests, "Dynamic row binding", "[core][dynamic]")
         ASSERT_EQUAL_APPROX(r.get<double>(0), 3.14);
         CHECK(r.get<int>(1) == 123);
         CHECK(r.get<std::string>(2) == "Johny");
-        std::tm t = { 0 };
+        std::tm t = std::tm();
         t = r.get<std::tm>(3);
         CHECK(t.tm_year == 105);
 
@@ -2600,7 +2600,7 @@ TEST_CASE_METHOD(common_tests, "Reading rows from rowset", "[core][row][rowset]"
                 ASSERT_EQUAL_APPROX(r1.get<double>(0), 3.14);
                 CHECK(r1.get<int>(1) == 123);
                 CHECK(r1.get<std::string>(2) == "Johny");
-                std::tm t1 = { 0 };
+                std::tm t1 = std::tm();
                 t1 = r1.get<std::tm>(3);
                 CHECK(t1.tm_year == 105);
                 CHECK_EQUAL_PADDED(r1.get<std::string>(4), "a");
@@ -3826,7 +3826,7 @@ TEST_CASE_METHOD(common_tests, "Get affected rows", "[core][affected-rows]")
         sql << "insert into soci_test(val) values(:val)", use(i);
     }
 
-    int step = 2; 
+    int step = 2;
     statement st1 = (sql.prepare <<
         "update soci_test set val = val + :step where val = 5", use(step, "step"));
     st1.execute(true);

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -361,7 +361,7 @@ public:
         return true;
     }
 
-    virtual bool enable_std_char_padding(soci::session& s) const
+    virtual bool enable_std_char_padding(soci::session&) const
     {
         // SQLite does not support right padded char type.
         return false;


### PR DESCRIPTION
- Fixed Coverity issues for SQLite3: 12644, 12645, 12646
- Fixed gcc/clang warns produced with ```-Wextra``` switch for SQLite3