### PR TITLE
Include soci/soci-platform.h instead of soci-config.h

### DIFF
--- a/include/soci/bind-values.h
+++ b/include/soci/bind-values.h
@@ -1,11 +1,11 @@
 #ifndef SOCI_BIND_VALUES_H_INCLUDED
 #define SOCI_BIND_VALUES_H_INCLUDED
 
+#include "soci/soci-platform.h"
 #include "exchange-traits.h"
 #include "into-type.h"
 #include "into.h"
 #include "soci-backend.h"
-#include <soci/soci-config.h>
 #include "use-type.h"
 #include "use.h"
 

--- a/include/soci/rowset.h
+++ b/include/soci/rowset.h
@@ -8,7 +8,7 @@
 #ifndef SOCI_ROWSET_H_INCLUDED
 #define SOCI_ROWSET_H_INCLUDED
 
-#include "soci/soci-config.h"
+#include "soci/soci-platform.h"
 #include "soci/statement.h"
 // std
 #include <iterator>

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -8,7 +8,7 @@
 #ifndef SOCI_SESSION_H_INCLUDED
 #define SOCI_SESSION_H_INCLUDED
 
-#include "soci/soci-config.h"
+#include "soci/soci-platform.h"
 #include "soci/once-temp-type.h"
 #include "soci/query_transformation.h"
 #include "soci/connection-parameters.h"

--- a/include/soci/soci.h
+++ b/include/soci/soci.h
@@ -9,7 +9,7 @@
 #define SOCI_H_INCLUDED
 
 // namespace soci
-#include "soci/soci-config.h"
+#include "soci/soci-platform.h"
 #include "soci/backend-loader.h"
 #include "soci/blob.h"
 #include "soci/blob-exchange.h"

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -6,7 +6,6 @@
 //
 
 #define SOCI_SOURCE
-#include "soci/soci-config.h"
 #include "soci/session.h"
 #include "soci/connection-parameters.h"
 #include "soci/connection-pool.h"


### PR DESCRIPTION
This is less confusing and ensures that common macros such as
SOCI_NOT_COPYABLE() are always defined.

Also remove an unneeded inclusion from session.cpp as the header is already
included from session.h anyhow.