### PR TITLE
Added singlerows mode for PostgreSQL.

### DIFF
--- a/docs/backends/postgresql.md
+++ b/docs/backends/postgresql.md
@@ -60,6 +60,20 @@ To establish a connection to the PostgreSQL database, create a `session` object 
 
 The set of parameters used in the connection string for PostgreSQL is the same as accepted by the `[PQconnectdb](http://www.postgresql.org/docs/8.3/interactive/libpq.html#LIBPQ-CONNECT)` function from the `libpq` library.
 
+In addition to standard PostgreSQL connection parameters, the following can be set:
+
+* `singlerow` or `singlerows`
+
+For example:
+
+    session sql(postgresql, "dbname=mydatabase singlerows=true");
+
+If the `singlerows` parameter is set to `true` or `yes`, then queries will be executed in the single-row mode, which prevents the client library from loading full query result set into memory and instead fetches rows one by one, as they are requested by the statement's fetch() function. This mode can be of interest to those users who want to make their client applications more responsive (with more fine-grained operation) by avoiding potentially long blocking times when complete query results are loaded to client's memory.
+Note that in the single-row operation:
+
+* bulk queries are not supported, and
+* in order to fulfill the expectations of the underlying client library, the complete rowset has to be exhausted before executing further queries on the same session.
+
 Once you have created a `session` object as shown above, you can use it to access the database, for example:
 
     int count;

--- a/include/soci/connection-parameters.h
+++ b/include/soci/connection-parameters.h
@@ -32,6 +32,7 @@ public:
 
     // Retrieve the backend and the connection strings specified in the ctor.
     backend_factory const * get_factory() const { return factory_; }
+    void set_connect_string(const std::string & connectString) { connectString_ = connectString; }
     std::string const & get_connect_string() const { return connectString_; }
 
     // Set the value of the given option, overwriting any previous value.

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -215,7 +215,8 @@ struct postgresql_vector_use_type_backend : details::vector_use_type_backend
 struct postgresql_session_backend;
 struct postgresql_statement_backend : details::statement_backend
 {
-    postgresql_statement_backend(postgresql_session_backend & session);
+    postgresql_statement_backend(postgresql_session_backend & session,
+        bool single_row_mode);
     ~postgresql_statement_backend();
 
     virtual void alloc();
@@ -242,6 +243,8 @@ struct postgresql_statement_backend : details::statement_backend
     virtual postgresql_vector_use_type_backend * make_vector_use_type_backend();
 
     postgresql_session_backend & session_;
+
+    bool single_row_mode_;
 
     details::postgresql_result result_;
     std::string query_;
@@ -304,7 +307,8 @@ struct postgresql_blob_backend : details::blob_backend
 
 struct postgresql_session_backend : details::session_backend
 {
-    postgresql_session_backend(connection_parameters const & parameters);
+    postgresql_session_backend(connection_parameters const & parameters,
+        bool single_row_mode);
 
     ~postgresql_session_backend();
 
@@ -328,6 +332,7 @@ struct postgresql_session_backend : details::session_backend
     std::string get_next_statement_name();
 
     int statementCount_;
+    bool single_row_mode_;
     PGconn * conn_;
 };
 

--- a/src/backends/postgresql/factory.cpp
+++ b/src/backends/postgresql/factory.cpp
@@ -7,6 +7,7 @@
 
 #define SOCI_POSTGRESQL_SOURCE
 #include "soci/postgresql/soci-postgresql.h"
+#include "soci/connection-parameters.h"
 #include "soci/backend-loader.h"
 #include <libpq/libpq-fs.h> // libpq
 
@@ -23,11 +24,103 @@
 using namespace soci;
 using namespace soci::details;
 
+namespace // unnamed
+{
+
+// iterates the string pointed by i, searching for pairs of key value.
+// it returns the position after the value
+std::string::const_iterator get_key_value(std::string::const_iterator & i,
+                                          std::string::const_iterator const & end,
+                                          std::string & key,
+                                          std::string & value)
+{
+    bool in_value = false;
+    bool quoted = false;
+
+    key.clear();
+    value.clear();
+
+    while (i != end)
+    {
+        if (in_value == false)
+        {
+            if (*i == '=')
+            {
+                in_value = true;
+                if (i != end && *(i + 1) == '"')
+                {
+                    quoted = true;
+                    ++i; // jump over the quote
+                }
+            }
+            else if (!isspace(*i))
+            {
+                key += *i;
+            }
+        }
+        else
+        {
+            if ((quoted == true && *i == '"') || (quoted == false && isspace(*i)))
+            {
+                return ++i;
+            }
+            else
+            {
+                value += *i;
+            }
+        }
+        ++i;
+    }
+    return i;
+}
+
+// retrieves specific parameters from the
+// uniform connect string
+std::string chop_connect_string(std::string const & connectString,
+    bool & single_row_mode)
+{
+    std::string pruned_conn_string;
+    
+    single_row_mode = false;
+
+    std::string key, value;
+    std::string::const_iterator i = connectString.begin();
+    while (i != connectString.end())
+    {
+        i = get_key_value(i, connectString.end(), key, value);
+        if (key == "singlerow" || key == "singlerows")
+        {
+            single_row_mode = (value == "true" || value == "yes");
+        }
+        else
+        {
+            if (pruned_conn_string.empty() == false)
+            {
+                pruned_conn_string += ' ';
+            }
+
+            pruned_conn_string += key + '=' + value;
+        }
+    }
+
+    return pruned_conn_string;
+}
+
+} // unnamed namespace
+
 // concrete factory for Empty concrete strategies
 postgresql_session_backend * postgresql_backend_factory::make_session(
      connection_parameters const & parameters) const
 {
-     return new postgresql_session_backend(parameters);
+    bool single_row_mode;
+
+    const std::string pruned_conn_string =
+        chop_connect_string(parameters.get_connect_string(), single_row_mode);
+
+    connection_parameters pruned_parameters(parameters);
+    pruned_parameters.set_connect_string(pruned_conn_string);
+    
+    return new postgresql_session_backend(pruned_parameters, single_row_mode);
 }
 
 postgresql_backend_factory const soci::postgresql;

--- a/src/backends/postgresql/session.cpp
+++ b/src/backends/postgresql/session.cpp
@@ -38,7 +38,7 @@ void hard_exec(PGconn * conn, char const * query, char const * errMsg)
 } // namespace unnamed
 
 postgresql_session_backend::postgresql_session_backend(
-    connection_parameters const& parameters)
+    connection_parameters const& parameters, bool single_row_mode)
     : statementCount_(0)
 {
     PGconn* conn = PQconnectdb(parameters.get_connect_string().c_str());
@@ -64,6 +64,8 @@ postgresql_session_backend::postgresql_session_backend(
         version >= 90000 ? "SET extra_float_digits = 3"
                          : "SET extra_float_digits = 2",
         "Cannot set extra_float_digits parameter");
+
+    single_row_mode_ = single_row_mode;
 
     conn_ = conn;
 }
