### PR TITLE
Bulk iterators

### DIFF
--- a/include/soci/into.h
+++ b/include/soci/into.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2004-2008 Maciej Sobczak, Stephen Hutton
+// Copyright (C) 2004-2016 Maciej Sobczak, Stephen Hutton
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -65,6 +65,24 @@ template <typename T>
 details::into_type_ptr into(T & t, std::size_t bufSize)
 {
     return details::into_type_ptr(new details::into_type<T>(t, bufSize));
+}
+
+// vectors with index ranges
+    
+template <typename T>
+details::into_type_ptr into(std::vector<T> & t,
+    std::size_t begin, std::size_t & end)
+{
+    return details::do_into(t, begin, &end,
+        typename details::exchange_traits<std::vector<T> >::type_family());
+}
+
+template <typename T>
+details::into_type_ptr into(std::vector<T> & t, std::vector<indicator> & ind,
+    std::size_t begin, std::size_t & end)
+{
+    return details::do_into(t, ind, begin, &end,
+        typename details::exchange_traits<std::vector<T> >::type_family());
 }
 
 } // namespace soci

--- a/include/soci/once-temp-type.h
+++ b/include/soci/once-temp-type.h
@@ -41,6 +41,8 @@ public:
     }
 
     once_temp_type & operator,(into_type_ptr const &);
+    once_temp_type & operator,(use_type_ptr const &);
+    
     template <typename T, typename Indicator>
     once_temp_type &operator,(into_container<T, Indicator> const &ic)
     {

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -149,16 +149,25 @@ struct postgresql_standard_into_type_backend : details::standard_into_type_backe
 struct postgresql_vector_into_type_backend : details::vector_into_type_backend
 {
     postgresql_vector_into_type_backend(postgresql_statement_backend & st)
-        : statement_(st) {}
+        : statement_(st), user_ranges_(true) {}
 
     virtual void define_by_pos(int & position,
-        void * data, details::exchange_type type);
+        void * data, details::exchange_type type)
+    {
+        user_ranges_ = false;
+        define_by_pos(position, data, type, 0, &end_var_);
+    }
+
+    virtual void define_by_pos(int & position,
+        void * data, details::exchange_type type,
+        std::size_t begin, std::size_t * end);
 
     virtual void pre_fetch();
     virtual void post_fetch(bool gotData, indicator * ind);
 
     virtual void resize(std::size_t sz);
-    virtual std::size_t size();
+    virtual std::size_t size(); // active size (might be lower than full vector size)
+    std::size_t full_size();    // actual size of the user-provided vector
 
     virtual void clean_up();
 
@@ -166,6 +175,10 @@ struct postgresql_vector_into_type_backend : details::vector_into_type_backend
 
     void * data_;
     details::exchange_type type_;
+    std::size_t begin_;
+    std::size_t * end_;
+    std::size_t end_var_;
+    bool user_ranges_;
     int position_;
 };
 
@@ -199,13 +212,29 @@ struct postgresql_vector_use_type_backend : details::vector_use_type_backend
         : statement_(st), position_(0) {}
 
     virtual void bind_by_pos(int & position,
-        void * data, details::exchange_type type);
+        void * data, details::exchange_type type)
+    {
+        bind_by_pos(position, data, type, 0, &end_var_);
+    }
+    
+    virtual void bind_by_pos(int & position,
+        void * data, details::exchange_type type,
+        std::size_t begin, std::size_t * end);
+    
     virtual void bind_by_name(std::string const & name,
-        void * data, details::exchange_type type);
+        void * data, details::exchange_type type)
+    {
+        bind_by_name(name, data, type, 0, &end_var_);
+    }
 
+    virtual void bind_by_name(const std::string & name,
+        void * data, details::exchange_type type,
+        std::size_t begin, std::size_t * end);
+    
     virtual void pre_use(indicator const * ind);
 
-    virtual std::size_t size();
+    virtual std::size_t size(); // active size (might be lower than full vector size)
+    std::size_t full_size();    // actual size of the user-provided vector
 
     virtual void clean_up();
 
@@ -213,6 +242,9 @@ struct postgresql_vector_use_type_backend : details::vector_use_type_backend
 
     void * data_;
     details::exchange_type type_;
+    std::size_t begin_;
+    std::size_t * end_;
+    std::size_t end_var_;
     int position_;
     std::string name_;
     std::vector<char *> buffers_;

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -83,6 +83,13 @@ public:
     vector_into_type_backend() {}
     virtual ~vector_into_type_backend() {}
 
+    virtual void define_by_pos(
+        int & /* position */, void * /* data */, exchange_type /* type */,
+        std::size_t /* begin */, std::size_t * /* end */)
+    {
+        throw soci_error("into bulk iterators are not supported with this backend");
+    }
+    
     virtual void define_by_pos(int& position, void* data, exchange_type type) = 0;
 
     virtual void pre_fetch() = 0;
@@ -126,8 +133,21 @@ public:
     virtual ~vector_use_type_backend() {}
 
     virtual void bind_by_pos(int& position, void* data, exchange_type type) = 0;
+    virtual void bind_by_pos(int& /* position */, void* /* data */, exchange_type /* type */,
+        std::size_t /* begin */, std::size_t * /* end */)
+    {
+        throw soci_error("use bulk iterators are not supported with this backend");
+    }
+
     virtual void bind_by_name(std::string const& name,
         void* data, exchange_type type) = 0;
+
+    virtual void bind_by_name(std::string const& /* name */,
+        void* /* data */, exchange_type /* type */,
+        std::size_t /* begin */, std::size_t * /* end */)
+    {
+        throw soci_error("use bulk iterators are not supported with this backend");
+    }
 
     virtual void pre_use(indicator const* ind) = 0;
 

