### PR TITLE
Fixed driver name and passwd for PostgreSQL ODBC driver on AppVeyor

### DIFF
--- a/tests/odbc/test-postgresql.dsn
+++ b/tests/odbc/test-postgresql.dsn
@@ -1,8 +1,8 @@
 [ODBC]
-Description=DSN for SOCI ODBC connection to PostgreSQL
-Driver=PostgreSQL ANSI
+Description=DSN for SOCI ODBC connection to PostgreSQL(AppVeyor)
+Driver=PostgreSQL ANSI(x64)
 Server=localhost
 Port=5432
 Database=soci_test
 UID=postgres
-PWD=
+PWD=Password12!


### PR DESCRIPTION
Fixed UT configuration for 

soci_odbc_test_postgresql
soci_odbc_test_postgresql_static

Now only mysql tests on Windows failed.