### PR TITLE
Avoid recursive inclusion between soci-{config,platform}.h

### DIFF
--- a/include/soci/soci-config.h.in
+++ b/include/soci/soci-config.h.in
@@ -8,8 +8,6 @@
 #ifndef SOCICONFIG_H_INCLUDED
 #define SOCICONFIG_H_INCLUDED
 
-#include "soci/soci-platform.h"
-
 //
 // SOCI has been build with support for:
 //


### PR DESCRIPTION
This resulted in SOCI_HAVE_CXX_C11 not being defined in soci-platform.h if
soci-config.h was the first header to be included, as soci-platform.h is
included from it before defining this symbol, but uses it.