--- a/include/soci/type-conversion.h
+++ b/include/soci/type-conversion.h
@@ -191,7 +191,7 @@ public:
         > base_type;
 
     conversion_into_type(std::vector<T> & value,
-        std::size_t begin, std::size_t * end)
+        std::size_t begin = 0, std::size_t * end = NULL)
         : details::base_vector_holder<T>(value.size()),
         into_type<base_type>(
             details::base_vector_holder<T>::vec_, ownInd_, begin, end),
@@ -205,7 +205,7 @@ public:
     }
 
     conversion_into_type(std::vector<T> & value, std::vector<indicator> & ind,
-        std::size_t begin, std::size_t * end)
+        std::size_t begin = 0, std::size_t * end = NULL)
         : details::base_vector_holder<T>(value.size()),
         into_type<base_type>(
             details::base_vector_holder<T>::vec_, ind, begin, end),
@@ -291,6 +291,20 @@ public:
         > base_type;
 
     conversion_use_type(std::vector<T> & value,
+        std::string const & name=std::string())
+        : details::base_vector_holder<T>(value.size()),
+        use_type<base_type>(
+            details::base_vector_holder<T>::vec_, ownInd_, 0, NULL, name),
+        value_(value),
+        ownInd_(),
+        ind_(ownInd_),
+        begin_(0),
+        end_(NULL),
+        user_ranges_(false)
+    {
+    }
+
+    conversion_use_type(std::vector<T> & value,
         std::size_t begin, std::size_t * end,
         std::string const & name=std::string())
         : details::base_vector_holder<T>(value.size()),
@@ -303,6 +317,20 @@ public:
         end_(end)
     {
         user_ranges_ = end != NULL;
+    }
+
+    conversion_use_type(std::vector<T> & value,
+        std::vector<indicator> & ind,
+        std::string const & name = std::string())
+        : details::base_vector_holder<T>(value.size()),
+        use_type<base_type>(
+            details::base_vector_holder<T>::vec_, ind, 0, NULL, name),
+        value_(value),
+        ind_(ind),
+        begin_(0),
+        end_(NULL),
+        user_ranges_(false)
+    {
     }
 
     conversion_use_type(std::vector<T> & value,

--- a/include/soci/use-type.h
+++ b/include/soci/use-type.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2004-2008 Maciej Sobczak, Stephen Hutton
+// Copyright (C) 2004-2016 Maciej Sobczak, Stephen Hutton
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -107,6 +107,20 @@ public:
         : data_(data)
         , type_(type)
         , ind_(NULL)
+        , begin_(0)
+        , end_(NULL)
+        , name_(name)
+        , backEnd_(NULL)
+    {}
+
+    vector_use_type(void* data, exchange_type type,
+        std::size_t begin, std::size_t * end,
+        std::string const& name = std::string())
+        : data_(data)
+        , type_(type)
+        , ind_(NULL)
+        , begin_(begin)
+        , end_(end)
         , name_(name)
         , backEnd_(NULL)
     {}
@@ -117,6 +131,21 @@ public:
         : data_(data)
         , type_(type)
         , ind_(&ind)
+        , begin_(0)
+        , end_(NULL)
+        , name_(name)
+        , backEnd_(NULL)
+    {}
+
+    vector_use_type(void* data, exchange_type type,
+        std::vector<indicator> const& ind,
+        std::size_t begin, std::size_t * end,
+        std::string const& name = std::string())
+        : data_(data)
+        , type_(type)
+        , ind_(&ind)
+        , begin_(begin)
+        , end_(end)
         , name_(name)
         , backEnd_(NULL)
     {}
@@ -135,6 +164,8 @@ private:
     void* data_;
     exchange_type type_;
     std::vector<indicator> const* ind_;
+    std::size_t begin_;
+    std::size_t * end_;
     std::string name_;
 
     vector_use_type_backend * backEnd_;
@@ -179,9 +210,21 @@ public:
             static_cast<exchange_type>(exchange_traits<T>::x_type), name)
     {}
 
+    use_type(std::vector<T>& v, std::size_t begin, std::size_t * end,
+        std::string const& name = std::string())
+        : vector_use_type(&v,
+            static_cast<exchange_type>(exchange_traits<T>::x_type), begin, end, name)
+    {}
+
     use_type(std::vector<T> const& v, std::string const& name = std::string())
         : vector_use_type(const_cast<std::vector<T>*>(&v),
             static_cast<exchange_type>(exchange_traits<T>::x_type), name)
+    {}
+
+    use_type(std::vector<T> const& v, std::size_t begin, std::size_t * end,
+        std::string const& name = std::string())
+        : vector_use_type(const_cast<std::vector<T>*>(&v),
+            static_cast<exchange_type>(exchange_traits<T>::x_type), begin, end, name)
     {}
 
     use_type(std::vector<T>& v, std::vector<indicator> const& ind,
@@ -190,10 +233,22 @@ public:
             static_cast<exchange_type>(exchange_traits<T>::x_type), ind, name)
     {}
 
+    use_type(std::vector<T>& v, std::vector<indicator> const& ind,
+        std::size_t begin, std::size_t * end, std::string const& name = std::string())
+        : vector_use_type(&v,
+            static_cast<exchange_type>(exchange_traits<T>::x_type), ind, begin, end, name)
+    {}
+
     use_type(std::vector<T> const& v, std::vector<indicator> const& ind,
         std::string const& name = std::string())
         : vector_use_type(const_cast<std::vector<T> *>(&v),
             static_cast<exchange_type>(exchange_traits<T>::x_type), ind, name)
+    {}
+
+    use_type(std::vector<T> const& v, std::vector<indicator> const& ind,
+        std::size_t begin, std::size_t * end, std::string const& name = std::string())
+        : vector_use_type(const_cast<std::vector<T> *>(&v),
+            static_cast<exchange_type>(exchange_traits<T>::x_type), ind, begin, end, name)
     {}
 };
 
