### PR TITLE
Added failover callback for Oracle and PostgreSQL.

### DIFF
--- a/include/soci/callbacks.h
+++ b/include/soci/callbacks.h
@@ -1,0 +1,47 @@
+//
+// Copyright (C) 2015 Maciej Sobczak
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_CALLBACKS_H_INCLUDED
+#define SOCI_CALLBACKS_H_INCLUDED
+
+namespace soci
+{
+
+class session;
+
+// Simple callback interface for reporting failover events.
+// The meaning of each operation is intended to be portable,
+// but the behaviour details and parameters can be backend-specific.
+class SOCI_DECL failover_callback
+{
+public:
+
+    // Called when the failover operation has started,
+    // after discovering connectivity problems.
+    virtual void started() {}
+
+    // Called after successful failover and creating a new connection;
+    // the sql parameter denotes the new connection and allows the user
+    // to replay any initial sequence of commands (like session configuration).
+    virtual void finished(session & /* sql */) {}
+
+    // Called when the attempt to reconnect failed,
+    // if the user code sets the retry parameter to true,
+    // then new connection will be attempted;
+    // the newTarget connection string is a hint that can be ignored
+    // by external means.
+    virtual void failed(bool & /* out */ /* retry */,
+        std::string & /* out */ newTarget) {}
+
+    // Called when there was a failure that prevents further failover attempts.
+    virtual void aborted() {}
+};
+
+} // namespace soci
+
+#endif // SOCI_CALLBACKS_H_INCLUDED
+

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -36,6 +36,7 @@ class blob_backend;
 } // namespace details
 
 class connection_pool;
