### PR TITLE
Removed padding extra char to the end of each std string in odbc vectro-use-type

### DIFF
--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -165,7 +165,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
             prepare_indicators(vecSize);
             for (std::size_t i = 0; i != vecSize; ++i)
             {
-                std::size_t sz = v[i].length() + 1;  // add one for null
+                std::size_t sz = v[i].length();
                 indHolderVec_[i] = static_cast<long>(sz);
                 maxSize = sz > maxSize ? sz : maxSize;
             }


### PR DESCRIPTION
Removed padding extra char to the end of each std string.