@@ -237,6 +292,42 @@ use_type_ptr do_use(T const & t, std::vector<indicator> & ind,
     std::string const & name, basic_type_tag)
 {
     return use_type_ptr(new use_type<T>(t, ind, name));
+}
+
+template <typename T>
+use_type_ptr do_use(std::vector<T> & t,
+    std::size_t begin, std::size_t * end,
+    std::string const & name, basic_type_tag)
+{
+    return use_type_ptr(
+        new use_type<std::vector<T> >(t, begin, end, name));
+}
+
+template <typename T>
+use_type_ptr do_use(const std::vector<T> & t,
+    std::size_t begin, std::size_t * end,
+    std::string const & name, basic_type_tag)
+{
+    return use_type_ptr(
+        new use_type<std::vector<T> >(t, begin, end, name));
+}
+
+template <typename T>
+use_type_ptr do_use(std::vector<T> & t, std::vector<indicator> & ind,
+    std::size_t begin, std::size_t * end,
+    std::string const & name, basic_type_tag)
+{
+    return use_type_ptr(
+        new use_type<std::vector<T> >(t, ind, begin, end, name));
+}
+
+template <typename T>
+use_type_ptr do_use(const std::vector<T> & t, std::vector<indicator> & ind,
+    std::size_t begin, std::size_t * end,
+    std::string const & name, basic_type_tag)
+{
+    return use_type_ptr(
+        new use_type<std::vector<T> >(t, ind, begin, end, name));
 }
 
 } // namespace details

--- a/include/soci/use.h
+++ b/include/soci/use.h
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2004-2008 Maciej Sobczak, Stephen Hutton
+// Copyright (C) 2004-2016 Maciej Sobczak, Stephen Hutton
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -72,6 +72,44 @@ template <typename T>
 details::use_container<std::vector<T>, details::no_indicator >
     use(std::vector<T> &t, const std::string &name = std::string())
 { return details::use_container<std::vector<T>, details::no_indicator>(t, name); }
+
+// vectors with index ranges
+
+template <typename T>
+details::use_type_ptr use(std::vector<T> & t,
+    std::size_t begin, std::size_t & end,
+    const std::string &name = std::string())
+{
+    return details::do_use(t, begin, &end, name,
+        typename details::exchange_traits<std::vector<T> >::type_family());
+}
+
+template <typename T>
+details::use_type_ptr use(const std::vector<T> & t,
+    std::size_t begin, std::size_t & end,
+    const std::string &name = std::string())
+{
+    return details::do_use(t, begin, &end, name,
+        typename details::exchange_traits<std::vector<T> >::type_family());
+}
+
+template <typename T>
+details::use_type_ptr use(std::vector<T> & t, std::vector<indicator> & ind,
+    std::size_t begin, std::size_t & end,
+    const std::string &name = std::string())
+{
+    return details::do_use(t, ind, begin, &end, name,
+        typename details::exchange_traits<std::vector<T> >::type_family());
+}
+
+template <typename T>
+details::use_type_ptr use(const std::vector<T> & t, std::vector<indicator> & ind,
+    std::size_t begin, std::size_t & end,
+    const std::string &name = std::string())
+{
+    return details::do_use(t, ind, begin, &end, name,
+        typename details::exchange_traits<std::vector<T> >::type_family());
+}
 
 } // namespace soci
 

