### PR TITLE
Add support c++11 on build with gcc

### DIFF
--- a/cmake/SociConfig.cmake
+++ b/cmake/SociConfig.cmake
@@ -29,6 +29,11 @@ endif(WIN32)
 
 set (SOCI_CXX_C11 OFF CACHE BOOL "Build to the C++11 standard")
 
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
+    if(NOT CMAKE_CXX_COMPILER_VERSION LESS 4.7)
+      set(SOCI_CXX_C11 ON)
+    endif()
+endif()
 
 #
 # Force compilation flags and set desired warnings level
@@ -94,3 +99,7 @@ endif()
 
 # Set SOCI_HAVE_* variables for soci-config.h generator
 set(SOCI_HAVE_CXX_C11 ${SOCI_CXX_C11} CACHE INTERNAL "Enables C++11 support")
+
+if(SOCI_CXX_C11)
+  add_definitions(-DSOCI_CXX_C11)
+endif()

--- a/src/core/once-temp-type.cpp
+++ b/src/core/once-temp-type.cpp
@@ -37,14 +37,7 @@ once_temp_type & once_temp_type::operator=(once_temp_type const & o)
 
 once_temp_type::~once_temp_type() SOCI_NOEXCEPT_FALSE
 {
-    //try
-    {
-        rcst_->dec_ref();
-    }
-    /*catch(...)
-    {
-        //Throwing an exception out of a destructor is forbidden
-    }*/
+    rcst_->dec_ref();
 }
 
 once_temp_type & once_temp_type::operator,(into_type_ptr const & i)

--- a/src/core/once-temp-type.cpp
+++ b/src/core/once-temp-type.cpp
@@ -37,14 +37,14 @@ once_temp_type & once_temp_type::operator=(once_temp_type const & o)
 
 once_temp_type::~once_temp_type() SOCI_NOEXCEPT_FALSE
 {
-    try
+    //try
     {
         rcst_->dec_ref();
     }
-    catch(...)
+    /*catch(...)
     {
         //Throwing an exception out of a destructor is forbidden
-    }
+    }*/
 }
 
 once_temp_type & once_temp_type::operator,(into_type_ptr const & i)

--- a/src/core/once-temp-type.cpp
+++ b/src/core/once-temp-type.cpp
@@ -37,7 +37,14 @@ once_temp_type & once_temp_type::operator=(once_temp_type const & o)
 
 once_temp_type::~once_temp_type() SOCI_NOEXCEPT_FALSE
 {
-    rcst_->dec_ref();
+    try
+    {
+        rcst_->dec_ref();
+    }
+    catch(...)
+    {
+        //Throwing an exception out of a destructor is forbidden
+    }
 }
 
 once_temp_type & once_temp_type::operator,(into_type_ptr const & i)


### PR DESCRIPTION
1. SOCI always builded with GCC compiler with c++03 flags
2. Аdd support c++11 for GCC to build SOCI