### PR TITLE
Include soci/soci-config.h only if it is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ set(CONFIG_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
 install(DIRECTORY ${CONFIG_INCLUDE_DIR}/soci DESTINATION ${INCLUDEDIR})
 set(CONFIG_FILE_IN "include/soci/soci-config.h.in")
 set(CONFIG_FILE_OUT "${CONFIG_INCLUDE_DIR}/soci/soci-config.h")
+add_definitions(-DHAVE_SOCI_CONFIG_H)
 
 
 

--- a/include/soci/bind-values.h
+++ b/include/soci/bind-values.h
@@ -1,11 +1,11 @@
 #ifndef SOCI_BIND_VALUES_H_INCLUDED
 #define SOCI_BIND_VALUES_H_INCLUDED
 
+#include "soci/soci-platform.h"
 #include "exchange-traits.h"
 #include "into-type.h"
 #include "into.h"
 #include "soci-backend.h"
-#include <soci/soci-config.h>
 #include "use-type.h"
 #include "use.h"
 

--- a/include/soci/once-temp-type.h
+++ b/include/soci/once-temp-type.h
@@ -8,7 +8,7 @@
 #ifndef SOCI_ONCE_TEMP_TYPE_H_INCLUDED
 #define SOCI_ONCE_TEMP_TYPE_H_INCLUDED
 
-#include "soci/soci-config.h"
+#include "soci/soci-platform.h"
 #include "soci/ref-counted-statement.h"
 #include "soci/prepare-temp-type.h"
 

--- a/include/soci/rowset.h
+++ b/include/soci/rowset.h
@@ -8,7 +8,7 @@
 #ifndef SOCI_ROWSET_H_INCLUDED
 #define SOCI_ROWSET_H_INCLUDED
 
-#include "soci/soci-config.h"
+#include "soci/soci-platform.h"
 #include "soci/statement.h"
 // std
 #include <iterator>

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -8,7 +8,7 @@
 #ifndef SOCI_SESSION_H_INCLUDED
 #define SOCI_SESSION_H_INCLUDED
 
-#include "soci/soci-config.h"
+#include "soci/soci-platform.h"
 #include "soci/once-temp-type.h"
 #include "soci/query_transformation.h"
 #include "soci/connection-parameters.h"

--- a/include/soci/soci-platform.h
+++ b/include/soci/soci-platform.h
@@ -8,6 +8,10 @@
 #ifndef SOCI_PLATFORM_H_INCLUDED
 #define SOCI_PLATFORM_H_INCLUDED
 
+#ifdef HAVE_SOCI_CONFIG_H
+#include "soci/soci-config.h"
+#endif
+
 //disable MSVC deprecated warnings
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS

--- a/include/soci/soci.h
+++ b/include/soci/soci.h
@@ -9,7 +9,7 @@
 #define SOCI_H_INCLUDED
 
 // namespace soci
-#include "soci/soci-config.h"
+#include "soci/soci-platform.h"
 #include "soci/backend-loader.h"
 #include "soci/blob.h"
 #include "soci/blob-exchange.h"

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -6,7 +6,6 @@
 //
 
 #define SOCI_SOURCE
-#include "soci/soci-config.h"
 #include "soci/session.h"
 #include "soci/connection-parameters.h"
 #include "soci/connection-pool.h"


### PR DESCRIPTION
Also include it only once, from soci/soci-platform.h, as both of these files
serve similar purposes.