@@ -123,7 +125,7 @@ std::string postgresql_session_backend::get_next_statement_name()
 
 postgresql_statement_backend * postgresql_session_backend::make_statement_backend()
 {
-    return new postgresql_statement_backend(*this);
+    return new postgresql_statement_backend(*this, single_row_mode_);
 }
 
 postgresql_rowid_backend * postgresql_session_backend::make_rowid_backend()

--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -25,9 +25,41 @@
 using namespace soci;
 using namespace soci::details;
 
+namespace // unnamed
+{
+
+// used only with asynchronous operations in single-row mode
+
+void wait_until_operation_complete(PGconn * conn)
+{
+    while (true)
+    {
+        PGresult * result = PQgetResult(conn);
+        if (result == NULL)
+        {
+            break;
+        }
+        else
+        {
+            PQclear(result);
+        }
+    }
+}
+
+void throw_soci_error(PGconn * conn, const char * msg)
+{
+    std::string description = msg;
+    description += ": ";
+    description += PQerrorMessage(conn);
+
+    throw soci_error(description);
+}
+
+} // unnamed namespace
+
 postgresql_statement_backend::postgresql_statement_backend(
-    postgresql_session_backend &session)
-     : session_(session)
+    postgresql_session_backend &session, bool single_row_mode)
+    : session_(session), single_row_mode_(single_row_mode)
      , rowsAffectedBulk_(-1LL), justDescribed_(false)
      , hasIntoElements_(false), hasVectorIntoElements_(false)
      , hasUseElements_(false), hasVectorUseElements_(false)
