### PR TITLE
Add Vagrant configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ CMakeLists.txt.user
 
 # Eclipse
 /.project
+
+# Vagrant
+/.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,50 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrant virtual development environments for SOCI
+
+# All Vagrant configuration is done below.
+# The "2" in Vagrant.configure configures the configuration version.
+# Please don't change it unless you know what you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Enable automatic box update checking.
+  config.vm.box_check_update = true
+
+  # Configure main SOCI development box with build essentials, OSS DBs
+  config.vm.define "soci" do |soci|
+    scripts = [
+      "bootstrap.sh",
+      "devel.sh",
+      "firebird.sh",
+      "mysql.sh",
+      "postgresql.sh",
+      "build.sh"
+    ]
+    scripts.each { |script|
+      soci.vm.provision :shell, privileged: false, :path => "bin/vagrant/" << script
+    }
+  end
+
+  # TODO
+  # Configure database box with Oracle XE
+  # config.vm.define "oracle" do |oracle|
+  #   oracle.vm.provision "database", type: "shell" do |s|
+  #     s.inline = "echo Installing Oracle'"
+  #   end
+  # end
+  #
+  # # Configure database box with IBM DB2 Express-C
+  # config.vm.define "db2" do |db2|
+  #   db2.vm.provision "database", type: "shell" do |s|
+  #     s.inline = "echo Installing DB2'"
+  #   end
+  # end
+end

--- a/bin/vagrant/bootstrap.sh
+++ b/bin/vagrant/bootstrap.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Part of Vagrant virtual development environments for SOCI
+
+# Pre-installation
+echo "Bootstrap: updating environment in /home/vagrant/.bashrc"
+echo "source /vagrant/bin/vagrant/common.env" >> /home/vagrant/.bashrc
+export DEBIAN_FRONTEND="noninteractive"
+# Installation
+# TODO: Switch to apt-fast when it is avaiable for Trusty
+sudo apt-get update -y -q

--- a/bin/vagrant/build.sh
+++ b/bin/vagrant/build.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Part of Vagrant virtual development environments for SOCI
+
+# Builds and tests SOCI from git master branch
+source /vagrant/bin/vagrant/common.env
+
+# Clone SOCI locally on Linux filesystem, instead of VM shared folder.
+# Otherwise, CMake will fail:
+# CMake Error: cmake_symlink_library: System Error: Protocol error
+# Explanation from https://github.com/mitchellh/vagrant/issues/713
+# The VirtualBox shared folder filesystem doesn't allow symlinks, unfortunately.
+# Your only option is to deploy outside of the shared folders.
+if [[ ! -d "${SOCI_HOME}" && ! -d "${SOCI_HOME}/.git" ]] ; then
+  echo "Build: cloning SOCI master"
+  git clone https://github.com/SOCI/soci.git ${SOCI_HOME}
+fi
+
+if [[ ! -d "${SOCI_HOME}/_build" ]] ; then
+  mkdir ${SOCI_HOME}/_build
+fi
+
+echo "Build: building SOCI"
+cd ${SOCI_HOME}/_build && \
+cmake \
+    -DCMAKE_VERBOSE_MAKEFILE=ON \
+    -DSOCI_TESTS=ON \
+    -DSOCI_STATIC=OFF \
+    -DSOCI_DB2=OFF \
+    -DSOCI_ODBC=OFF \
+    -DSOCI_ORACLE=OFF \
+    -DSOCI_EMPTY=ON \
+    -DSOCI_FIREBIRD=OFF \
+    -DSOCI_MYSQL=ON \
+    -DSOCI_POSTGRESQL=ON \
+    -DSOCI_SQLITE3=ON \
+    -DSOCI_FIREBIRD_TEST_CONNSTR:STRING="service=LOCALHOST:/tmp/soci.fdb user=${SOCI_USER} password==${SOCI_PASS}" \
+    -DSOCI_MYSQL_TEST_CONNSTR:STRING="host=localhost db=${SOCI_USER} user=${SOCI_USER} password==${SOCI_PASS}" \
+    -DSOCI_POSTGRESQL_TEST_CONNSTR:STRING="host=localhost port=5432 dbname=${SOCI_USER} user=${SOCI_USER} password==${SOCI_PASS}" \
+    .. && \
+make && \
+ctest -V --output-on-failure .
+echo "Build: building DONE"

--- a/bin/vagrant/common.env
+++ b/bin/vagrant/common.env
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Part of Vagrant virtual development environments for SOCI
+export SOCI_USER=soci
+export SOCI_PASS=soci
+export SOCI_HOME=/home/vagrant/soci.git

