### PR TITLE
Portable metadata queries.

### DIFF
--- a/docs/statements.md
+++ b/docs/statements.md
@@ -5,6 +5,7 @@
 * [Bulk operations](#bulk)
 * [Stored procedures](#procedures)
 * [Transactions](#transactions)
+* [Metadata queries](#metadata)
 * [Basic logging support](#logging)
 
 ### <a name="preparation"></a> Statement preparation and repeated execution
@@ -288,6 +289,37 @@ A typical usage pattern for this class might be:
     }
 
 With the above pattern the transaction is committed only when the code successfully reaches the end of block. If some exception is thrown before that, the scope will be left without reaching the final statement and the transaction object will automatically roll back in its destructor.
+
+### <a name="metadata"></a> Metadata queries
+
+It is possible to portably query the database server to obtain basic metadata information.
+
+In order to get the list of table names in the current schema:
+
+    std::vector<std::string> names(100);
+    sql.get_table_names(), into(names);
+
+alternatively:
+
+    std::string name;
+    soci::statement st = (sql.prepare_table_names(), into(name));
+    
+    st.execute();
+    while (st.fetch())
+    {
+        // ...
+    }
+
+Similarly, to get the description of all columns in the given table:
+
+    soci::column_info ci;
+    soci::statement st = (sql.prepare_column_descriptions(table_name), into(ci));
+
+    st.execute();
+    while (st.fetch())
+    {
+        // ci fields describe each column in turn
+    }
 
 ### <a name="logging"></a> Basic logging support
 

--- a/include/soci/column-info.h
+++ b/include/soci/column-info.h
@@ -1,0 +1,117 @@
+//
+// Copyright (C) 2016 Maciej Sobczak
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_COLUMN_INFO_H_INCLUDED
+#define SOCI_COLUMN_INFO_H_INCLUDED
+
+#include "soci/soci-backend.h"
+#include "soci/type-conversion.h"
+#include "soci/values.h"
+
+namespace soci
+{
+
+struct SOCI_DECL column_info
+{
+    std::string name;
+    data_type type;
+    std::size_t length; // meaningful for text columns only
+    std::size_t precision;
+    std::size_t scale;
+    bool nullable;
+};
+
+std::size_t get_numeric_value(const values & v,
+    const std::string & field_name)
+{
+    data_type dt = v.get_properties(field_name).get_data_type();
+    switch (dt)
+    {
+    case dt_double:
+        return static_cast<std::size_t>(
+            v.get<double>(field_name, 0.0));
+    case dt_integer:
+        return static_cast<std::size_t>(
+            v.get<int>(field_name, 0));
+    case dt_long_long:
+        return static_cast<std::size_t>(
+            v.get<long long>(field_name, 0ll));
+    case dt_unsigned_long_long:
+        return static_cast<std::size_t>(
+            v.get<unsigned long long>(field_name, 0ull));
+        break;
+    default:
+        return 0u;
+    }        
+}
+
+template <>
+struct type_conversion<column_info>
+{
+    typedef values base_type;
+    
+    static void from_base(values const & v, indicator /* ind */, column_info & ci)
+    {
+        ci.name = v.get<std::string>("COLUMN_NAME");
+
+        ci.length = get_numeric_value(v, "CHARACTER_MAXIMUM_LENGTH");
+        ci.precision = get_numeric_value(v, "NUMERIC_PRECISION");
+        ci.scale = get_numeric_value(v, "NUMERIC_SCALE");
+
+        const std::string & type_name = v.get<std::string>("DATA_TYPE");
+        if (type_name == "text" ||
+            type_name.find("char") != std::string::npos ||
+            type_name.find("CHAR") != std::string::npos)
+        {
+            ci.type = dt_string;
+        }
+        else if (type_name == "integer" || type_name == "INTEGER")
+        {
+            ci.type = dt_integer;
+        }
+        else if (type_name.find("number") != std::string::npos ||
+            type_name.find("NUMBER") != std::string::npos ||
+            type_name.find("numeric") != std::string::npos ||
+            type_name.find("NUMERIC") != std::string::npos)
+        {
+            if (ci.scale != 0)
+            {
+                ci.type = dt_double;
+            }
+            else
+            {
+                ci.type = dt_integer;
+            }
+        }
+        else if (type_name.find("time") != std::string::npos ||
+            type_name.find("TIME") != std::string::npos ||
+            type_name.find("date") != std::string::npos ||
+            type_name.find("DATE") != std::string::npos)
+        {
+            ci.type = dt_date;
+        }
+        else if (type_name.find("blob") != std::string::npos ||
+            type_name.find("BLOB") != std::string::npos ||
+            type_name.find("bytea") != std::string::npos ||
+            type_name.find("BYTEA") != std::string::npos)
+        {
+            ci.type = dt_blob;
+        }
+        else
+        {
+            // this seems to be a safe default
+            ci.type = dt_string;
+        }
+
+        const std::string & nullable_s = v.get<std::string>("IS_NULLABLE");
+        ci.nullable = (nullable_s == "YES");
+    }
+};
+
+} // namespace soci
+
+#endif // SOCI_COLUMN_INFO_H_INCLUDED

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -260,6 +260,24 @@ struct oracle_session_backend : details::session_backend
     virtual void commit();
     virtual void rollback();
 
+    virtual std::string get_table_names_query() const
+    {
+        return "select table_name"
+            " from user_tables";
+    }
+
+    virtual std::string get_column_descriptions_query() const
+    {
+        return "select column_name,"
+            " data_type,"
+            " char_length as character_maximum_length,"
+            " data_precision as numeric_precision,"
+            " data_scale as numeric_scale,"
+            " decode(nullable, 'Y', 'YES', 'N', 'NO') as is_nullable"
+            " from user_tab_columns"
+            " where table_name = :t";
+    }
+    
     virtual std::string get_backend_name() const { return "oracle"; }
 
     void clean_up();

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -113,7 +113,34 @@ public:
     // return the last value auto-generated in this session).
     bool get_last_insert_id(std::string const & table, long & value);
 
+    // Returns once_temp_type for the internally composed query
+    // for the list of tables in the current schema.
+    // Since this query usually returns multiple results (for multiple tables),
+    // it makes sense to bind std::vector<std::string> for the single output field.
+    details::once_temp_type get_table_names();
 
+    // Returns prepare_temp_type for the internally composed query
+    // for the list of tables in the current schema.
+    // Since this is intended for use with statement objects, where results are obtained one row after another,
+    // it makes sense to bind std::string for the output field.
+    details::prepare_temp_type prepare_table_names();
+
+    // Returns once_temp_type for the internally composed query
+    // for the list of column descriptions.
+    // Since this query usually returns multiple results (for multiple columns),
+    // it makes sense to bind std::vector<std::string> for each output field.
+    // Note: table_name is a non-const reference to prevent temporary objects,
+    // this argument is bound as a regular "use" element.
+    details::once_temp_type get_column_descriptions(std::string & table_name);
+
+    // Returns prepare_temp_type for the internally composed query
+    // for the list of column descriptions.
+    // Since this is intended for use with statement objects, where results are obtained one row after another,
+    // it makes sense to bind either std::string for each output field or soci::column_info for the whole row.
+    // Note: table_name is a non-const reference to prevent temporary objects,
+    // this argument is bound as a regular "use" element.
+    details::prepare_temp_type prepare_column_descriptions(std::string & table_name);
+    
     // for diagnostics and advanced users
     // (downcast it to expected back-end session class)
     details::session_backend * get_backend() { return backEnd_; }

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -125,14 +125,6 @@ public:
     // it makes sense to bind std::string for the output field.
     details::prepare_temp_type prepare_table_names();
 
-    // Returns once_temp_type for the internally composed query
-    // for the list of column descriptions.
-    // Since this query usually returns multiple results (for multiple columns),
-    // it makes sense to bind std::vector<std::string> for each output field.
-    // Note: table_name is a non-const reference to prevent temporary objects,
-    // this argument is bound as a regular "use" element.
-    details::once_temp_type get_column_descriptions(std::string & table_name);
-
     // Returns prepare_temp_type for the internally composed query
     // for the list of column descriptions.
     // Since this is intended for use with statement objects, where results are obtained one row after another,

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -238,12 +238,17 @@ public:
     // queried in a portable way - backends that are standard compliant
     // do not need to override the following methods, which are intended
     // to return a proper query for basic metadata statements.
+
+    // Returns a parameterless query for the list of table names in the current schema.
     virtual std::string get_table_names_query() const
     {
         return "select table_name as \"TABLE_NAME\""
             " from information_schema.tables"
             " where table_schema = 'public'";
     }
+    
+    // Returns a query with a single parameter (table name) for the list
+    // of columns and their properties.
     virtual std::string get_column_descriptions_query() const
     {
         return "select column_name as \"COLUMN_NAME\","

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -234,6 +234,28 @@ public:
         return false;
     }
 
+    // There is a set of standard SQL metadata structures that can be
+    // queried in a portable way - backends that are standard compliant
+    // do not need to override the following methods, which are intended
+    // to return a proper query for basic metadata statements.
+    virtual std::string get_table_names_query() const
+    {
+        return "select table_name as \"TABLE_NAME\""
+            " from information_schema.tables"
+            " where table_schema = 'public'";
+    }
+    virtual std::string get_column_descriptions_query() const
+    {
+        return "select column_name as \"COLUMN_NAME\","
+            " data_type as \"DATA_TYPE\","
+            " character_maximum_length as \"CHARACTER_MAXIMUM_LENGTH\","
+            " numeric_precision as \"NUMERIC_PRECISION\","
+            " numeric_scale as \"NUMERIC_SCALE\","
+            " is_nullable as \"IS_NULLABLE\""
+            " from information_schema.columns"
+            " where table_schema = 'public' and table_name = :t";
+    }
+
     virtual std::string get_backend_name() const = 0;
 
     virtual statement_backend* make_statement_backend() = 0;

--- a/include/soci/soci.h
+++ b/include/soci/soci.h
@@ -13,6 +13,7 @@
 #include "soci/backend-loader.h"
 #include "soci/blob.h"
 #include "soci/blob-exchange.h"
+#include "soci/column-info.h"
 #include "soci/connection-pool.h"
 #include "soci/error.h"
 #include "soci/exchange-traits.h"

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -359,6 +359,26 @@ bool session::get_last_insert_id(std::string const & sequence, long & value)
     return backEnd_->get_last_insert_id(*this, sequence, value);
 }
 
+details::once_temp_type session::get_table_names()
+{
+    return once << backEnd_->get_table_names_query();
+}
+
+details::prepare_temp_type session::prepare_table_names()
+{
+    return prepare << backEnd_->get_table_names_query();
+}
+
+details::once_temp_type session::get_column_descriptions(std::string & table_name)
+{
+    return once << backEnd_->get_column_descriptions_query(), use(table_name, "t");
+}
+
+details::prepare_temp_type session::prepare_column_descriptions(std::string & table_name)
+{
+    return prepare << backEnd_->get_column_descriptions_query(), use(table_name, "t");
+}
+    
 std::string session::get_backend_name() const
 {
     ensureConnected(backEnd_);

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -369,11 +369,6 @@ details::prepare_temp_type session::prepare_table_names()
     return prepare << backEnd_->get_table_names_query();
 }
 
-details::once_temp_type session::get_column_descriptions(std::string & table_name)
-{
-    return once << backEnd_->get_column_descriptions_query(), use(table_name, "t");
-}
-
 details::prepare_temp_type session::prepare_column_descriptions(std::string & table_name)
 {
     return prepare << backEnd_->get_column_descriptions_query(), use(table_name, "t");


### PR DESCRIPTION
This PR is an interface extension for portable metadata queries.
Assuming 'sql' is a session object, this is possible:

    // get all table names in user's schema
    std::string name;
    soci::statement st = (sql.prepare_table_names(), into(name));
    // st.execute/while-fetch/etc.

    // get column descriptions for the given table name:
    soci::column_info ci;
    soci::statement st = (sql.prepare_column_descriptions(table_name), into(ci))
    // st.execute/while-fetch/etc.

(bulk versions for vector<string> are also supported, see the diff)
where column_info is defined as:

struct column_info
{
    std::string name;
    data_type type;
    std::size_t length; // meaningful for text columns only
    std::size_t precision;
    std::size_t scale;
    bool nullable;
};

The implementation assumes standard SQL information schema and PostgreSQL is used as a reference. Other backends do not need to do anything if they follow the standard. Oracle has a separate implementation since it is not standard-compliant in this regard - it is enough for the backend to override a set of backend functions that compose schema queries to redefine the standard behaviour.

This PR introduces one new header file. It *might* be necessary to fix build scripts appropriately.