### PR TITLE
Added support for portable DDL statements.

### DIFF
--- a/docs/statements.md
+++ b/docs/statements.md
@@ -5,6 +5,7 @@
 * [Bulk operations](#bulk)
 * [Stored procedures](#procedures)
 * [Transactions](#transactions)
+* [Portable DDL](#ddl)
 * [Metadata queries](#metadata)
 * [Basic logging support](#logging)
 
@@ -289,6 +290,58 @@ A typical usage pattern for this class might be:
     }
 
 With the above pattern the transaction is committed only when the code successfully reaches the end of block. If some exception is thrown before that, the scope will be left without reaching the final statement and the transaction object will automatically roll back in its destructor.
+
+### <a name="ddl"></a> Portable DDL
+
+SOCI supports some basic methods to construct portable DDL queries. That is, instead of writing explicit SQL statement for creating or modifying tables, it is possible to use dedicated SOCI functions, which prepare appropriate DDL statements behind the scenes, thus enabling the user application to create basic database structures in a way that is portable across different database servers. Note that the actual support for these functions depends on the actual backend implementation.
+
+It is possible to create a new table in a single statement:
+
+   sql.create_table("t1").column("i", soci::dt_integer).column("j", soci::dt_integer);
+
+Above, table "t1" will be created with two columns ("i", "j") of type integer.
+
+It is also possible to build such a statement piece by piece:
+
+   {
+      soci::ddl_type ddl = sql.create_table("t2");
+      ddl.column("i", soci::dt_integer);
+      ddl.column("j", soci::dt_integer);
+      ddl.column("k", soci::dt_integer)("not null");
+      ddl.primary_key("t2_pk", "j");
+   }
+
+The actual statement is executed at the end of above block, when the ddl object goes out of scope. The "not null" constraint was added to the definition of column "k" explicitly and in fact any piece of SQL can be inserted this way - with the obvious caveat of having limited portability (the "not null" piece seems to be universaly portable).
+
+Columns can be added to and dropped from already existing tables as well:
+
+   sql.add_column("t1", "k", soci::dt_integer);
+   // or with constraint:
+   //sql.add_column("t1", "k", soci::dt_integer)("not null");
+   
+   sql.drop_column("t1", "i");
+
+If needed, precision and scale can be defined with additional integer arguments to functions that create columns:
+
+   sql.add_column("t1", "s", soci::dt_string, precision);
+   sql.add_column("t1", "d", soci::dt_double, precision, scale);
+
+Tables with foreign keys to each other can be also created:
+
+   {
+      soci::ddl_type ddl = sql.create_table("t3");
+      ddl.column("x", soci::dt_integer);
+      ddl.column("y", soci::dt_integer);
+      ddl.foreign_key("t3_fk", "x", "t2", "j");
+   }
+
+Tables can be dropped, too:
+
+   sql.drop_table("t1");
+   sql.drop_table("t3");
+   sql.drop_table("t2");
+
+Note that due to the differences in the set of types that are actually supported on the target database server, the type mappings, as well as precision and scales, might be different, even in the way that makes them impossible to portably recover with metadata queries.
 
 ### <a name="metadata"></a> Metadata queries
 

--- a/docs/statements.md
+++ b/docs/statements.md
@@ -301,7 +301,7 @@ It is possible to create a new table in a single statement:
 
 Above, table "t1" will be created with two columns ("i", "j") of type integer.
 
-It is also possible to build such a statement piece by piece:
+It is also possible to build similar statements piece by piece, which is useful if the table structure is computed dynamically:
 
    {
       soci::ddl_type ddl = sql.create_table("t2");

--- a/include/soci/once-temp-type.h
+++ b/include/soci/once-temp-type.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2004-2008 Maciej Sobczak, Stephen Hutton
+// Copyright (C) 2004-2016 Maciej Sobczak, Stephen Hutton
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -108,6 +108,48 @@ private:
 };
 
 } // namespace details
+
+// Note: ddl_type is intended to be used just as once_type_type,
+// but since it can be also used directly (explicitly) by the user code,
+// it is declared outside of the namespace details.
+class SOCI_DECL ddl_type
+{
+public:
+
+    ddl_type(session & s);
+    ddl_type(const ddl_type & d);
+    ddl_type & operator=(const ddl_type & d);
+
+    ~ddl_type() SOCI_NOEXCEPT_FALSE;
+
+    void create_table(const std::string & tableName);
+    void add_column(const std::string & tableName,
+        const std::string & columnName, data_type dt,
+        int precision, int scale);
+    void alter_column(const std::string & tableName,
+        const std::string & columnName, data_type dt,
+        int precision, int scale);
+    void drop_column(const std::string & tableName,
+        const std::string & columnName);
+    ddl_type & column(const std::string & columnName, data_type dt,
+        int precision = 0, int scale = 0);
+    ddl_type & unique(const std::string & name,
+        const std::string & columnNames);
+    ddl_type & primary_key(const std::string & name,
+        const std::string & columnNames);
+    ddl_type & foreign_key(const std::string & name,
+        const std::string & columnNames,
+        const std::string & refTableName,
+        const std::string & refColumnNames);
+
+    ddl_type & operator()(const std::string & arbitrarySql);
+
+    void set_tail(const std::string & tail);
+
+private:
+    session * s_;
+    details::ref_counted_statement * rcst_;
+};
 
 } // namespace soci
 

--- a/include/soci/once-temp-type.h
+++ b/include/soci/once-temp-type.h
@@ -109,7 +109,7 @@ private:
 
 } // namespace details
 
-// Note: ddl_type is intended to be used just as once_type_type,
+// Note: ddl_type is intended to be used just as once_temp_type,
 // but since it can be also used directly (explicitly) by the user code,
 // it is declared outside of the namespace details.
 class SOCI_DECL ddl_type
@@ -144,6 +144,8 @@ public:
 
     ddl_type & operator()(const std::string & arbitrarySql);
 
+    // helper function for handling delimiters
+    // between various parts of DDL statements
     void set_tail(const std::string & tail);
 
 private:

--- a/include/soci/ref-counted-statement.h
+++ b/include/soci/ref-counted-statement.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2004-2008 Maciej Sobczak, Stephen Hutton
+// Copyright (C) 2004-2016 Maciej Sobczak, Stephen Hutton
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -37,6 +37,11 @@ public:
         {
             try
             {
+                if (tail_.empty() == false)
+                {
+                    accumulate(tail_);
+                }
+                
                 final_action();
             }
             catch (...)
@@ -52,6 +57,10 @@ public:
     template <typename T>
     void accumulate(T const & t) { get_query_stream() << t; }
 
+    void set_tail(const std::string & tail) { tail_ = tail; }
+    void set_need_comma(bool need_comma) { need_comma_ = need_comma; }
+    bool get_need_comma() const { return need_comma_; }
+
 protected:
     // this function allows to break the circular dependenc
     // between session and this class
@@ -60,6 +69,10 @@ protected:
     int refCount_;
 
     session & session_;
+
+    // used mainly for portable ddl
+    std::string tail_;
+    bool need_comma_;
 
 private:
     SOCI_NOT_COPYABLE(ref_counted_statement_base)

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2004-2008 Maciej Sobczak, Stephen Hutton
+// Copyright (C) 2004-2016 Maciej Sobczak, Stephen Hutton
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -83,7 +83,7 @@ public:
 
         cxx_details::auto_ptr<details::query_transformation_function> qtf(new details::query_transformation<T>(callback));
         set_query_transformation_(qtf);
-   }
+    }
 
     // support for basic logging
     void set_log_stream(std::ostream * s);
@@ -133,6 +133,20 @@ public:
     // this argument is bound as a regular "use" element.
     details::prepare_temp_type prepare_column_descriptions(std::string & table_name);
     
+    // Functions for basic portable DDL statements.
+
+    ddl_type create_table(const std::string & tableName);
+    void drop_table(const std::string & tableName);
+    void truncate_table(const std::string & tableName);
+    ddl_type add_column(const std::string & tableName,
+        const std::string & columnName, data_type dt,
+        int precision = 0, int scale = 0);
+    ddl_type alter_column(const std::string & tableName,
+        const std::string & columnName, data_type dt,
+        int precision = 0, int scale = 0);
+    ddl_type drop_column(const std::string & tableName,
+        const std::string & columnName);
+
     // for diagnostics and advanced users
     // (downcast it to expected back-end session class)
     details::session_backend * get_backend() { return backEnd_; }

--- a/src/core/once-temp-type.cpp
+++ b/src/core/once-temp-type.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2004-2008 Maciej Sobczak, Stephen Hutton
+// Copyright (C) 2004-2016 Maciej Sobczak, Stephen Hutton
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -44,4 +44,137 @@ once_temp_type & once_temp_type::operator,(into_type_ptr const & i)
 {
     rcst_->exchange(i);
     return *this;
+}
+
+ddl_type::ddl_type(session & s)
+    : s_(&s), rcst_(new ref_counted_statement(s))
+{
+    // this is the beginning of new query
+    s.get_query_stream().str("");
+}
+
+ddl_type::ddl_type(const ddl_type & d)
+    :rcst_(d.rcst_)
+{
+    rcst_->inc_ref();
+}
+
+ddl_type & ddl_type::operator=(const ddl_type & d)
+{
+    d.rcst_->inc_ref();
+    rcst_->dec_ref();
+    rcst_ = d.rcst_;
+
+    return *this;
+}
+
+ddl_type::~ddl_type() SOCI_NOEXCEPT_FALSE
+{
+    rcst_->dec_ref();
+}
+
+void ddl_type::create_table(const std::string & tableName)
+{
+    rcst_->accumulate(s_->get_backend()->create_table(tableName));
+}
+
+void ddl_type::add_column(const std::string & tableName,
+    const std::string & columnName, data_type dt,
+    int precision, int scale)
+{
+    rcst_->accumulate(s_->get_backend()->add_column(
+            tableName, columnName, dt, precision, scale));
+}
+
+void ddl_type::alter_column(const std::string & tableName,
+    const std::string & columnName, data_type dt,
+    int precision, int scale)
+{
+    rcst_->accumulate(s_->get_backend()->alter_column(
+            tableName, columnName, dt, precision, scale));
+}
+
+void ddl_type::drop_column(const std::string & tableName,
+    const std::string & columnName)
+{
+    rcst_->accumulate(s_->get_backend()->drop_column(
+            tableName, columnName));
+}
+
+ddl_type & ddl_type::column(const std::string & columnName, data_type dt,
+    int precision, int scale)
+{
+    if (rcst_->get_need_comma())
+    {
+        rcst_->accumulate(", ");
+    }
+        
+    rcst_->accumulate(s_->get_backend()->create_column(
+            columnName, dt, precision, scale));
+
+    rcst_->set_need_comma(true);
+        
+    return *this;
+}
+
+ddl_type & ddl_type::unique(const std::string & name,
+    const std::string & columnNames)
+{
+    if (rcst_->get_need_comma())
+    {
+        rcst_->accumulate(", ");
+    }
+        
+    rcst_->accumulate(s_->get_backend()->constraint_unique(
+            name, columnNames));
+
+    rcst_->set_need_comma(true);
+        
+    return *this;
+}
+
+ddl_type & ddl_type::primary_key(const std::string & name,
+    const std::string & columnNames)
+{
+    if (rcst_->get_need_comma())
+    {
+        rcst_->accumulate(", ");
+    }
+        
+    rcst_->accumulate(s_->get_backend()->constraint_primary_key(
+            name, columnNames));
+
+    rcst_->set_need_comma(true);
+        
+    return *this;
+}
+
+ddl_type & ddl_type::foreign_key(const std::string & name,
+    const std::string & columnNames,
+    const std::string & refTableName,
+    const std::string & refColumnNames)
+{
+    if (rcst_->get_need_comma())
+    {
+        rcst_->accumulate(", ");
+    }
+        
+    rcst_->accumulate(s_->get_backend()->constraint_foreign_key(
+            name, columnNames, refTableName, refColumnNames));
+
+    rcst_->set_need_comma(true);
+        
+    return *this;
+}
+
+ddl_type & ddl_type::operator()(const std::string & arbitrarySql)
+{
+    rcst_->accumulate(" " + arbitrarySql);
+
+    return *this;
+}
+
+void ddl_type::set_tail(const std::string & tail)
+{
+    rcst_->set_tail(tail);
 }

--- a/src/core/ref-counted-statement.cpp
+++ b/src/core/ref-counted-statement.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2004-2008 Maciej Sobczak, Stephen Hutton
+// Copyright (C) 2004-2016 Maciej Sobczak, Stephen Hutton
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -13,8 +13,7 @@ using namespace soci;
 using namespace soci::details;
 
 ref_counted_statement_base::ref_counted_statement_base(session& s)
-    : refCount_(1)
-    , session_(s)
+    : refCount_(1), session_(s), need_comma_(false)
 {
 }
 

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -374,6 +374,58 @@ details::prepare_temp_type session::prepare_column_descriptions(std::string & ta
     return prepare << backEnd_->get_column_descriptions_query(), use(table_name, "t");
 }
     
+ddl_type session::create_table(const std::string & tableName)
+{
+    ddl_type ddl(*this);
+
+    ddl.create_table(tableName);
+    ddl.set_tail(")");
+
+    return ddl;
+}
+
+void session::drop_table(const std::string & tableName)
+{
+    once << backEnd_->drop_table(tableName);
+}
+
+void session::truncate_table(const std::string & tableName)
+{
+    once << backEnd_->truncate_table(tableName);
+}
+
+ddl_type session::add_column(const std::string & tableName,
+    const std::string & columnName, data_type dt,
+    int precision, int scale)
+{
+    ddl_type ddl(*this);
+
+    ddl.add_column(tableName, columnName, dt, precision, scale);
+
+    return ddl;
+}
+
+ddl_type session::alter_column(const std::string & tableName,
+    const std::string & columnName, data_type dt,
+    int precision, int scale)
+{
+    ddl_type ddl(*this);
+
+    ddl.alter_column(tableName, columnName, dt, precision, scale);
+
+    return ddl;
+}
+
+ddl_type session::drop_column(const std::string & tableName,
+    const std::string & columnName)
+{
+    ddl_type ddl(*this);
+
+    ddl.drop_column(tableName, columnName);
+
+    return ddl;
+}
+
 std::string session::get_backend_name() const
 {
     ensureConnected(backEnd_);

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -687,6 +687,217 @@ TEST_CASE("PostgreSQL ORM cast", "[postgresql][orm]")
     sql << "select :a::int", use(v); // Must not throw an exception!
 }
 
+// Test the DDL and metadata functionality
+TEST_CASE("PostgreSQL DDL with metadata", "[postfresql][ddl]")
+{
+    soci::session sql(backEnd, connectString);
+
+    // note: prepare_column_descriptions expects l-value
+    std::string ddl_t1 = "ddl_t1";
+    std::string ddl_t2 = "ddl_t2";
+    std::string ddl_t3 = "ddl_t3";
+    
+    // single-expression variant:
+    sql.create_table(ddl_t1).column("i", soci::dt_integer).column("j", soci::dt_integer);
+
+    // check whether this table was created:
+    
+    bool ddl_t1_found = false;
+    bool ddl_t2_found = false;
+    bool ddl_t3_found = false;
+    std::string table_name;
+    soci::statement st = (sql.prepare_table_names(), into(table_name));
+    st.execute();
+    while (st.fetch())
+    {
+        if (table_name == ddl_t1) { ddl_t1_found = true; }
+        if (table_name == ddl_t2) { ddl_t2_found = true; }
+        if (table_name == ddl_t3) { ddl_t3_found = true; }
+    }
+
+    CHECK(ddl_t1_found);
+    CHECK(ddl_t2_found == false);
+    CHECK(ddl_t3_found == false);
+
+    // check whether ddl_t1 has the right structure:
+    
+    bool i_found = false;
+    bool j_found = false;
+    bool other_found = false;
+    soci::column_info ci;
+    soci::statement st1 = (sql.prepare_column_descriptions(ddl_t1), into(ci));
+    st1.execute();
+    while (st1.fetch())
+    {
+        if (ci.name == "i")
+        {
+            CHECK(ci.type == soci::dt_integer);
+            CHECK(ci.nullable);
+            i_found = true;
+        }
+        else if (ci.name == "j")
+        {
+            CHECK(ci.type == soci::dt_integer);
+            CHECK(ci.nullable);
+            j_found = true;
+        }
+        else
+        {
+            other_found = true;
+        }
+    }
+
+    CHECK(i_found);
+    CHECK(j_found);
+    CHECK(other_found == false);
+
+    // two more tables:
+    
+    // separately defined columns:
+    // (note: statement is executed when ddl object goes out of scope)
+    {
+        soci::ddl_type ddl = sql.create_table(ddl_t2);
+        ddl.column("i", soci::dt_integer);
+        ddl.column("j", soci::dt_integer);
+        ddl.column("k", soci::dt_integer)("not null");
+        ddl.primary_key("t2_pk", "j");
+    }
+
+    sql.add_column(ddl_t1, "k", soci::dt_integer);
+    sql.drop_column(ddl_t1, "i");
+
+    // or with constraint as in t2:
+    sql.add_column(ddl_t2, "m", soci::dt_integer)("not null");
+
+    // third table with a foreign key to the second one
+    {
+        soci::ddl_type ddl = sql.create_table(ddl_t3);
+        ddl.column("x", soci::dt_integer);
+        ddl.column("y", soci::dt_integer);
+        ddl.foreign_key("t3_fk", "x", ddl_t2, "j");
+    }
+
+    // check if all tables were created:
+    
+    ddl_t1_found = false;
+    ddl_t2_found = false;
+    ddl_t3_found = false;
+    soci::statement st2 = (sql.prepare_table_names(), into(table_name));
+    st2.execute();
+    while (st2.fetch())
+    {
+        if (table_name == ddl_t1) { ddl_t1_found = true; }
+        if (table_name == ddl_t2) { ddl_t2_found = true; }
+        if (table_name == ddl_t3) { ddl_t3_found = true; }
+    }
+
+    CHECK(ddl_t1_found);
+    CHECK(ddl_t2_found);
+    CHECK(ddl_t3_found);
+
+    // check if ddl_t1 has the right structure (it was altered):
+    
+    i_found = false;
+    j_found = false;
+    bool k_found = false;
+    other_found = false;
+    soci::statement st3 = (sql.prepare_column_descriptions(ddl_t1), into(ci));
+    st3.execute();
+    while (st3.fetch())
+    {
+        if (ci.name == "j")
+        {
+            CHECK(ci.type == soci::dt_integer);
+            CHECK(ci.nullable);
+            j_found = true;
+        }
+        else if (ci.name == "k")
+        {
+            CHECK(ci.type == soci::dt_integer);
+            CHECK(ci.nullable);
+            k_found = true;
+        }
+        else
+        {
+            other_found = true;
+        }
+    }
+
+    CHECK(i_found == false);
+    CHECK(j_found);
+    CHECK(k_found);
+    CHECK(other_found == false);
+    
+    // check if ddl_t2 has the right structure:
+    
+    i_found = false;
+    j_found = false;
+    k_found = false;
+    bool m_found = false;
+    other_found = false;
+    soci::statement st4 = (sql.prepare_column_descriptions(ddl_t2), into(ci));
+    st4.execute();
+    while (st4.fetch())
+    {
+        if (ci.name == "i")
+        {
+            CHECK(ci.type == soci::dt_integer);
+            CHECK(ci.nullable);
+            i_found = true;
+        }
+        else if (ci.name == "j")
+        {
+            CHECK(ci.type == soci::dt_integer);
+            CHECK(ci.nullable == false); // primary key
+            j_found = true;
+        }
+        else if (ci.name == "k")
+        {
+            CHECK(ci.type == soci::dt_integer);
+            CHECK(ci.nullable == false);
+            k_found = true;
+        }
+        else if (ci.name == "m")
+        {
+            CHECK(ci.type == soci::dt_integer);
+            CHECK(ci.nullable == false);
+            m_found = true;
+        }
+        else
+        {
+            other_found = true;
+        }
+    }
+
+    CHECK(i_found);
+    CHECK(j_found);
+    CHECK(k_found);
+    CHECK(m_found);
+    CHECK(other_found == false);
+
+    sql.drop_table(ddl_t1);
+    sql.drop_table(ddl_t3); // note: this must be dropped before ddl_t2
+    sql.drop_table(ddl_t2);
+    
+    // check if all tables were dropped:
+    
+    ddl_t1_found = false;
+    ddl_t2_found = false;
+    ddl_t3_found = false;
+    st2 = (sql.prepare_table_names(), into(table_name));
+    st2.execute();
+    while (st2.fetch())
+    {
+        if (table_name == ddl_t1) { ddl_t1_found = true; }
+        if (table_name == ddl_t2) { ddl_t2_found = true; }
+        if (table_name == ddl_t3) { ddl_t3_found = true; }
+    }
+
+    CHECK(ddl_t1_found == false);
+    CHECK(ddl_t2_found == false);
+    CHECK(ddl_t3_found == false);
+}
+
 //
 // Support for soci Common Tests
 //


### PR DESCRIPTION
This PR proposes a portable API for basic DDL statements.
The idea is best described by the diff of the docs/statement.md file.

Since PostgreSQL is the most standard with regard to its SQL dialect, it was chosen as a basis. Other backends do not have to do anything if they are compliant, otherwise they need to override methods from the base backend interface in order to generate appropriate target SQL code. This was already done for Oracle.
