### PR TITLE
Define cxx_details::auto_ptr<> to get rid of preprocessor checks

### DIFF
--- a/include/soci/rowset.h
+++ b/include/soci/rowset.h
@@ -8,7 +8,7 @@
 #ifndef SOCI_ROWSET_H_INCLUDED
 #define SOCI_ROWSET_H_INCLUDED
 
-#include "soci/soci-config.h"
+#include "soci/soci-platform.h"
 #include "soci/statement.h"
 // std
 #include <iterator>
@@ -148,13 +148,8 @@ private:
 
     unsigned int refs_;
 
-#ifdef SOCI_HAVE_CXX_C11
-    const std::unique_ptr<statement> st_;
-    const std::unique_ptr<T> define_;
-#else
-    const std::auto_ptr<statement> st_;
-    const std::auto_ptr<T> define_;
-#endif
+    const cxx_details::auto_ptr<statement> st_;
+    const cxx_details::auto_ptr<T> define_;
     SOCI_NOT_COPYABLE(rowset_impl)
 }; // class rowset_impl
 

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -41,11 +41,7 @@ class SOCI_DECL session
 {
 private:
 
-#ifdef SOCI_HAVE_CXX_C11
-    void set_query_transformation_(std::unique_ptr<details::query_transformation_function> & qtf);
-#else
-    void set_query_transformation_(std::auto_ptr<details::query_transformation_function> qtf);
-#endif
+    void set_query_transformation_(cxx_details::auto_ptr<details::query_transformation_function>& qtf);
 
 
 
@@ -85,11 +81,7 @@ public:
     void set_query_transformation(T callback)
     {
 
-#ifdef SOCI_HAVE_CXX_C11
-        std::unique_ptr<details::query_transformation_function> qtf(new details::query_transformation<T>(callback));
-#else
-        std::auto_ptr<details::query_transformation_function> qtf(new details::query_transformation<T>(callback));
-#endif
+        cxx_details::auto_ptr<details::query_transformation_function> qtf(new details::query_transformation<T>(callback));
         set_query_transformation_(qtf);
    }
 

--- a/include/soci/soci-platform.h
+++ b/include/soci/soci-platform.h
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <ctime>
+#include <memory>
 
 #include "soci/soci-config.h" // for SOCI_HAVE_CXX_C11
 
@@ -90,6 +91,23 @@ namespace std {
 // C++11 features are always available in MSVS as it has no separate C++98
 // mode, we just need to check for the minimal compiler version supporting them
 // (see https://msdn.microsoft.com/en-us/library/hh567368.aspx).
+
+namespace soci
+{
+
+namespace cxx_details
+{
+
+#if defined(SOCI_HAVE_CXX_C11) || (defined(_MSC_VER) && _MSC_VER >= 1600)
+    template <typename T>
+    using auto_ptr = std::unique_ptr<T>;
+#else // std::unique_ptr<> not available
+    using std::auto_ptr;
+#endif
+
+} // namespace cxx_details
+
+} // namespace soci
 
 #if defined(SOCI_HAVE_CXX_C11) || (defined(_MSC_VER) && _MSC_VER >= 1800)
     #define SOCI_NOT_ASSIGNABLE(classname) \

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -232,13 +232,7 @@ std::string session::get_query() const
 }
 
 
-#ifdef SOCI_HAVE_CXX_C11
-void session::set_query_transformation_( std::unique_ptr<details::query_transformation_function> &qtf)
-#else
-void session::set_query_transformation_( std::auto_ptr<details::query_transformation_function> qtf)
-#endif
-
-
+void session::set_query_transformation_(cxx_details::auto_ptr<details::query_transformation_function>& qtf)
 {
     if (isFromPool_)
     {

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -477,7 +477,7 @@ protected:
     SOCI_NOT_COPYABLE(common_tests)
 };
 
-typedef std::auto_ptr<table_creator_base> auto_table_creator;
+typedef cxx_details::auto_ptr<table_creator_base> auto_table_creator;
 
 // Define the test cases in their own namespace to avoid clashes with the test
 // cases defined in individual backend tests: as only line number is used for


### PR DESCRIPTION
Defining cxx_details::auto_ptr<> as either std::auto_ptr<> or
std::unique_ptr<> once instead of checking for SOCI_HAVE_CXX_C11 simplifies
the code and also allows to use unique_ptr<> for MSVS 2010+ which has it even
when SOCI_HAVE_CXX_C11 is not defined.

Also use cxx_details::auto_ptr<> instead of std::auto_ptr<> in the tests to
fix the build in C++11 mode with clang 3.8 due to -Wdeprecated-declarations
warnings given by it for std::auto_ptr<> (and -Werror used by CMake and which
apparently can't be overridden from command line...).