### PR TITLE
[SQLITE3] Add reset API to reset sqlite3 statement

### DIFF
--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -208,6 +208,7 @@ struct sqlite3_statement_backend : details::statement_backend
     virtual void prepare(std::string const &query,
         details::statement_type eType);
     void reset_if_needed();
+    void reset();
 
     virtual exec_fetch_result execute(int number);
     virtual exec_fetch_result fetch(int number);

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -80,11 +80,16 @@ void sqlite3_statement_backend::reset_if_needed()
 {
     if (stmt_ && databaseReady_ == false)
     {
-        int const res = sqlite3_reset(stmt_);
-        if (SQLITE_OK == res)
-        {
-            databaseReady_ = true;
-        }
+        reset();
+    }
+}
+
+void sqlite3_statement_backend::reset()
+{
+    int const res = sqlite3_reset(stmt_);
+    if (SQLITE_OK == res)
+    {
+        databaseReady_ = true;
     }
 }
 


### PR DESCRIPTION
As I keep sqlite3 statement in a cache I need to reset them once they have been used. `reset_if_needed` was not enough as it was not reseting statement if it was not done `SQLITE3_DONE`