### PR TITLE
CMake read version from version.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,7 @@ colormsg(_HIBLUE_ "Configuring SOCI:")
 ###############################################################################
 include(SociVersion)
 
-# The version here should be in sync with the one in include/soci/version.h.
-soci_version(MAJOR 4 MINOR 0 PATCH 0)
+soci_version()
 
 ###############################################################################
 # Build features and variants

--- a/cmake/SociVersion.cmake
+++ b/cmake/SociVersion.cmake
@@ -20,14 +20,19 @@
 #    MAJOR.MINOR version is used to set SOVERSION
 #
 macro(soci_version)
-  parse_arguments(THIS_VERSION "MAJOR;MINOR;PATCH;"
-    ""
-    ${ARGN})
+  # get version from soci/version.h
+  file(
+    STRINGS
+    "${PROJECT_SOURCE_DIR}/include/soci/version.h"
+    _VERSION
+    REGEX
+    "#define SOCI_VERSION ([0-9]+)"
+  )
+  string(REGEX MATCH "([0-9]+)" _VERSION "${_VERSION}")
 
-  # Set version components
-  set(${PROJECT_NAME}_VERSION_MAJOR ${THIS_VERSION_MAJOR})
-  set(${PROJECT_NAME}_VERSION_MINOR ${THIS_VERSION_MINOR})
-  set(${PROJECT_NAME}_VERSION_PATCH ${THIS_VERSION_PATCH})
+  math(EXPR ${PROJECT_NAME}_VERSION_MAJOR "${_VERSION} / 100000")
+  math(EXPR ${PROJECT_NAME}_VERSION_MINOR "${_VERSION} / 100 % 1000")
+  math(EXPR ${PROJECT_NAME}_VERSION_PATCH "${_VERSION} % 100")
 
   # Set VERSION string
   set(${PROJECT_NAME}_VERSION

--- a/cmake/SociVersion.cmake
+++ b/cmake/SociVersion.cmake
@@ -54,16 +54,4 @@ macro(soci_version)
 
   add_definitions(-DSOCI_ABI_VERSION="${${PROJECT_NAME}_ABI_VERSION}")
 
-  math(
-      EXPR
-      SOCI_VERSION_H
-      "${${PROJECT_NAME}_VERSION_MAJOR} * 100000
-       + ${${PROJECT_NAME}_VERSION_MINOR} * 100
-       + ${${PROJECT_NAME}_VERSION_PATCH}"
-    )
-
-  set(SOCI_LIB_VERSION_H
-      "${${PROJECT_NAME}_VERSION_MAJOR}_${${PROJECT_NAME}_VERSION_MINOR}_${${PROJECT_NAME}_VERSION_PATCH}")
-
-  configure_file("include/soci/version.h.in" "${CMAKE_CURRENT_BINARY_DIR}/include/soci/version.h")
 endmacro()

--- a/include/soci/version.h
+++ b/include/soci/version.h
@@ -22,13 +22,13 @@
 //  SOCI_VERSION / 100 % 1000 is the minor version
 //  SOCI_VERSION / 100000 is the major version
 
-#define SOCI_VERSION @SOCI_VERSION_H@
+#define SOCI_VERSION 400000
 
 //
 //  SOCI_LIB_VERSION must be defined to be the same as SOCI_VERSION
 //  but as a *string* in the form "x_y[_z]" where x is the major version
 //  number, y is the minor version number, and z is the patch level if not 0.
 
-#define SOCI_LIB_VERSION "@SOCI_LIB_VERSION_H@"
+#define SOCI_LIB_VERSION "4_0_0"
 
 #endif // SOCI_VERSION_HPP


### PR DESCRIPTION
As discussed in mailing list, code should be sufficient. So lets read SOCI version from `include/soci/version.h` instead of defining it in root CMakeLists.txt