--- a/bin/vagrant/devel.sh
+++ b/bin/vagrant/devel.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Part of Vagrant virtual development environments for SOCI
+
+# Installs essentials and core dependencies
+# Pre-installation
+source /vagrant/bin/vagrant/common.env
+export DEBIAN_FRONTEND="noninteractive"
+# Trusty has CMake 2.8, we need CMake 3
+sudo apt-get install software-properties-common
+sudo add-apt-repository ppa:george-edison55/cmake-3.x
+sudo apt-get update -y -q
+# Installation
+sudo apt-get -o Dpkg::Options::='--force-confnew' -y -q install \
+  build-essential \
+  cmake \
+  firebird2.5-dev \
+  git \
+  libboost-dev \
+  libboost-date-time-dev \
+  libmyodbc \
+  libmysqlclient-dev \
+  libpq-dev \
+  libsqlite3-dev \
+  odbc-postgresql \
+  unixodbc-dev \
+  valgrind
+# Post-installation

--- a/bin/vagrant/firebird.sh
+++ b/bin/vagrant/firebird.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Part of Vagrant virtual development environments for SOCI
+
+# Installs PostgreSQL with 'soci' user and database
+# Pre-installation
+source /vagrant/bin/vagrant/common.env
+export DEBIAN_FRONTEND="noninteractive"
+# FIXME: these debconf lines should automate the Firebird config but do/may not :(
+#        We work around this bug with Expect script below used to update SYSDBA password.
+sudo debconf-set-selections <<< "firebird2.5-super shared/firebird/enabled boolean true"
+sudo debconf-set-selections <<< "firebird2.5-super shared/firebird/sysdba_password/first_install password masterkey"
+# Installation
+sudo apt-get -o Dpkg::Options::='--force-confnew' -y -q install \
+  expect \
+  firebird2.5-super
+# Post-installation
+FB_ORIGINAL_PASS=`sudo cat /etc/firebird/2.5/SYSDBA.password \
+  | grep ISC_PASSWORD | sed -e 's/ISC_PASSWORD="\([^"]*\)".*/\1/'`
+echo "Firebird: dpkg-reconfigure resetting sysdba password from ${FB_ORIGINAL_PASS} to ${SOCI_PASS}"
+export DEBIAN_FRONTEND="readline"
+# Expect script feeding dpkg-reconfigure prompts
+sudo /usr/bin/expect - << ENDMARK > /dev/null
+spawn dpkg-reconfigure firebird2.5-super -freadline
+expect "Enable Firebird server?"
+send "Y\r"
+
+expect "Password for SYSDBA:"
+send "${SOCI_PASS}\r"
+
+# done
+expect eof
+ENDMARK
+# End of Expect script
+export DEBIAN_FRONTEND="noninteractive"
+echo "Firebird: cat /etc/firebird/2.5/SYSDBA.password"
+sudo cat /etc/firebird/2.5/SYSDBA.password | grep ISC_
+echo
+echo "Firebird: creating user ${SOCI_USER}"
+sudo gsec -user sysdba -pass ${SOCI_PASS} -delete ${SOCI_USER}
+sudo gsec -user sysdba -pass ${SOCI_PASS} -add ${SOCI_USER} -pw ${SOCI_PASS} -admin yes
+echo "Firebird: creating database /tmp/${SOCI_USER}.fdb"
+sudo rm -f /tmp/${SOCI_USER}.fdb
+echo "CREATE DATABASE \"LOCALHOST:/tmp/${SOCI_USER}.fdb\";" \
+  | isql-fb -q -u ${SOCI_USER} -p ${SOCI_PASS}
+echo "Firebird: restarting"
+sudo service firebird2.5-super restart
+echo "Firebird: DONE"

--- a/bin/vagrant/mysql.sh
+++ b/bin/vagrant/mysql.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Part of Vagrant virtual development environments for SOCI
+
+# Installs MySQL with 'soci' user and database
+# Pre-installation
+source /vagrant/bin/vagrant/common.env
+export DEBIAN_FRONTEND="noninteractive"
+sudo debconf-set-selections <<< "mysql-server mysql-server/root_password password ${SOCI_PASS}"
+sudo debconf-set-selections <<< "mysql-server mysql-server/root_password_again password ${SOCI_PASS}"
+# Installation
+sudo apt-get -o Dpkg::Options::='--force-confnew' -y -q install \
+  mysql-server
+# Post-installation
+echo "MySQL: updating /etc/mysql/my.cnf"
+sudo sed -i "s/bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/my.cnf
+echo "MySQL: setting root password to ${SOCI_PASS}"
+mysql -uroot -p${SOCI_PASS} -e \
+  "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${SOCI_PASS}' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+echo "MySQL: creating user ${SOCI_USER}"
+mysql -uroot -p${SOCI_PASS} -e \
+  "GRANT ALL PRIVILEGES ON ${SOCI_USER}.* TO '${SOCI_USER}'@'%' IDENTIFIED BY '${SOCI_PASS}' WITH GRANT OPTION"
+mysql -uroot -p${SOCI_PASS} -e "DROP DATABASE IF EXISTS ${SOCI_USER}"
+echo "MySQL: creating database ${SOCI_USER}"
+mysql -uroot -p${SOCI_PASS} -e "CREATE DATABASE ${SOCI_USER}"
+echo "MySQL: restarting"
+sudo service mysql restart
+echo "MySQL: DONE"

