### PR TITLE
fix iOS compile error

### DIFF
--- a/src/backends/sqlite3/common.cpp
+++ b/src/backends/sqlite3/common.cpp
@@ -55,5 +55,5 @@ void soci::details::sqlite3::parse_std_tm(char const *buf, std::tm &t)
         second = parse10(p1, p2, errMsg);
     }
 
-    details::mktime_from_ymdhms(t, year, month, day, hour, minute, second);
+    details::mktime_from_ymdhms(t, (int)year, (int)month, (int)day, (int)hour, (int)minute, (int)second);
 }


### PR DESCRIPTION
soci/src/backends/sqlite3/common.cpp:58:36: error:
      implicit conversion loses integer precision: 'long' to 'int'
      [-Werror,-Wshorten-64-to-32]
    details::mktime_from_ymdhms(t, year, month, day, hour, minute, second);

just a hotfix for compile error
