### PR TITLE
reset count of affected rows (sqlite3)

### DIFF
--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -233,6 +233,8 @@ sqlite3_statement_backend::bind_and_execute(int number)
 
     long long rowsAffectedBulkTemp = 0;
 
+    rowsAffectedBulk_ = -1;
+
     int const rows = static_cast<int>(useData_.size());
     for (int row = 0; row < rows; ++row)
     {

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -3832,6 +3832,10 @@ TEST_CASE_METHOD(common_tests, "Get affected rows", "[core][affected-rows]")
     st1.execute(true);
     CHECK(st1.get_affected_rows() == 1);
 
+    // attempts to run the query again, no rows should be affected
+    st1.execute(true);
+    CHECK(st1.get_affected_rows() == 0);
+
     statement st2 = (sql.prepare <<
         "update soci_test set val = val + 1");
     st2.execute(true);


### PR DESCRIPTION
when reusing prepared statements, the count was not reset, causing subsequent calls to `execute` to set `get_affected_rows` wrong.

Here is sample code that was failing:

```C++
session << "CREATE TABLE IF NOT EXISTS kv("
        "k   CHARACTER(32) PRIMARY KEY,"
        "v       TEXT);";

    session
        << "INSERT INTO kv (k, v) VALUES ('a', '2')";

    soci::statement st(session);
    st.alloc();

    std::string k = "a";
    std::string v = "1";

    st.clean_up(false);

    st.prepare("UPDATE kv SET v = :v WHERE k = :k;");
    st.exchange(soci::use(v));
    st.exchange(soci::use(k));
    st.define_and_bind();
    st.execute(true);

    if (st.get_affected_rows() != 1)
    {
        throw std::runtime_error("could not update");
    }

    std::string k2 = "b";

    st.clean_up(false);

    st.exchange(soci::use(v));
    st.exchange(soci::use(k2));
    st.define_and_bind();
    st.execute(true);

    // update should not do anything as 'b' does not exist
    if (st.get_affected_rows() == 1)
    {
        throw std::runtime_error("should not happen");
    }
```