### PR TITLE
Fix travis-ci build

### DIFF
--- a/tests/odbc/CMakeLists.txt
+++ b/tests/odbc/CMakeLists.txt
@@ -35,12 +35,17 @@ soci_backend_test(
   SOURCE test-odbc-mysql.cpp ${SOCI_TESTS_COMMON}
   CONNSTR "test-mysql.dsn")
 
+if(WIN32)
+  set(TEST_PGSQL_DSN "test-postgresql-win64.dsn")
+else()
+  set(TEST_PGSQL_DSN "test-postgresql.dsn")
+endif()
 soci_backend_test(
   NAME postgresql
   BACKEND ODBC
   DEPENDS ODBC
   SOURCE test-odbc-postgresql.cpp ${SOCI_TESTS_COMMON}
-  CONNSTR "test-postgresql.dsn")
+  CONNSTR ${TEST_PGSQL_DSN})
 
 # TODO: DB2 backend is tested by Travis CI on dedicated VM, separate from ODBC,
 # in order to test DB2 with ODBC, it would be best to install DB2 driver only.

--- a/tests/odbc/test-postgresql-win64.dsn
+++ b/tests/odbc/test-postgresql-win64.dsn
@@ -1,0 +1,8 @@
+[ODBC]
+Description=DSN for SOCI ODBC connection to PostgreSQL(AppVeyor)
+Driver=PostgreSQL ANSI(x64)
+Server=localhost
+Port=5432
+Database=soci_test
+UID=postgres
+PWD=Password12!

--- a/tests/odbc/test-postgresql.dsn
+++ b/tests/odbc/test-postgresql.dsn
@@ -1,6 +1,6 @@
 [ODBC]
-Description=DSN for SOCI ODBC connection to PostgreSQL(AppVeyor)
-Driver=PostgreSQL ANSI(x64)
+Description=DSN for SOCI ODBC connection to PostgreSQL(Travis-CI)
+Driver=PostgreSQL ANSI
 Server=localhost
 Port=5432
 Database=soci_test


### PR DESCRIPTION
Some trick to make Travis/Appveyor both happy with different ODBC driver name on same test.