--- a/bin/vagrant/postgresql.sh
+++ b/bin/vagrant/postgresql.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Part of Vagrant virtual development environments for SOCI
+
+# Installs PostgreSQL with 'soci' user and database
+# Pre-installation
+source /vagrant/bin/vagrant/common.env
+export DEBIAN_FRONTEND="noninteractive"
+# Installation
+sudo apt-get -o Dpkg::Options::='--force-confnew' -y -q install \
+  postgresql \
+  postgresql-contrib
+# Post-installation
+echo "PostgreSQL: updating /etc/postgresql/9.3/main/postgresql.conf"
+sudo sed -i "s/#listen_address.*/listen_addresses '*'/" /etc/postgresql/9.3/main/postgresql.conf
+echo "PostgreSQL: updating /etc/postgresql/9.3/main/pg_hba.conf"
+sudo cat >> /etc/postgresql/9.3/main/pg_hba.conf <<EOF
+# Accept all IPv4 connections - DEVELOPMENT ONLY
+host    all         all         0.0.0.0/0             md5
+EOF
+echo "PostgreSQL: creating user ${SOCI_USER}"
+sudo -u postgres psql -c "CREATE ROLE ${SOCI_USER} WITH LOGIN SUPERUSER CREATEDB ENCRYPTED PASSWORD '${SOCI_PASS}'"
+echo "PostgreSQL: creating database ${SOCI_USER}"
+sudo -u postgres dropdb --if-exists ${SOCI_USER}
+sudo -u postgres createdb ${SOCI_USER} --owner=${SOCI_USER}
+echo "PostgreSQL: restarting"
+sudo service postgresql restart
+echo "PostgreSQL: DONE"

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -1,0 +1,65 @@
+# Vagrant SOCI
+
+[Vagrant](https://www.vagrantup.com/) used to build and provision
+virtual environments for SOCI development.
+
+## Features
+
+* Ubuntu 14.04 (Trusty) virtual machine
+* Multi-machine set-up with three VMs: soci, oracle, db2.
+* `soci.vm`:
+  * build essentials
+  * core dependenciesh
+  * backend dependencies
+  * FOSS databases installed with sample `soci` user and instance pre-configured
+  * during provision, automatically clones and builds SOCI from `master` branch.
+* `oracle.vm`:
+  * *TODO*: provision with Oracle XE
+* `db2.vm`:
+  * *TODO*: provision with IBM DB2 Express-C
+
+## Usage
+
+* [Boot](https://docs.vagrantup.com/v2/getting-started/up.html)
+```
+vagrant up soci
+```
+First time you run it, be patient as Vagrant downloads VM box and provisions it
+installing all the necessary packages.
+
+* You can SSH into the machine
+```
+vagrant ssh soci
+```
+
+* Develop
+```
+cd $SOCI_HOME
+git pull origin master
+# edit - build - test - commit
+```
+
+* [Teardown](https://docs.vagrantup.com/v2/getting-started/teardown.html)
+```
+vagrant {suspend|halt|destroy} soci
+```
+
+Check Vagrant [command-line interface](https://docs.vagrantup.com/v2/cli/index.html) for complete list of commands.
+
+### Environment variables
+
+The variables available to the `vagrant` user on the virtual machine(s):
+
+* `SOCI_HOME` is where SOCI master is cloned
+* `SOCI_USER` default database user and database name
+* `SOCI_PASS` default database password for both, `SOCI_USER` and root/sysdba
+  of particular database.
+
+Note, those variables are also used by provision scripts to set up databases.
+
+## Troubleshooting
+
+* Analyze `vagrant up` output.
+* On Windows, prefer `vagrant ssh` from inside MinGW Shell with `ssh.exe`
+  installed or learn how to use Vagrant with PuTTY.
+* If you modify any of `bin/vagrant/*.sh` scripts, **ensure** they have unified end-of-line characters to `LF` only. Othwerise, provisioning steps may fail.


### PR DESCRIPTION
Address #432 and provision virtual development environment for SOCI.
Currently, only main VM is provisioned: soci.
In future, oracle and db2 are planned to allow connections from the soci and perform testing of corresponding backends.

See docs/vagrant.md for details.