### PR TITLE
export cmake package

### DIFF
--- a/cmake/SociBackend.cmake
+++ b/cmake/SociBackend.cmake
@@ -215,17 +215,22 @@ macro(soci_backend NAME)
 
       if (SOCI_SHARED)
         install(TARGETS ${THIS_BACKEND_TARGET}
-         RUNTIME DESTINATION ${BINDIR}
-         LIBRARY DESTINATION ${LIBDIR}
-         ARCHIVE DESTINATION ${LIBDIR})
+          EXPORT SOCI
+          RUNTIME DESTINATION ${BINDIR}
+          LIBRARY DESTINATION ${LIBDIR}
+          ARCHIVE DESTINATION ${LIBDIR})
       endif()
 
       if (SOCI_STATIC)
         install(TARGETS ${THIS_BACKEND_TARGET_STATIC}
-         RUNTIME DESTINATION ${BINDIR}
-         LIBRARY DESTINATION ${LIBDIR}
-         ARCHIVE DESTINATION ${LIBDIR})
+          EXPORT SOCI
+          RUNTIME DESTINATION ${BINDIR}
+          LIBRARY DESTINATION ${LIBDIR}
+          ARCHIVE DESTINATION ${LIBDIR}
+         )
       endif()
+
+      install(EXPORT SOCI NAMESPACE SOCI:: DESTINATION cmake)
 
     else()
         colormsg(HIRED "${NAME}" RED "backend disabled, since")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -75,13 +75,11 @@ if (SOCI_STATIC)
 
   add_library(${SOCI_CORE_TARGET_STATIC} STATIC
     ${SOCI_CORE_HEADERS} ${SOCI_CORE_SOURCES})
-  
+
   # we still need to link against dl if we have it
   target_link_libraries (${SOCI_CORE_TARGET_STATIC}
     ${SOCI_CORE_DEPS_LIBS}
   )
-  
-
 
   set_target_properties(${SOCI_CORE_TARGET_STATIC}
     PROPERTIES
@@ -97,6 +95,7 @@ install(FILES ${SOCI_CORE_HEADERS} DESTINATION ${INCLUDEDIR}/${PROJECTNAMEL})
 
 if (SOCI_SHARED)
   install(TARGETS ${SOCI_CORE_TARGET}
+    EXPORT SOCI
     RUNTIME DESTINATION ${BINDIR}
     LIBRARY DESTINATION ${LIBDIR}
     ARCHIVE DESTINATION ${LIBDIR})
@@ -104,10 +103,13 @@ endif()
 
 if (SOCI_STATIC)
   install(TARGETS ${SOCI_CORE_TARGET_STATIC}
+    EXPORT SOCI
     RUNTIME DESTINATION ${BINDIR}
     LIBRARY DESTINATION ${LIBDIR}
     ARCHIVE DESTINATION ${LIBDIR})
 endif()
+
+install(EXPORT SOCI NAMESPACE SOCI:: DESTINATION cmake)
 
 #
 # Core configuration summary


### PR DESCRIPTION
Hi there,

I finally made modifications to export SOCI as a cmake package as we talked in my previous issue.
I was not able to fully test it because I need to integrate it into my local hunter script.
Since I tried to keep modifications minimalist as possible, the target names are different from my FindSOCI.cmake, e.g.: ``SOCI::core`` → ``SOCI::soci_core``. But it should support shared vs. static build, e.g.: ``SOCI::soci_core`` vs. ``SOCI::soci_core_static``.
For some reason, when I built SOCI with hunter, it seems ``CMAKE_DEBUG_POSTFIX`` is set to "d".
In this case, it's not. I've to manually add ``-DCMAKE_DEBUG_POSTFIX="d"`` to differentiate release and debug builds (which is mandatory on Visual Studio).
If everything is fine and this pull request is merged, I'd like to propose this library for hunter project, are you ok with this? Usually it requires to upload an recent .tar.gz archive of the source code, is it something you could maintain?

For the info, I use these command lines to build SOCI:
```
md _build;cd _build
cmake .. -G"Visual Studio 14 Win64" -DCMAKE_INSTALL_PREFIX=../_install -DSOCI_CXX_C11=TRUE -DCMAKE_DEBUG_POSTFIX="d"
cmake --build . --target install --config release --config debug
```

Thanks in advance,