### PR TITLE
compilation fix for msvc2012

### DIFF
--- a/include/soci/soci-platform.h
+++ b/include/soci/soci-platform.h
@@ -98,7 +98,7 @@ namespace soci
 namespace cxx_details
 {
 
-#if defined(SOCI_HAVE_CXX_C11) || (defined(_MSC_VER) && _MSC_VER >= 1600)
+#if defined(SOCI_HAVE_CXX_C11) || (defined(_MSC_VER) && _MSC_VER >= 1800)
     template <typename T>
     using auto_ptr = std::unique_ptr<T>;
 #else // std::unique_ptr<> not available


### PR DESCRIPTION
Introduced in  #452.
MSVC 2012 not supported type aliases ``` using auto_ptr =  ... ```.
So I restrict it to more recent compiler MSVC 2013.