### PR TITLE
Handle MSVS 2015 (and 2013, to some extent) as C++11 compiler

### DIFF
--- a/include/soci/once-temp-type.h
+++ b/include/soci/once-temp-type.h
@@ -8,15 +8,9 @@
 #ifndef SOCI_ONCE_TEMP_TYPE_H_INCLUDED
 #define SOCI_ONCE_TEMP_TYPE_H_INCLUDED
 
-#include "soci/soci-config.h"
+#include "soci/soci-platform.h"
 #include "soci/ref-counted-statement.h"
 #include "soci/prepare-temp-type.h"
-
-#ifdef SOCI_HAVE_CXX_C11
-#define SOCI_ONCE_TEMP_TYPE_NOEXCEPT noexcept(false)
-#else
-#define SOCI_ONCE_TEMP_TYPE_NOEXCEPT
-#endif
 
 namespace soci
 {
@@ -37,7 +31,7 @@ public:
     once_temp_type(once_temp_type const & o);
     once_temp_type & operator=(once_temp_type const & o);
 
-    ~once_temp_type() SOCI_ONCE_TEMP_TYPE_NOEXCEPT;
+    ~once_temp_type() SOCI_NOEXCEPT_FALSE;
 
     template <typename T>
     once_temp_type & operator<<(T const & t)

--- a/include/soci/soci-platform.h
+++ b/include/soci/soci-platform.h
@@ -107,6 +107,10 @@ namespace std {
 
 #define SOCI_UNUSED(x) (void)x;
 
-
+#if defined(SOCI_HAVE_CXX_C11) || (defined(_MSC_VER) && _MSC_VER >= 1900)
+    #define SOCI_NOEXCEPT_FALSE noexcept(false)
+#else
+    #define SOCI_NOEXCEPT_FALSE
+#endif
 
 #endif // SOCI_PLATFORM_H_INCLUDED

--- a/include/soci/soci-platform.h
+++ b/include/soci/soci-platform.h
@@ -20,6 +20,8 @@
 #include <cstdlib>
 #include <ctime>
 
+#include "soci/soci-config.h" // for SOCI_HAVE_CXX_C11
+
 #if defined(_MSC_VER)
 #define LL_FMT_FLAGS "I64"
 #else
@@ -85,12 +87,23 @@ namespace std {
 # define SOCI_DECL
 #endif
 
-#define SOCI_NOT_ASSIGNABLE(classname) \
-    classname& operator=(const classname&);
+// C++11 features are always available in MSVS as it has no separate C++98
+// mode, we just need to check for the minimal compiler version supporting them
+// (see https://msdn.microsoft.com/en-us/library/hh567368.aspx).
 
-#define SOCI_NOT_COPYABLE(classname) \
-    classname(const classname&); \
-    SOCI_NOT_ASSIGNABLE(classname)
+#if defined(SOCI_HAVE_CXX_C11) || (defined(_MSC_VER) && _MSC_VER >= 1800)
+    #define SOCI_NOT_ASSIGNABLE(classname) \
+        classname& operator=(const classname&) = delete;
+    #define SOCI_NOT_COPYABLE(classname) \
+        classname(const classname&) = delete; \
+        SOCI_NOT_ASSIGNABLE(classname)
+#else // no C++11 deleted members support
+    #define SOCI_NOT_ASSIGNABLE(classname) \
+        classname& operator=(const classname&);
+    #define SOCI_NOT_COPYABLE(classname) \
+        classname(const classname&); \
+        SOCI_NOT_ASSIGNABLE(classname)
+#endif // C++11 deleted members available
 
 #define SOCI_UNUSED(x) (void)x;
 

--- a/src/core/once-temp-type.cpp
+++ b/src/core/once-temp-type.cpp
@@ -35,7 +35,7 @@ once_temp_type & once_temp_type::operator=(once_temp_type const & o)
     return *this;
 }
 
-once_temp_type::~once_temp_type() SOCI_ONCE_TEMP_TYPE_NOEXCEPT
+once_temp_type::~once_temp_type() SOCI_NOEXCEPT_FALSE
 {
     rcst_->dec_ref();
 }


### PR DESCRIPTION
Notably this fixes the problem of crashing as soon as `once_temp_type` dtor throws, see #441.