+class failover_callback;
 
 class SOCI_DECL session
 {
@@ -147,6 +148,12 @@ public:
     ddl_type drop_column(const std::string & tableName,
         const std::string & columnName);
 
+    // Sets the failover callback object.
+    void set_failover_callback(failover_callback & callback)
+    {
+        backEnd_->set_failover_callback(callback, *this);
+    }
+    
     // for diagnostics and advanced users
     // (downcast it to expected back-end session class)
     details::session_backend * get_backend() { return backEnd_; }

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -29,6 +29,7 @@ enum data_type
 enum indicator { i_ok, i_null, i_truncated };
 
 class session;
+class failover_callback;
 
 namespace details
 {
@@ -213,7 +214,7 @@ private:
 class session_backend
 {
 public:
-    session_backend() {}
+    session_backend() : failoverCallback_(NULL), session_(NULL) {}
     virtual ~session_backend() {}
 
     virtual void begin() = 0;
@@ -372,11 +373,20 @@ public:
             " references " + refTableName + " (" + refColumnNames + ")";
     }
     
+    void set_failover_callback(failover_callback & callback, session & sql)
+    {
+        failoverCallback_ = &callback;
+        session_ = &sql;
+    }
+
     virtual std::string get_backend_name() const = 0;
 
     virtual statement_backend* make_statement_backend() = 0;
     virtual rowid_backend* make_rowid_backend() = 0;
     virtual blob_backend* make_blob_backend() = 0;
+
+    failover_callback * failoverCallback_;
+    session * session_;
 
 private:
     SOCI_NOT_COPYABLE(session_backend)

--- a/src/backends/oracle/session.cpp
+++ b/src/backends/oracle/session.cpp
@@ -7,6 +7,7 @@
 
 #define SOCI_ORACLE_SOURCE
 #include "soci/oracle/soci-oracle.h"
+#include "soci/callbacks.h"
 #include "error.h"
 #include <cctype>
 #include <cstdio>
@@ -22,11 +23,109 @@ using namespace soci;
 using namespace soci::details;
 using namespace soci::details::oracle;
 
+namespace // unnamed
+{
+
+sb4 fo_callback(void * svchp, void * envhp, void * fo_ctx,
+    ub4 fo_type, ub4 fo_event)
+{
+    oracle_session_backend * backend =
+        static_cast<oracle_session_backend *>(fo_ctx);
+
+    failover_callback * callback = backend->failoverCallback_;
+    
+    if (callback != NULL)
+    {
+        session * sql = backend->session_;
+        
+        switch (fo_event)
+        {
+        case OCI_FO_BEGIN:
+            // failover operation was initiated
+    
+            try
+            {
+                callback->started();
+            }
+            catch (...)
+            {
+                // ignore exceptions from user callbacks
+            }
+            
+            break;
+            
+        case OCI_FO_END:
+            // failover was successful
+            
+            try
+            {
+                callback->finished(*sql);
+            }
+            catch (...)
+            {
+                // ignore exceptions from user callbacks
+            }
+
+            break;
+            
+        case OCI_FO_ABORT:
+            // failover was aborted with no possibility to recovery
+
+            try
+            {
+                callback->aborted();
+            }
+            catch (...)
+            {
+                // ignore exceptions from user callbacks
+            }
+
+            break;
+
+        case OCI_FO_ERROR:
+            // failover failed, but can be retried
+            
+            try
+            {
+                bool retry = false;
+                std::string newTarget;
+                callback->failed(retry, newTarget);
+                
+                // newTarget is ignored, as the new target
+                // is selected by Oracle client configuration
+                
+                if (retry)
+                {
+                    return OCI_FO_RETRY;
+                }
+            }
+            catch (...)
+            {
+                // ignore exceptions from user callbacks
+            }
+
+            break;
+
+        case OCI_FO_REAUTH:
+            // nothing interesting
+            break;
+            
+        default:
+            // ignore unknown callback types (if any)
+            break;
+        }
+    }
+
+    return 0;
+}
+
+} // unnamed namespace
+
 oracle_session_backend::oracle_session_backend(std::string const & serviceName,
     std::string const & userName, std::string const & password, int mode,
     bool decimals_as_strings, int charset, int ncharset)
-    : envhp_(NULL), srvhp_(NULL), errhp_(NULL), svchp_(NULL), usrhp_(NULL)
-      , decimals_as_strings_(decimals_as_strings)
+    : envhp_(NULL), srvhp_(NULL), errhp_(NULL), svchp_(NULL), usrhp_(NULL),
+      decimals_as_strings_(decimals_as_strings)
 {
     // assume service/user/password are utf8-compatible already
     const int defaultSourceCharSetId = 871;
@@ -147,6 +246,22 @@ oracle_session_backend::oracle_session_backend(std::string const & serviceName,
     // create the server context
     res = OCIServerAttach(srvhp_, errhp_,
         reinterpret_cast<text*>(nlsService), nlsServiceLen, OCI_DEFAULT);
+    if (res != OCI_SUCCESS)
+    {
+        std::string msg;
+        int errNum;
+        get_error_details(res, errhp_, msg, errNum);
+        clean_up();
+        throw oracle_soci_error(msg, errNum);
+    }
+
+    // register failover callback
+    OCIFocbkStruct fo;
+    fo.fo_ctx = this;
+    fo.callback_function = &fo_callback;
+
+    res = OCIAttrSet(srvhp_, static_cast<ub4>(OCI_HTYPE_SERVER),
+        &fo, 0, static_cast<ub4>(OCI_ATTR_FOCBK), errhp_);
     if (res != OCI_SUCCESS)
     {
         std::string msg;

--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -59,10 +59,11 @@ void throw_soci_error(PGconn * conn, const char * msg)
 
 postgresql_statement_backend::postgresql_statement_backend(
     postgresql_session_backend &session, bool single_row_mode)
-    : session_(session), single_row_mode_(single_row_mode)
-     , rowsAffectedBulk_(-1LL), justDescribed_(false)
-     , hasIntoElements_(false), hasVectorIntoElements_(false)
-     , hasUseElements_(false), hasVectorUseElements_(false)
+    : session_(session), single_row_mode_(single_row_mode),
+      result_(session, NULL),
+      rowsAffectedBulk_(-1LL), justDescribed_(false),
+      hasIntoElements_(false), hasVectorIntoElements_(false),
+      hasUseElements_(false), hasVectorUseElements_(false)
 {
 }
 
@@ -235,7 +236,7 @@ void postgresql_statement_backend::prepare(std::string const & query,
         {
             // default multi-row query execution
             
-            postgresql_result result(
+            postgresql_result result(session_,
                 PQprepare(session_.conn_, statementName.c_str(),
                     query_.c_str(), static_cast<int>(names_.size()), NULL));
             result.check_for_errors("Cannot prepare statement.");


### PR DESCRIPTION
Hi all,

In this PR I would like to propose the failover capability, implemented for Oracle (where it is supported by the native OCI interface, especially in RAC configurations) and PostgreSQL (where it is emulated by the backend).
The idea is that when the database connection gets broken, the backend can notify the user about that fact and allow him to guide the automated reconnection process. It is possible to instruct the backend to retry to the same or to another destination, as well as replay necessary session configuration sequence.

The comments for functions in new file callbacks.h explain it all.

(no, don't ask for unit tests...)