@@ -185,10 +217,29 @@ void postgresql_statement_backend::prepare(std::string const & query,
         // if it fails to prepare it we can't DEALLOCATE it.
         std::string statementName = session_.get_next_statement_name();
 
-        postgresql_result result(
-            PQprepare(session_.conn_, statementName.c_str(),
-              query_.c_str(), static_cast<int>(names_.size()), NULL));
-        result.check_for_errors("Cannot prepare statement.");
+        if (single_row_mode_)
+        {
+            // prepare for single-row retrieval
+
+            int result = PQsendPrepare(session_.conn_, statementName.c_str(),
+                query_.c_str(), static_cast<int>(names_.size()), NULL);
+            if (result != 1)
+            {
+                throw_soci_error(session_.conn_,
+                    "Cannot prepare statement in singlerow mode");
+            }
+
+            wait_until_operation_complete(session_.conn_);
+        }
+        else
+        {
+            // default multi-row query execution
+            
+            postgresql_result result(
+                PQprepare(session_.conn_, statementName.c_str(),
+                    query_.c_str(), static_cast<int>(names_.size()), NULL));
+            result.check_for_errors("Cannot prepare statement.");
+        }
 
         // Now it's safe to save this info.
         statementName_ = statementName;
@@ -202,18 +253,27 @@ void postgresql_statement_backend::prepare(std::string const & query,
 statement_backend::exec_fetch_result
 postgresql_statement_backend::execute(int number)
 {
+    if (single_row_mode_ && (number > 1))
+    {
+        throw soci_error("Bulk operations are not supported with single-row mode.");
+    }
+    
     // If the statement was "just described", then we know that
     // it was actually executed with all the use elements
     // already bound and pre-used. This means that the result of the
     // query is already on the client side, so there is no need
     // to re-execute it.
+    // The optimization based on the existing results
+    // from the row description can be performed only once.
+    // If the same statement is re-executed,
+    // it will be *really* re-executed, without reusing existing data.
 
     if (justDescribed_ == false)
     {
         // This object could have been already filled with data before.
         clean_up();
 
-        if (number > 1 && hasIntoElements_)
+        if ((number > 1) && hasIntoElements_)
         {
              throw soci_error(
                   "Bulk use with single into elements is not supported.");
@@ -295,27 +355,97 @@ postgresql_statement_backend::execute(int number)
 
 #ifdef SOCI_POSTGRESQL_NOPREPARE
 
-                result_.reset(PQexecParams(session_.conn_, query_.c_str(),
-                    static_cast<int>(paramValues.size()),
-                    NULL, &paramValues[0], NULL, NULL, 0));
+                if (single_row_mode_)
+                {
+                    int result = PQsendQueryParams(
+                        session_.conn_, query_.c_str(),
+                        static_cast<int>(paramValues.size()),
+                        NULL, &paramValues[0], NULL, NULL, 0);
+                    if (result != 1)
+                    {
+                        throw_soci_error(session_.conn_,
+                            "Cannot execute query in single-row mode");
+                    }
+
+                    result = PQsetSingleRowMode(session_.conn_);
+                    if (result != 1)
+                    {
+                        throw_soci_error(session_.conn_,
+                            "cannot set singlerow mode");
+                    }
+                }
+                else
+                {
+                    // default multi-row execution
+                    result_.reset(PQexecParams(session_.conn_, query_.c_str(),
+                            static_cast<int>(paramValues.size()),
+                            NULL, &paramValues[0], NULL, NULL, 0));
+                }
 #else
                 if (stType_ == st_repeatable_query)
                 {
                     // this query was separately prepared
 
-                    result_.reset(PQexecPrepared(session_.conn_,
-                        statementName_.c_str(),
-                        static_cast<int>(paramValues.size()),
-                        &paramValues[0], NULL, NULL, 0));
+                    if (single_row_mode_)
+                    {
+                        int result = PQsendQueryPrepared(session_.conn_,
+                            statementName_.c_str(),
+                            static_cast<int>(paramValues.size()),
+                            &paramValues[0], NULL, NULL, 0);
+                        if (result != 1)
+                        {
+                            throw_soci_error(session_.conn_,
+                                "Cannot execute prepared query in single-row mode");
+                        }
+                        
+                        result = PQsetSingleRowMode(session_.conn_);
+                        if (result != 1)
+                        {
+                            throw_soci_error(session_.conn_,
+                                "Cannot set singlerow mode");
+                        }
+                    }
+                    else
+                    {
+                        // default multi-row execution
+                        
+                        result_.reset(PQexecPrepared(session_.conn_,
+                                statementName_.c_str(),
+                                static_cast<int>(paramValues.size()),
+                                &paramValues[0], NULL, NULL, 0));
+                    }
                 }
                 else // stType_ == st_one_time_query
                 {
                     // this query was not separately prepared and should
                     // be executed as a one-time query
 
-                    result_.reset(PQexecParams(session_.conn_, query_.c_str(),
-                        static_cast<int>(paramValues.size()),
-                        NULL, &paramValues[0], NULL, NULL, 0));
+                    if (single_row_mode_)
+                    {
+                        int result = PQsendQueryParams(session_.conn_, query_.c_str(),
+                            static_cast<int>(paramValues.size()),
+                            NULL, &paramValues[0], NULL, NULL, 0);
+                        if (result != 1)
+                        {
+                            throw_soci_error(session_.conn_,
+                                "cannot execute query in single-row mode");
+                        }
+                        
+                        result = PQsetSingleRowMode(session_.conn_);
+                        if (result != 1)
+                        {
+                            throw_soci_error(session_.conn_,
+                                "Cannot set singlerow mode");
+                        }
+                    }
+                    else
+                    {
+                        // default multi-row execution
+                        
+                        result_.reset(PQexecParams(session_.conn_, query_.c_str(),
+                                static_cast<int>(paramValues.size()),
+                                NULL, &paramValues[0], NULL, NULL, 0));
+                    }
                 }
 
 #endif // SOCI_POSTGRESQL_NOPREPARE
@@ -352,34 +482,114 @@ postgresql_statement_backend::execute(int number)
 
 #ifdef SOCI_POSTGRESQL_NOPREPARE
 
-            result_.reset(PQexec(session_.conn_, query_.c_str()));
+            if (single_row_mode_)
+            {
+                int result = PQsendQuery(session_.conn_, query_.c_str());
+                if (result != 1)
+                {
+                    throw_soci_error(session_.conn_,
+                        "Cannot execute query in single-row mode");
+                }
+
+                result = PQsetSingleRowMode(session_.conn_);
+                if (result != 1)
+                {
+                    throw_soci_error(session_.conn_,
+                        "Cannot set single-row mode");
+                }
+            }
+            else
+            {
+                // default multi-row execution
+                
+                result_.reset(PQexec(session_.conn_, query_.c_str()));
+            }
 #else
             if (stType_ == st_repeatable_query)
             {
                 // this query was separately prepared
 
-                result_.reset(PQexecPrepared(session_.conn_,
-                    statementName_.c_str(), 0, NULL, NULL, NULL, 0));
+                if (single_row_mode_)
+                {
+                    int result = PQsendQueryPrepared(session_.conn_,
+                        statementName_.c_str(), 0, NULL, NULL, NULL, 0);
+                    if (result != 1)
+                    {
+                        throw_soci_error(session_.conn_,
+                            "Cannot execute prepared query in single-row mode");
+                    }
+                    
+                    result = PQsetSingleRowMode(session_.conn_);
+                    if (result != 1)
+                    {
+                        throw_soci_error(session_.conn_,
+                            "Cannot set singlerow mode");
+                    }
+                }
+                else
+                {
+                    // default multi-row execution
+                    
+                    result_.reset(PQexecPrepared(session_.conn_,
+                            statementName_.c_str(), 0, NULL, NULL, NULL, 0));
+                }
             }
             else // stType_ == st_one_time_query
             {
-                result_.reset(PQexec(session_.conn_, query_.c_str()));
+                if (single_row_mode_)
+                {
+                    int result = PQsendQuery(session_.conn_, query_.c_str());
+                    if (result != 1)
+                    {
+                        throw_soci_error(session_.conn_,
+                            "Cannot execute query in single-row mode");
+                    }
+
+                    result = PQsetSingleRowMode(session_.conn_);
+                    if (result != 1)
+                    {
+                        throw_soci_error(session_.conn_,
+                            "Cannot set single-row mode");
+                    }
+                }
+                else
+                {
+                    // default multi-row execution
+                    
+                    result_.reset(PQexec(session_.conn_, query_.c_str()));
+                }
             }
 
 #endif // SOCI_POSTGRESQL_NOPREPARE
         }
     }
+
+    bool process_result;
+    if (single_row_mode_)
+    {
+        if (justDescribed_)
+        {
+            // reuse the result_ that was already filled when executing the query
+            // for the purpose of row describe
+        }
+        else
+        {
+            PGresult * res = PQgetResult(session_.conn_); 
+            result_.reset(res);
+        }
+
+        process_result = result_.get_result() != NULL;
+    }
     else
     {
-        // The optimization based on the existing results
-        // from the row description can be performed only once.
-        // If the same statement is re-executed,
-        // it will be *really* re-executed, without reusing existing data.
-
-        justDescribed_ = false;
+        // default multi-row execution
+        
+        process_result = result_.check_for_data("Cannot execute query.");
     }
 
-    if (result_.check_for_data("Cannot execute query."))
+    justDescribed_ = false;
+    
+    if (process_result)
     {
         currentRow_ = 0;
         rowsToConsume_ = 0;
@@ -405,41 +615,98 @@ postgresql_statement_backend::execute(int number)
     }
     else
     {
-      return ef_no_data;
+        return ef_no_data;
     }
 }
 
 statement_backend::exec_fetch_result
 postgresql_statement_backend::fetch(int number)
 {
-    // Note: This function does not actually fetch anything from anywhere
+    if (single_row_mode_ && (number > 1))
+    {
+        throw soci_error("Bulk operations are not supported with single-row mode.");
+    }
+    
+    // Note:
+    // In the multi-row mode this function does not actually fetch anything from anywhere
     // - the data was already retrieved from the server in the execute()
     // function, and the actual consumption of this data will take place
     // in the postFetch functions, called for each into element.
     // Here, we only prepare for this to happen (to emulate "the Oracle way").
+    // In the single-row mode the fetch of single row of data is performed as expected.
 
     // forward the "cursor" from the last fetch
     currentRow_ += rowsToConsume_;
 
     if (currentRow_ >= numberOfRows_)
     {
-        // all rows were already consumed
-        return ef_no_data;
+        if (single_row_mode_)
+        {
+            PGresult* res = PQgetResult(session_.conn_);
+            result_.reset(res);
+            
+            if (res == NULL)
+            {
+                return ef_no_data;
+            }
+            
+            currentRow_ = 0;
+            rowsToConsume_ = 0;
+
+            numberOfRows_ = PQntuples(result_);
+            if (numberOfRows_ == 0)
+            {
+                return ef_no_data;
+            }
+            else
+            {
+                rowsToConsume_ = 1;
+                
+                return ef_success;
+            }
+        }
+        else
+        {
+            // default multi-row execution
+            
+            // all rows were already consumed
+            
+            return ef_no_data;
+        }
     }
     else
     {
         if (currentRow_ + number > numberOfRows_)
         {
-            rowsToConsume_ = numberOfRows_ - currentRow_;
+            if (single_row_mode_)
+            {
+                rowsToConsume_ = 1;
+            
+                return ef_success;
+            }
+            else
+            {
+                // default multi-row execution
+            
+                rowsToConsume_ = numberOfRows_ - currentRow_;
 
-            // this simulates the behaviour of Oracle
-            // - when EOF is hit, we return ef_no_data even when there are
-            // actually some rows fetched
-            return ef_no_data;
+                // this simulates the behaviour of Oracle
+                // - when EOF is hit, we return ef_no_data even when there are
+                // actually some rows fetched
+                return ef_no_data;
+            }
         }
         else
         {
-            rowsToConsume_ = number;
+            if (single_row_mode_)
+            {
+                rowsToConsume_ = 1;
+            }
+            else
+            {
+                rowsToConsume_ = number;
+            }
+            
             return ef_success;
         }
     }
@@ -512,9 +779,9 @@ void postgresql_statement_backend::describe_column(int colNum, data_type & type,
     case 2275: // cstring
     case 18:   // char
     case 1042: // bpchar
-    case 142: // xml
+    case 142:  // xml
     case 114:  // json
-    case 17: // bytea
+    case 17:   // bytea
     case 2950: // uuid
         type = dt_string;
         break;
@@ -557,7 +824,9 @@ void postgresql_statement_backend::describe_column(int colNum, data_type & type,
         else
         {
             std::stringstream message;
-            message << "unknown data type with typelem: " << typeOid << " for colNum: " << colNum << " with name: " << PQfname(result_, pos);
+            message << "unknown data type with typelem: " << typeOid
+                << " for colNum: " << colNum
+                << " with name: " << PQfname(result_, pos);
             throw soci_error(message.str());
         }
     }


### PR DESCRIPTION
I would like to propose a new feature for PostgreSQL - query execution in the single-row mode.
From the docs:

In addition to standard PostgreSQL connection parameters, the following can be set:

* `singlerow` or `singlerows`

For example:

    session sql(postgresql, "dbname=mydatabase singlerows=true");

If the `singlerows` parameter is set to `true` or `yes`, then queries will be executed in the single-row mode, which prevents the client library from loading full query result set into memory and instead fetches rows one by one, as they are requested by the statement's fetch() function. This mode can be of interest to those users who want to make their client applications more responsive (with more fine-grained operation) by avoiding potentially long blocking times when complete query results are loaded to client's memory.

Note that this feature is performance-oriented and as such has no influence on the base functionality - except that bulk queries are not supported as they do not make any sense in such operation mode.