--- a/src/backends/oracle/vector-into-type.cpp
+++ b/src/backends/oracle/vector-into-type.cpp
@@ -41,13 +41,19 @@ void oracle_vector_into_type_backend::prepare_indicators(std::size_t size)
 }
 
 void oracle_vector_into_type_backend::define_by_pos(
-    int &position, void *data, exchange_type type)
+    int & position, void * data, exchange_type type,
+    std::size_t begin, std::size_t * end)
 {
     data_ = data; // for future reference
     type_ = type; // for future reference
+    begin_ = begin;
+    end_ = end;
 
-    ub2 oracleType = 0; // dummy initialization to please the compiler
-    sb4 size = 0;       // also dummy
+    end_var_ = full_size();
+
+    ub2 oracleType = 0;  // dummy initialization to please the compiler
+    sb4 elementSize = 0; // also dummy
+    void * dataBuf;
 
     switch (type)
     {
@@ -55,41 +61,41 @@ void oracle_vector_into_type_backend::define_by_pos(
     case x_char:
         {
             oracleType = SQLT_AFC;
-            size = sizeof(char);
+            elementSize = sizeof(char);
             std::vector<char> *vp = static_cast<std::vector<char> *>(data);
             std::vector<char> &v(*vp);
-            prepare_indicators(v.size());
-            data = &v[0];
+            prepare_indicators(size());
+            dataBuf = &v[begin_];
         }
         break;
     case x_short:
         {
             oracleType = SQLT_INT;
-            size = sizeof(short);
+            elementSize = sizeof(short);
             std::vector<short> *vp = static_cast<std::vector<short> *>(data);
             std::vector<short> &v(*vp);
-            prepare_indicators(v.size());
-            data = &v[0];
+            prepare_indicators(size());
+            dataBuf = &v[begin_];
         }
         break;
     case x_integer:
         {
             oracleType = SQLT_INT;
-            size = sizeof(int);
+            elementSize = sizeof(int);
             std::vector<int> *vp = static_cast<std::vector<int> *>(data);
             std::vector<int> &v(*vp);
-            prepare_indicators(v.size());
-            data = &v[0];
+            prepare_indicators(size());
+            dataBuf = &v[begin_];
         }
         break;
     case x_double:
         {
             oracleType = statement_.session_.get_double_sql_type();
-            size = sizeof(double);
+            elementSize = sizeof(double);
             std::vector<double> *vp = static_cast<std::vector<double> *>(data);
             std::vector<double> &v(*vp);
-            prepare_indicators(v.size());
-            data = &v[0];
+            prepare_indicators(size());
+            dataBuf = &v[begin_];
         }
         break;
 
@@ -98,61 +104,57 @@ void oracle_vector_into_type_backend::define_by_pos(
     case x_long_long:
         {
             oracleType = SQLT_STR;
-            std::vector<long long> *v
-                = static_cast<std::vector<long long> *>(data);
+            const std::size_t vecSize = size();
             colSize_ = 100; // arbitrary buffer size for each entry
-            std::size_t const bufSize = colSize_ * v->size();
+            std::size_t const bufSize = colSize_ * vecSize;
             buf_ = new char[bufSize];
 
-            prepare_indicators(v->size());
+            prepare_indicators(vecSize);
 
-            size = static_cast<sb4>(colSize_);
-            data = buf_;
+            elementSize = static_cast<sb4>(colSize_);
+            dataBuf = buf_;
         }
         break;
     case x_unsigned_long_long:
         {
             oracleType = SQLT_STR;
-            std::vector<unsigned long long> *v
-                = static_cast<std::vector<unsigned long long> *>(data);
+            const std::size_t vecSize = size();
             colSize_ = 100; // arbitrary buffer size for each entry
-            std::size_t const bufSize = colSize_ * v->size();
+            std::size_t const bufSize = colSize_ * vecSize;
             buf_ = new char[bufSize];
 
-            prepare_indicators(v->size());
+            prepare_indicators(vecSize);
 
-            size = static_cast<sb4>(colSize_);
-            data = buf_;
+            elementSize = static_cast<sb4>(colSize_);
+            dataBuf = buf_;
         }
         break;
     case x_stdstring:
         {
             oracleType = SQLT_CHR;
-            std::vector<std::string> *v
-                = static_cast<std::vector<std::string> *>(data);
+            const std::size_t vecSize = size();
             colSize_ = statement_.column_size(position) + 1;
-            std::size_t bufSize = colSize_ * v->size();
+            std::size_t bufSize = colSize_ * vecSize;
             buf_ = new char[bufSize];
 
-            prepare_indicators(v->size());
+            prepare_indicators(vecSize);
 
-            size = static_cast<sb4>(colSize_);
-            data = buf_;
+            elementSize = static_cast<sb4>(colSize_);
+            dataBuf = buf_;
         }
         break;
     case x_stdtm:
         {
             oracleType = SQLT_DAT;
-            std::vector<std::tm> *v
-                = static_cast<std::vector<std::tm> *>(data);
+            const std::size_t vecSize = size();
 
-            prepare_indicators(v->size());
+            prepare_indicators(vecSize);
 
-            size = 7; // 7 is the size of SQLT_DAT
-            std::size_t bufSize = size * v->size();
+            elementSize = 7; // 7 is the size of SQLT_DAT
+            std::size_t bufSize = elementSize * vecSize;
 
             buf_ = new char[bufSize];
-            data = buf_;
+            dataBuf = buf_;
         }
         break;
 
@@ -163,7 +165,7 @@ void oracle_vector_into_type_backend::define_by_pos(
 
     sword res = OCIDefineByPos(statement_.stmtp_, &defnp_,
         statement_.session_.errhp_,
-        position++, data, size, oracleType,
+        position++, dataBuf, elementSize, oracleType,
         indOCIHolders_, &sizes_[0], &rCodes_[0], OCI_DEFAULT);
     if (res != OCI_SUCCESS)
     {
@@ -176,7 +178,7 @@ void oracle_vector_into_type_backend::pre_fetch()
     // nothing to do for the supported types
 }
 
-void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
+void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator * ind)
 {
     if (gotData)
     {
@@ -191,12 +193,12 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             std::vector<std::string> &v(*vp);
 
             char *pos = buf_;
-            std::size_t const vsize = v.size();
-            for (std::size_t i = 0; i != vsize; ++i)
+            std::size_t const vecSize = size();
+            for (std::size_t i = 0; i != vecSize; ++i)
             {
                 if (indOCIHolderVec_[i] != -1)
                 {
-                    v[i].assign(pos, sizes_[i]);
+                    v[begin_ + i].assign(pos, sizes_[i]);
                 }
                 pos += colSize_;
             }
@@ -209,12 +211,12 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             std::vector<long long> &v(*vp);
 
             char *pos = buf_;
-            std::size_t const vsize = v.size();
-            for (std::size_t i = 0; i != vsize; ++i)
+            std::size_t const vecSize = size();
+            for (std::size_t i = 0; i != vecSize; ++i)
             {
                 if (indOCIHolderVec_[i] != -1)
                 {
-                    v[i] = std::strtoll(pos, NULL, 10);
+                    v[begin_ + i] = std::strtoll(pos, NULL, 10);
                 }
                 pos += colSize_;
             }
@@ -227,12 +229,12 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             std::vector<unsigned long long> &v(*vp);
 
             char *pos = buf_;
-            std::size_t const vsize = v.size();
-            for (std::size_t i = 0; i != vsize; ++i)
+            std::size_t const vecSize = size();
+            for (std::size_t i = 0; i != vecSize; ++i)
             {
                 if (indOCIHolderVec_[i] != -1)
                 {
-                    v[i] = std::strtoull(pos, NULL, 10);
+                    v[begin_ + i] = std::strtoull(pos, NULL, 10);
                 }
                 pos += colSize_;
             }
@@ -245,8 +247,8 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             std::vector<std::tm> &v(*vp);
 
             ub1 *pos = reinterpret_cast<ub1*>(buf_);
-            std::size_t const vsize = v.size();
-            for (std::size_t i = 0; i != vsize; ++i)
+            std::size_t const vecSize = size();
+            for (std::size_t i = 0; i != vecSize; ++i)
             {
                 if (indOCIHolderVec_[i] == -1)
                 {
@@ -262,7 +264,8 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
                     int const minute = *pos++ - 1;
                     int const second = *pos++ - 1;
 
-                    details::mktime_from_ymdhms(v[i], year, month, day, hour, minute, second);
+                    details::mktime_from_ymdhms(v[begin_ + i],
+                        year, month, day, hour, minute, second);
                 }
             }
         }
@@ -280,15 +283,15 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             {
                 if (indOCIHolderVec_[i] == 0)
                 {
-                    ind[i] = i_ok;
+                    ind[begin_ + i] = i_ok;
                 }
                 else if (indOCIHolderVec_[i] == -1)
                 {
-                    ind[i] = i_null;
+                    ind[begin_ + i] = i_null;
                 }
                 else
                 {
-                    ind[i] = i_truncated;
+                    ind[begin_ + i] = i_truncated;
                 }
             }
         }
@@ -314,70 +317,103 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
 
 void oracle_vector_into_type_backend::resize(std::size_t sz)
 {
-    switch (type_)
+    if (user_ranges_)
     {
-    // simple cases
-    case x_char:
-        {
-            std::vector<char> *v = static_cast<std::vector<char> *>(data_);
-            v->resize(sz);
-        }
-        break;
-    case x_short:
-        {
-            std::vector<short> *v = static_cast<std::vector<short> *>(data_);
-            v->resize(sz);
-        }
-        break;
-    case x_integer:
-        {
-            std::vector<int> *v = static_cast<std::vector<int> *>(data_);
-            v->resize(sz);
-        }
-        break;
-    case x_long_long:
-        {
-            std::vector<long long> *v
-                = static_cast<std::vector<long long> *>(data_);
-            v->resize(sz);
-        }
-        break;
-    case x_unsigned_long_long:
-        {
-            std::vector<unsigned long long> *v
-                = static_cast<std::vector<unsigned long long> *>(data_);
-            v->resize(sz);
-        }
-        break;
-    case x_double:
-        {
-            std::vector<double> *v
-                = static_cast<std::vector<double> *>(data_);
-            v->resize(sz);
-        }
-        break;
-    case x_stdstring:
-        {
-            std::vector<std::string> *v
-                = static_cast<std::vector<std::string> *>(data_);
-            v->resize(sz);
-        }
-        break;
-    case x_stdtm:
-        {
-            std::vector<std::tm> *v
-                = static_cast<std::vector<std::tm> *>(data_);
-            v->resize(sz);
-        }
-        break;
-
-    case x_statement: break; // not supported
-    case x_rowid:     break; // not supported
-    case x_blob:      break; // not supported
+        // resize only in terms of user-provided ranges (below)
     }
+    else
+    {
+        switch (type_)
+        {
+            // simple cases
+        case x_char:
+            {
+                std::vector<char> *v = static_cast<std::vector<char> *>(data_);
+                v->resize(sz);
+            }
+            break;
+        case x_short:
+            {
+                std::vector<short> *v = static_cast<std::vector<short> *>(data_);
+                v->resize(sz);
+            }
+            break;
+        case x_integer:
+            {
+                std::vector<int> *v = static_cast<std::vector<int> *>(data_);
+                v->resize(sz);
+            }
+            break;
+        case x_long_long:
+            {
+                std::vector<long long> *v
+                    = static_cast<std::vector<long long> *>(data_);
+                v->resize(sz);
+            }
+            break;
+        case x_unsigned_long_long:
+            {
+                std::vector<unsigned long long> *v
+                    = static_cast<std::vector<unsigned long long> *>(data_);
+                v->resize(sz);
+            }
+            break;
+        case x_double:
+            {
+                std::vector<double> *v
+                    = static_cast<std::vector<double> *>(data_);
+                v->resize(sz);
+            }
+            break;
+        case x_stdstring:
+            {
+                std::vector<std::string> *v
+                    = static_cast<std::vector<std::string> *>(data_);
+                v->resize(sz);
+            }
+            break;
+        case x_stdtm:
+            {
+                std::vector<std::tm> *v
+                    = static_cast<std::vector<std::tm> *>(data_);
+                v->resize(sz);
+            }
+            break;
+
+        case x_statement: break; // not supported
+        case x_rowid:     break; // not supported
+        case x_blob:      break; // not supported
+        }
+
+        end_var_ = sz;
+    }
+
+    // resize ranges, either user-provided or internally managed
+    *end_ = begin_ + sz;
 }
 
 std::size_t oracle_vector_into_type_backend::size()
+{
+    // as a special error-detection measure, check if the actual vector size
+    // was changed since the original bind (when it was stored in end_var_):
+    const std::size_t actual_size = full_size();
+    if (actual_size != end_var_)
+    {
+        // ... and in that case return the actual size
+        return actual_size;
+    }
+    
+    if (end_ != NULL && *end_ != 0)
+    {
+        return *end_ - begin_;
+    }
+    else
+    {
+        return end_var_;
+    }
+}
+
+std::size_t oracle_vector_into_type_backend::full_size()
 {
     std::size_t sz = 0; // dummy initialization to please the compiler
     switch (type_)

--- a/src/backends/oracle/vector-use-type.cpp
+++ b/src/backends/oracle/vector-use-type.cpp
@@ -36,7 +36,7 @@ void oracle_vector_use_type_backend::prepare_indicators(std::size_t size)
 }
 
 void oracle_vector_use_type_backend::prepare_for_bind(
-    void *&data, sb4 &size, ub2 &oracleType)
+    void * & data, sb4 & elementSize, ub2 & oracleType)
 {
     switch (type_)
     {
@@ -44,41 +44,41 @@ void oracle_vector_use_type_backend::prepare_for_bind(
     case x_char:
         {
             oracleType = SQLT_AFC;
-            size = sizeof(char);
-            std::vector<char> *vp = static_cast<std::vector<char> *>(data);
+            elementSize = sizeof(char);
+            std::vector<char> *vp = static_cast<std::vector<char> *>(data_);
             std::vector<char> &v(*vp);
-            prepare_indicators(v.size());
-            data = &v[0];
+            prepare_indicators(size());
+            data = &v[begin_];
         }
         break;
     case x_short:
         {
             oracleType = SQLT_INT;
-            size = sizeof(short);
-            std::vector<short> *vp = static_cast<std::vector<short> *>(data);
+            elementSize = sizeof(short);
+            std::vector<short> *vp = static_cast<std::vector<short> *>(data_);
             std::vector<short> &v(*vp);
-            prepare_indicators(v.size());
-            data = &v[0];
+            prepare_indicators(size());
+            data = &v[begin_];
         }
         break;
     case x_integer:
         {
             oracleType = SQLT_INT;
-            size = sizeof(int);
-            std::vector<int> *vp = static_cast<std::vector<int> *>(data);
+            elementSize = sizeof(int);
+            std::vector<int> *vp = static_cast<std::vector<int> *>(data_);
             std::vector<int> &v(*vp);
-            prepare_indicators(v.size());
-            data = &v[0];
+            prepare_indicators(size());
+            data = &v[begin_];
         }
         break;
     case x_double:
         {
             oracleType = statement_.session_.get_double_sql_type();
-            size = sizeof(double);
-            std::vector<double> *vp = static_cast<std::vector<double> *>(data);
+            elementSize = sizeof(double);
+            std::vector<double> *vp = static_cast<std::vector<double> *>(data_);
             std::vector<double> &v(*vp);
-            prepare_indicators(v.size());
-            data = &v[0];
+            prepare_indicators(size());
+            data = &v[begin_];
         }
         break;
 
@@ -86,36 +86,28 @@ void oracle_vector_use_type_backend::prepare_for_bind(
 
     case x_long_long:
         {
-            std::vector<long long> *vp
-                = static_cast<std::vector<long long> *>(data);
-            std::vector<long long> &v(*vp);
-
-            std::size_t const vecSize = v.size();
+            std::size_t const vecSize = size();
             std::size_t const entrySize = 100; // arbitrary
             std::size_t const bufSize = entrySize * vecSize;
             buf_ = new char[bufSize];
 
             oracleType = SQLT_STR;
             data = buf_;
-            size = entrySize;
+            elementSize = entrySize;
 
             prepare_indicators(vecSize);
         }
         break;
     case x_unsigned_long_long:
         {
-            std::vector<unsigned long long> *vp
-                = static_cast<std::vector<unsigned long long> *>(data);
-            std::vector<unsigned long long> &v(*vp);
-
-            std::size_t const vecSize = v.size();
+            std::size_t const vecSize = size();
             std::size_t const entrySize = 100; // arbitrary
             std::size_t const bufSize = entrySize * vecSize;
             buf_ = new char[bufSize];
 
             oracleType = SQLT_STR;
             data = buf_;
-            size = entrySize;
+            elementSize = entrySize;
 
             prepare_indicators(vecSize);
         }
@@ -123,15 +115,15 @@ void oracle_vector_use_type_backend::prepare_for_bind(
     case x_stdstring:
         {
             std::vector<std::string> *vp
-                = static_cast<std::vector<std::string> *>(data);
+                = static_cast<std::vector<std::string> *>(data_);
             std::vector<std::string> &v(*vp);
 
             std::size_t maxSize = 0;
-            std::size_t const vecSize = v.size();
+            std::size_t const vecSize = size();
             prepare_indicators(vecSize);
             for (std::size_t i = 0; i != vecSize; ++i)
             {
-                std::size_t sz = v[i].length();
+                std::size_t sz = v[begin_ + i].length();
                 sizes_.push_back(static_cast<ub2>(sz));
                 maxSize = sz > maxSize ? sz : maxSize;
             }
@@ -140,28 +132,26 @@ void oracle_vector_use_type_backend::prepare_for_bind(
             char *pos = buf_;
             for (std::size_t i = 0; i != vecSize; ++i)
             {
-                strncpy(pos, v[i].c_str(), v[i].length());
+                strncpy(pos, v[begin_ + i].c_str(), v[begin_ + i].length());
                 pos += maxSize;
             }
 
             oracleType = SQLT_CHR;
             data = buf_;
-            size = static_cast<sb4>(maxSize);
+            elementSize = static_cast<sb4>(maxSize);
         }
         break;
     case x_stdtm:
         {
-            std::vector<std::tm> *vp
-                = static_cast<std::vector<std::tm> *>(data);
-
-            prepare_indicators(vp->size());
+            std::size_t const vecSize = size();
+            prepare_indicators(vecSize);
 
             sb4 const dlen = 7; // size of SQLT_DAT
-            buf_ = new char[dlen * vp->size()];
+            buf_ = new char[dlen * vecSize];
 
             oracleType = SQLT_DAT;
             data = buf_;
-            size = dlen;
+            elementSize = dlen;
         }
         break;
 
@@ -171,16 +161,22 @@ void oracle_vector_use_type_backend::prepare_for_bind(
     }
 }
 
-void oracle_vector_use_type_backend::bind_by_pos(int &position,
-        void *data, exchange_type type)
+void oracle_vector_use_type_backend::bind_by_pos(int & position,
+    void * data, exchange_type type,
+    std::size_t begin, std::size_t * end)
 {
     data_ = data; // for future reference
     type_ = type; // for future reference
+    begin_ = begin;
+    end_ = end;
 
+    end_var_ = full_size();
+    
     ub2 oracleType;
-    sb4 size;
+    sb4 elementSize;
+    void * dataBuf;
 
-    prepare_for_bind(data, size, oracleType);
+    prepare_for_bind(dataBuf, elementSize, oracleType);
 
     ub2 *sizesP = 0; // used only for std::string
     if (type == x_stdstring)
@@ -190,7 +186,7 @@ void oracle_vector_use_type_backend::bind_by_pos(int &position,
 
     sword res = OCIBindByPos(statement_.stmtp_, &bindp_,
         statement_.session_.errhp_,
-        position++, data, size, oracleType,
+        position++, dataBuf, elementSize, oracleType,
         indOCIHolders_, sizesP, 0, 0, 0, OCI_DEFAULT);
     if (res != OCI_SUCCESS)
     {
@@ -199,15 +195,21 @@ void oracle_vector_use_type_backend::bind_by_pos(int &position,
 }
 
 void oracle_vector_use_type_backend::bind_by_name(
-    std::string const &name, void *data, exchange_type type)
+    std::string const &name, void *data, exchange_type type,
+    std::size_t begin, std::size_t * end)
 {
     data_ = data; // for future reference
     type_ = type; // for future reference
+    begin_ = begin;
+    end_ = end;
 
+    end_var_ = full_size();
+    
     ub2 oracleType;
-    sb4 size;
+    sb4 elementSize;
+    void * dataBuf;
 
-    prepare_for_bind(data, size, oracleType);
+    prepare_for_bind(dataBuf, elementSize, oracleType);
 
     ub2 *sizesP = 0; // used only for std::string
     if (type == x_stdstring)
@@ -219,7 +221,7 @@ void oracle_vector_use_type_backend::bind_by_name(
         statement_.session_.errhp_,
         reinterpret_cast<text*>(const_cast<char*>(name.c_str())),
         static_cast<sb4>(name.size()),
-        data, size, oracleType,
+        dataBuf, elementSize, oracleType,
         indOCIHolders_, sizesP, 0, 0, 0, OCI_DEFAULT);
     if (res != OCI_SUCCESS)
     {
@@ -244,10 +246,10 @@ void oracle_vector_use_type_backend::pre_use(indicator const *ind)
 
         char *pos = buf_;
         std::size_t const entrySize = 100; // arbitrary, but consistent
-        std::size_t const vecSize = v.size();
+        std::size_t const vecSize = size();
         for (std::size_t i = 0; i != vecSize; ++i)
         {
-            snprintf(pos, entrySize, "%" LL_FMT_FLAGS "d", v[i]);
+            snprintf(pos, entrySize, "%" LL_FMT_FLAGS "d", v[begin_ + i]);
             pos += entrySize;
         }
     }
@@ -259,10 +261,10 @@ void oracle_vector_use_type_backend::pre_use(indicator const *ind)
 
         char *pos = buf_;
         std::size_t const entrySize = 100; // arbitrary, but consistent
-        std::size_t const vecSize = v.size();
+        std::size_t const vecSize = size();
         for (std::size_t i = 0; i != vecSize; ++i)
         {
-            snprintf(pos, entrySize, "%" LL_FMT_FLAGS "u", v[i]);
+            snprintf(pos, entrySize, "%" LL_FMT_FLAGS "u", v[begin_ + i]);
             pos += entrySize;
         }
     }
@@ -273,26 +275,28 @@ void oracle_vector_use_type_backend::pre_use(indicator const *ind)
         std::vector<std::tm> &v(*vp);
 
         ub1* pos = reinterpret_cast<ub1*>(buf_);
-        std::size_t const vsize = v.size();
-        for (std::size_t i = 0; i != vsize; ++i)
+        std::size_t const vecSize = size();
+        for (std::size_t i = 0; i != vecSize; ++i)
         {
-            *pos++ = static_cast<ub1>(100 + (1900 + v[i].tm_year) / 100);
-            *pos++ = static_cast<ub1>(100 + v[i].tm_year % 100);
-            *pos++ = static_cast<ub1>(v[i].tm_mon + 1);
-            *pos++ = static_cast<ub1>(v[i].tm_mday);
-            *pos++ = static_cast<ub1>(v[i].tm_hour + 1);
-            *pos++ = static_cast<ub1>(v[i].tm_min + 1);
-            *pos++ = static_cast<ub1>(v[i].tm_sec + 1);
+            std::tm & t = v[begin_ + i];
+            
+            *pos++ = static_cast<ub1>(100 + (1900 + t.tm_year) / 100);
+            *pos++ = static_cast<ub1>(100 + t.tm_year % 100);
+            *pos++ = static_cast<ub1>(t.tm_mon + 1);
+            *pos++ = static_cast<ub1>(t.tm_mday);
+            *pos++ = static_cast<ub1>(t.tm_hour + 1);
+            *pos++ = static_cast<ub1>(t.tm_min + 1);
+            *pos++ = static_cast<ub1>(t.tm_sec + 1);
         }
     }
 
     // then handle indicators
     if (ind != NULL)
     {
-        std::size_t const vsize = size();
-        for (std::size_t i = 0; i != vsize; ++i, ++ind)
+        std::size_t const vecSize = size();
+        for (std::size_t i = 0; i != vecSize; ++i)
         {
-            if (*ind == i_null)
+            if (ind[begin_ + i] == i_null)
             {
                 indOCIHolderVec_[i] = -1; // null
             }
@@ -305,8 +309,8 @@ void oracle_vector_use_type_backend::pre_use(indicator const *ind)
     else
     {
         // no indicators - treat all fields as OK
-        std::size_t const vsize = size();
-        for (std::size_t i = 0; i != vsize; ++i, ++ind)
+        std::size_t const vecSize = size();
+        for (std::size_t i = 0; i != vecSize; ++i)
         {
             indOCIHolderVec_[i] = 0;  // value is OK
         }
@@ -314,6 +318,27 @@ void oracle_vector_use_type_backend::pre_use(indicator const *ind)
 }
 
 std::size_t oracle_vector_use_type_backend::size()
+{
+    // as a special error-detection measure, check if the actual vector size
+    // was changed since the original bind (when it was stored in end_var_):
+    const std::size_t actual_size = full_size();
+    if (actual_size != end_var_)
+    {
+        // ... and in that case return the actual size
+        return actual_size;
+    }
+    
+    if (end_ != NULL && *end_ != 0)
+    {
+        return *end_ - begin_;
+    }
+    else
+    {
+        return end_var_;
+    }
+}
+
+std::size_t oracle_vector_use_type_backend::full_size()
 {
     std::size_t sz = 0; // dummy initialization to please the compiler
     switch (type_)

--- a/src/core/into-type.cpp
+++ b/src/core/into-type.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2004-2008 Maciej Sobczak, Stephen Hutton
+// Copyright (C) 2004-2016 Maciej Sobczak, Stephen Hutton
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -55,7 +55,15 @@ vector_into_type::~vector_into_type()
 void vector_into_type::define(statement_impl & st, int & position)
 {
     backEnd_ = st.make_vector_into_type_backend();
-    backEnd_->define_by_pos(position, data_, type_);
+
+    if (end_ != NULL)
+    {
+        backEnd_->define_by_pos(position, data_, type_, begin_, end_);
+    }
+    else
+    {
+        backEnd_->define_by_pos(position, data_, type_);
+    }
 }
 
 void vector_into_type::pre_fetch()
@@ -82,7 +90,7 @@ void vector_into_type::post_fetch(bool gotData, bool /* calledFromFetch */)
 
 void vector_into_type::resize(std::size_t sz)
 {
-    if (indVec_ != NULL)
+    if (indVec_ != NULL && end_ == NULL)
     {
         indVec_->resize(sz);
     }

--- a/src/core/once-temp-type.cpp
+++ b/src/core/once-temp-type.cpp
@@ -46,6 +46,12 @@ once_temp_type & once_temp_type::operator,(into_type_ptr const & i)
     return *this;
 }
 
+once_temp_type & once_temp_type::operator,(use_type_ptr const & u)
+{
+    rcst_->exchange(u);
+    return *this;
+}
+
 ddl_type::ddl_type(session & s)
     : s_(&s), rcst_(new ref_counted_statement(s))
 {

--- a/src/core/use-type.cpp
+++ b/src/core/use-type.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2004-2008 Maciej Sobczak, Stephen Hutton
+// Copyright (C) 2004-2016 Maciej Sobczak, Stephen Hutton
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -150,11 +150,25 @@ void vector_use_type::bind(statement_impl & st, int & position)
     }
     if (name_.empty())
     {
-        backEnd_->bind_by_pos(position, data_, type_);
+        if (end_ != NULL)
+        {
+            backEnd_->bind_by_pos(position, data_, type_, begin_, end_);
+        }
+        else
+        {
+            backEnd_->bind_by_pos(position, data_, type_);
+        }
     }
     else
     {
-        backEnd_->bind_by_name(name_, data_, type_);
+        if (end_ != NULL)
+        {
+            backEnd_->bind_by_name(name_, data_, type_, begin_, end_);
+        }
+        else
+        {
+            backEnd_->bind_by_name(name_, data_, type_);
+        }
     }
 }
 

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -1273,6 +1273,88 @@ TEST_CASE("Oracle DDL with metadata", "[oracle][ddl]")
     CHECK(ddl_t3_found == false);
 }
 
+// Test the bulk iterators functionality
+TEST_CASE("Bulk iterators", "[oracle][bulkiters]")
+{
+    soci::session sql(backEnd, connectString);
+
+    sql << "create table t (i integer)";
+
+    // test bulk iterators with basic types
+    {
+        std::vector<int> v;
+        v.push_back(10);
+        v.push_back(20);
+        v.push_back(30);
+        v.push_back(40);
+        v.push_back(50);
+
+        std::size_t begin = 2;
+        std::size_t end = 5;
+        sql << "insert into t (i) values (:v)", soci::use(v, begin, end);
+
+        v.clear();
+        v.resize(20);
+        begin = 5;
+        end = 20;
+        sql << "select i from t", soci::into(v, begin, end);
+
+        CHECK(end == 8);
+        for (std::size_t i = 0; i != 5; ++i)
+        {
+            CHECK(v[i] == 0);
+        }
+        CHECK(v[5] == 30);
+        CHECK(v[6] == 40);
+        CHECK(v[7] == 50);
+        for (std::size_t i = end; i != 20; ++i)
+        {
+            CHECK(v[i] == 0);
+        }
+    }
+
+    sql << "delete from t";
+
+    // test bulk iterators with user types
+    {
+        std::vector<MyInt> v;
+        v.push_back(MyInt(10));
+        v.push_back(MyInt(20));
+        v.push_back(MyInt(30));
+        v.push_back(MyInt(40));
+        v.push_back(MyInt(50));
+
+        std::size_t begin = 2;
+        std::size_t end = 5;
+        sql << "insert into t (i) values (:v)", soci::use(v, begin, end);
+
+        v.clear();
+        for (std::size_t i = 0; i != 20; ++i)
+        {
+            v.push_back(MyInt(-1));
+        }
+
+        begin = 5;
+        end = 20;
+        sql << "select i from t", soci::into(v, begin, end);
+
+        CHECK(end == 8);
+        for (std::size_t i = 0; i != 5; ++i)
+        {
+            CHECK(v[i].get() == -1);
+        }
+        CHECK(v[5].get() == 30);
+        CHECK(v[6].get() == 40);
+        CHECK(v[7].get() == 50);
+        for (std::size_t i = end; i != 20; ++i)
+        {
+            CHECK(v[i].get() == -1);
+        }
+    }
+
+    sql << "drop table t";
+}
+
 //
 // Support for soci Common Tests
 //


### PR DESCRIPTION
In this PR I would like to propose the bulk iterators feature - the ability to operate on the chosen sub-range of the vector in bulk operations.
This feature is performance-optimization related. In the case of very large vectors, executing the transfer as a single operation can freeze the application for too long and copying around smaller vectors is not optimal either. Sub-ranges allow the user to select the fragment of the vector to operate on, and perhaps divide the whole transfer into smaller, more optimal chunks.
This is implemented for Oracle and PostgreSQL.
The feature supports also user-defined data types, as shown by the unit tests.
See docs diff for more details.
