### PR TITLE
fixed #478

### DIFF
--- a/include/soci/connection-pool.h
+++ b/include/soci/connection-pool.h
@@ -32,6 +32,8 @@ public:
 private:
     struct connection_pool_impl;
     connection_pool_impl * pimpl_;
+
+    SOCI_NOT_COPYABLE(connection_pool)
 };
 
 }


### PR DESCRIPTION
Disabled copy constructor/assignment operator by default to avoid usage as described in #478 