### PR TITLE
CMake generates soci/version.h

### DIFF
--- a/cmake/SociVersion.cmake
+++ b/cmake/SociVersion.cmake
@@ -54,4 +54,16 @@ macro(soci_version)
 
   add_definitions(-DSOCI_ABI_VERSION="${${PROJECT_NAME}_ABI_VERSION}")
 
+  math(
+      EXPR
+      SOCI_VERSION_H
+      "${${PROJECT_NAME}_VERSION_MAJOR} * 100000
+       + ${${PROJECT_NAME}_VERSION_MINOR} * 100
+       + ${${PROJECT_NAME}_VERSION_PATCH}"
+    )
+
+  set(SOCI_LIB_VERSION_H
+      "${${PROJECT_NAME}_VERSION_MAJOR}_${${PROJECT_NAME}_VERSION_MINOR}_${${PROJECT_NAME}_VERSION_PATCH}")
+
+  configure_file("include/soci/version.h.in" "${CMAKE_CURRENT_BINARY_DIR}/include/soci/version.h")
 endmacro()

--- a/include/soci/version.h.in
+++ b/include/soci/version.h.in
@@ -22,13 +22,13 @@
 //  SOCI_VERSION / 100 % 1000 is the minor version
 //  SOCI_VERSION / 100000 is the major version
 
-#define SOCI_VERSION 400000
+#define SOCI_VERSION @SOCI_VERSION_H@
 
 //
 //  SOCI_LIB_VERSION must be defined to be the same as SOCI_VERSION
 //  but as a *string* in the form "x_y[_z]" where x is the major version
 //  number, y is the minor version number, and z is the patch level if not 0.
 
-#define SOCI_LIB_VERSION "4_0_0"
+#define SOCI_LIB_VERSION "@SOCI_LIB_VERSION_H@"
 
 #endif // SOCI_VERSION_HPP


### PR DESCRIPTION
During my last cmake review I discovered that SOCI version was defined in both root CMakeLists.txt and include/soci/version.h

This is a quick fix to avoid forgetting one of them: include/soci/version.h is now generated based on what is defined in root CMakeLists.txt