### PR TITLE
Added bigstring (XML and CLOB) support.

### DIFF
--- a/docs/exchange.md
+++ b/docs/exchange.md
@@ -15,6 +15,7 @@
     * [Extending with user-provided datatypes](#custom_types)
     * [Object-relational mapping](#object_relational)
 * [Large objects (BLOBs)](#blob)
+* [Long strings and XML](#xml)
 
 
 ### <a name="bind_local"></a> Binding local data
@@ -567,3 +568,31 @@ The `offset` parameter is always counted from the beginning of the BLOB's data.
 
 * The way to define BLOB table columns and create or destroy BLOB objects in the database varies between different database engines. Please see the SQL documentation relevant for the given server to learn how this is actually done. The test programs provided with the SOCI library can be also a simple source of full working examples.
 * The `trim` function is not currently available for the PostgreSQL backend.
+
+### <a name="xml"></a> Long strings and XML
+
+The SOCI library recognizes the fact that long string values are not handled portably and in some databases long string values need to be stored as a different data type. Similar concerns relate to the use of XML values, which are essentially strings at the application level, but can be stored in special database-level field types.
+
+In order to facilitate handling of long strings and XML values the following wrapper types are defined:
+
+    struct xml_type
+    {
+        std::string value;
+    };
+
+    struct long_string
+    {
+        std::string value;
+    };
+
+Values of these wrapper types can be used with `into` and `use` elements with the database target type that is specifically intended to handle XML and long strings data types.
+
+For Oracle, these database-side types are, respectively:
+
+    *`XMLType`,
+    *`CLOB`
+
+For PostgreSQL, these types are:
+
+    *`XML`
+    *`text`

--- a/include/soci/column-info.h
+++ b/include/soci/column-info.h
@@ -63,7 +63,8 @@ struct type_conversion<column_info>
         ci.scale = get_numeric_value(v, "NUMERIC_SCALE");
 
         const std::string & type_name = v.get<std::string>("DATA_TYPE");
-        if (type_name == "text" ||
+        if (type_name == "text" || type_name == "TEXT" ||
+            type_name == "clob" || type_name == "CLOB" ||
             type_name.find("char") != std::string::npos ||
             type_name.find("CHAR") != std::string::npos)
         {
@@ -96,10 +97,15 @@ struct type_conversion<column_info>
         }
         else if (type_name.find("blob") != std::string::npos ||
             type_name.find("BLOB") != std::string::npos ||
-            type_name.find("bytea") != std::string::npos ||
-            type_name.find("BYTEA") != std::string::npos)
+            type_name.find("oid") != std::string::npos ||
+            type_name.find("OID") != std::string::npos)
         {
             ci.type = dt_blob;
+        }
+        else if (type_name.find("xml") != std::string::npos ||
+            type_name.find("XML") != std::string::npos)
+        {
+            ci.type = dt_xml;
         }
         else
         {

--- a/include/soci/exchange-traits.h
+++ b/include/soci/exchange-traits.h
@@ -10,6 +10,7 @@
 
 #include "soci/type-conversion-traits.h"
 #include "soci/soci-backend.h"
+#include "soci/type-wrappers.h"
 // std
 #include <ctime>
 #include <string>
@@ -129,6 +130,22 @@ struct exchange_traits<std::vector<T> >
 {
     typedef typename exchange_traits<T>::type_family type_family;
     enum { x_type = exchange_traits<T>::x_type };
+};
+
+// handling of wrapper types
+
+template <>
+struct exchange_traits<xml_type>
+{
+    typedef basic_type_tag type_family;
+    enum { x_type = x_xmltype };
+};
+
+template <>
+struct exchange_traits<long_string>
+{
+    typedef basic_type_tag type_family;
+    enum { x_type = x_longstring };
 };
 
 } // namespace details

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -345,7 +345,15 @@ struct oracle_session_backend : details::session_backend
         case dt_string:
             {
                 std::ostringstream oss;
-                oss << "varchar(" << precision << ")";
+                
+                if (precision == 0)
+                {
+                    oss << "clob";
+                }
+                else
+                {
+                    oss << "varchar(" << precision << ")";
+                }
                 
                 res += oss.str();
             }

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -58,6 +58,8 @@ struct oracle_standard_into_type_backend : details::standard_into_type_backend
     virtual void define_by_pos(int &position,
         void *data, details::exchange_type type);
 
+    void read_from_lob(OCILobLocator * lobp, std::string & value);
+    
     virtual void pre_fetch();
     virtual void post_fetch(bool gotData, bool calledFromFetch,
         indicator *ind);
@@ -69,6 +71,7 @@ struct oracle_standard_into_type_backend : details::standard_into_type_backend
     OCIDefine *defnp_;
     sb2 indOCIHolder_;
     void *data_;
+    void *ociData_;
     char *buf_;        // generic buffer
     details::exchange_type type_;
 
@@ -137,6 +140,9 @@ struct oracle_standard_use_type_backend : details::standard_use_type_backend
     // common part for bind_by_pos and bind_by_name
     void prepare_for_bind(void *&data, sb4 &size, ub2 &oracleType, bool readOnly);
 
+    // common helper for pre_use for LOB-directed wrapped types
+    void write_to_lob(OCILobLocator * lobp, const std::string & value);
+    
     virtual void pre_use(indicator const *ind);
     virtual void post_use(bool gotData, indicator *ind);
 
@@ -147,6 +153,7 @@ struct oracle_standard_use_type_backend : details::standard_use_type_backend
     OCIBind *bindp_;
     sb2 indOCIHolder_;
     void *data_;
+    void *ociData_;
     bool readOnly_;
     char *buf_;        // generic buffer
     details::exchange_type type_;
@@ -379,6 +386,13 @@ struct oracle_session_backend : details::session_backend
         case dt_blob:
             res += "blob";
             break;
+
+        case dt_xml:
+            res += "xmltype";
+            break;
+
+        default:
+            throw soci_error("this data_type is not supported in create_column");
         }
 
         return res;

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -326,7 +326,15 @@ public:
         case dt_string:
             {
                 std::ostringstream oss;
-                oss << "varchar(" << precision << ")";
+                
+                if (precision == 0)
+                {
+                    oss << "text";
+                }
+                else
+                {
+                    oss << "varchar(" << precision << ")";
+                }
                 
                 res += oss.str();
             }

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -22,7 +22,8 @@ namespace soci
 // data types, as seen by the user
 enum data_type
 {
-    dt_string, dt_date, dt_double, dt_integer, dt_long_long, dt_unsigned_long_long, dt_blob
+    dt_string, dt_date, dt_double, dt_integer, dt_long_long, dt_unsigned_long_long,
+    dt_blob, dt_xml
 };
 
 // the enum type for indicator variables
@@ -47,7 +48,10 @@ enum exchange_type
     x_stdtm,
     x_statement,
     x_rowid,
-    x_blob
+    x_blob,
+    
+    x_xmltype,
+    x_longstring
 };
 
 // type of statement (used for optimizing statement preparation)
@@ -361,8 +365,15 @@ public:
             break;
 
         case dt_blob:
-            res += "bytea";
+            res += "oid";
             break;
+
+        case dt_xml:
+            res += "xml";
+            break;
+
+        default:
+            throw soci_error("this data_type is not supported in create_column");
         }
 
         return res;
@@ -372,7 +383,7 @@ public:
         int precision, int scale)
     {
         return "alter table " + tableName + " add column " + columnName +
-            create_column_type(dt, precision, scale);
+            " " + create_column_type(dt, precision, scale);
     }
     virtual std::string alter_column(const std::string & tableName,
         const std::string & columnName, data_type dt,

--- a/include/soci/soci.h
+++ b/include/soci/soci.h
@@ -37,6 +37,7 @@
 #include "soci/type-conversion-traits.h"
 #include "soci/type-holder.h"
 #include "soci/type-ptr.h"
+#include "soci/type-wrappers.h"
 #include "soci/unsigned-types.h"
 #include "soci/use.h"
 #include "soci/use-type.h"

--- a/include/soci/type-wrappers.h
+++ b/include/soci/type-wrappers.h
@@ -1,0 +1,33 @@
+//
+// Copyright (C) 2016 Maciej Sobczak
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_TYPE_WRAPPERS_H_INCLUDED
+#define SOCI_TYPE_WRAPPERS_H_INCLUDED
+
+namespace soci
+{
+
+// These wrapper types can be used by the application
+// with 'into' and 'use' elements in order to guide the library
+// in selecting specialized methods for binding and transferring data;
+// if the target database does not provide any such specialized methods,
+// it is expected to handle these wrappers as equivalent
+// to their contained field types.
+
+struct xml_type
+{
+    std::string value;
+};
+
+struct long_string
+{
+    std::string value;
+};
+
+} // namespace soci
+
+#endif // SOCI_TYPE_WRAPPERS_H_INCLUDED

--- a/src/backends/oracle/vector-into-type.cpp
+++ b/src/backends/oracle/vector-into-type.cpp
@@ -158,9 +158,11 @@ void oracle_vector_into_type_backend::define_by_pos(
         }
         break;
 
-    case x_statement: break; // not supported
-    case x_rowid:     break; // not supported
-    case x_blob:      break; // not supported
+    case x_xmltype:    break; // not supported
+    case x_longstring: break; // not supported
+    case x_statement:  break; // not supported
+    case x_rowid:      break; // not supported
+    case x_blob:       break; // not supported
     }
 
     sword res = OCIDefineByPos(statement_.stmtp_, &defnp_,
@@ -380,9 +382,11 @@ void oracle_vector_into_type_backend::resize(std::size_t sz)
             }
             break;
 
-        case x_statement: break; // not supported
-        case x_rowid:     break; // not supported
-        case x_blob:      break; // not supported
+        case x_xmltype:    break; // not supported
+        case x_longstring: break; // not supported
+        case x_statement:  break; // not supported
+        case x_rowid:      break; // not supported
+        case x_blob:       break; // not supported
         }
 
         end_var_ = sz;
@@ -473,9 +477,11 @@ std::size_t oracle_vector_into_type_backend::full_size()
         }
         break;
 
-    case x_statement: break; // not supported
-    case x_rowid:     break; // not supported
-    case x_blob:      break; // not supported
+    case x_xmltype:    break; // not supported
+    case x_longstring: break; // not supported
+    case x_statement:  break; // not supported
+    case x_rowid:      break; // not supported
+    case x_blob:       break; // not supported
     }
 
     return sz;

--- a/src/backends/oracle/vector-use-type.cpp
+++ b/src/backends/oracle/vector-use-type.cpp
@@ -155,9 +155,11 @@ void oracle_vector_use_type_backend::prepare_for_bind(
         }
         break;
 
-    case x_statement: break; // not supported
-    case x_rowid:     break; // not supported
-    case x_blob:      break; // not supported
+    case x_xmltype:    break; // not supported
+    case x_longstring: break; // not supported
+    case x_statement:  break; // not supported
+    case x_rowid:      break; // not supported
+    case x_blob:       break; // not supported
     }
 }
 
@@ -398,9 +400,11 @@ std::size_t oracle_vector_use_type_backend::full_size()
         }
         break;
 
-    case x_statement: break; // not supported
-    case x_rowid:     break; // not supported
-    case x_blob:      break; // not supported
+    case x_xmltype:    break; // not supported
+    case x_longstring: break; // not supported
+    case x_statement:  break; // not supported
+    case x_rowid:      break; // not supported
+    case x_blob:       break; // not supported
     }
 
     return sz;

--- a/src/backends/postgresql/standard-into-type.cpp
+++ b/src/backends/postgresql/standard-into-type.cpp
@@ -12,6 +12,7 @@
 #include "common.h"
 #include "soci/rowid.h"
 #include "soci/blob.h"
+#include "soci/type-wrappers.h"
 #include "soci-exchange-cast.h"
 #include <libpq/libpq-fs.h> // libpq
 #include <cctype>
@@ -148,6 +149,14 @@ void postgresql_standard_into_type_backend::post_fetch(
 
                 bbe->fd_ = fd;
                 bbe->oid_ = oid;
+            }
+            break;
+        case x_xmltype:
+            {
+                long_string * ls = static_cast<long_string *>(data_);
+                std::string * dest = &(ls->value);
+                
+                dest->assign(buf);
             }
             break;
 

--- a/src/backends/postgresql/standard-use-type.cpp
+++ b/src/backends/postgresql/standard-use-type.cpp
@@ -9,6 +9,7 @@
 #include "soci/postgresql/soci-postgresql.h"
 #include "soci/blob.h"
 #include "soci/rowid.h"
+#include "soci/type-wrappers.h"
 #include "soci/soci-platform.h"
 #include "soci-dtocstr.h"
 #include "soci-exchange-cast.h"
@@ -159,7 +160,25 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
                 snprintf(buf_, bufSize, "%lu", bbe->oid_);
             }
             break;
-
+        case x_xmltype:
+            {
+                xml_type * xml = static_cast<xml_type *>(data_);
+                std::string * s = &(xml->value);
+                
+                buf_ = new char[s->size() + 1];
+                std::strcpy(buf_, s->c_str());
+            }
+            break;
+        case x_longstring:
+            {
+                long_string * ls = static_cast<long_string *>(data_);
+                std::string * s = &(ls->value);
+                
+                buf_ = new char[s->size() + 1];
+                std::strcpy(buf_, s->c_str());
+            }
+            break;
+            
         default:
             throw soci_error("Use element used with non-supported type.");
         }

--- a/src/backends/postgresql/vector-use-type.cpp
+++ b/src/backends/postgresql/vector-use-type.cpp
@@ -10,6 +10,7 @@
 #include "soci/postgresql/soci-postgresql.h"
 #include "soci-dtocstr.h"
 #include "common.h"
+#include "soci/type-wrappers.h"
 #include <libpq/libpq-fs.h> // libpq
 #include <cctype>
 #include <cstdio>
@@ -178,6 +179,26 @@ void postgresql_vector_use_type_backend::pre_use(indicator const * ind)
                         v[i].tm_hour, v[i].tm_min, v[i].tm_sec);
                 }
                 break;
+            case x_xmltype:
+                {
+                    std::vector<xml_type> * pv
+                        = static_cast<std::vector<xml_type> *>(data_);
+                    std::vector<xml_type> & v = *pv;
+
+                    buf = new char[v[i].value.size() + 1];
+                    std::strcpy(buf, v[i].value.c_str());
+                }
+                break;
+            case x_longstring:
+                {
+                    std::vector<long_string> * pv
+                        = static_cast<std::vector<long_string> *>(data_);
+                    std::vector<long_string> & v = *pv;
+
+                    buf = new char[v[i].value.size() + 1];
+                    std::strcpy(buf, v[i].value.c_str());
+                }
+                break;
 
             default:
                 throw soci_error(
@@ -250,6 +271,12 @@ std::size_t postgresql_vector_use_type_backend::full_size()
         break;
     case x_stdtm:
         sz = get_vector_size<std::tm>(data_);
+        break;
+    case x_xmltype:
+        sz = get_vector_size<xml_type>(data_);
+        break;
+    case x_longstring:
+        sz = get_vector_size<long_string>(data_);
         break;
     default:
         throw soci_error("Use vector element used with non-supported type.");

--- a/src/backends/sqlite3/Makefile.basic
+++ b/src/backends/sqlite3/Makefile.basic
@@ -1,28 +1,39 @@
 # The following variable is specific to this backend and its correct
 # values might depend on your environment - feel free to set it accordingly.
 
-SQLITE3INCLUDEDIR =
+SQLITE3INCLUDEDIR = -I/usr/include
+SQLITE3LIBDIR = -L/usr/lib
+SQLITE3LIBS = -lsqlite3
 
 # The rest of the Makefile is indepentent of the target environment.
 
 COMPILER = g++
 CXXFLAGS = -Wall -pedantic -Wno-long-long
-CXXFLAGSSO = ${CXXFLAGS} -fPIC
-INCLUDEDIRS = -I../../core ${SQLITE3INCLUDEDIR}
+SHARED_CXXFLAGS = ${CXXFLAGS} -fPIC
+INCLUDEDIRS = -I../../../include -I../../../include/private ${SQLITE3INCLUDEDIR}
+
+SHARED_LIBDIRS = ${SQLITE3LIBDIR}
+SHARED_LIBS = ${SQLITE3LIBS} ../../core/libsoci_core.a
+
+UNAME = $(shell uname)
+ifeq ($(UNAME),Darwin)
+	SHARED_LINK_FLAGS = -dynamiclib -flat_namespace -undefined suppress
+else
+	SHARED_LINK_FLAGS = -shared
+endif
 
 
 OBJECTS = blob.o error.o factory.o row-id.o session.o standard-into-type.o \
 	standard-use-type.o statement.o vector-into-type.o vector-use-type.o \
 	common.o
 
-OBJECTSSO = blob-s.o factory-s.o row-id-s.o session-s.o \
+SHARED_OBJECTS = blob-s.o factory-s.o row-id-s.o session-s.o \
 	standard-into-type-s.o standard-use-type-s.o statement-s.o \
 	vector-into-type-s.o vector-use-type-s.o common-s.o
 
 
 libsoci_sqlite3.a : ${OBJECTS}
 	ar rv $@ $?
-	ranlib $@
 	rm *.o
 
 
@@ -60,42 +71,43 @@ vector-use-type.o : vector-use-type.cpp
 	${COMPILER} -c $? ${CXXFLAGS} ${INCLUDEDIRS}
 
 
-shared : ${OBJECTSSO}
-	${COMPILER} -shared -o libsoci_sqlite3.so ${OBJECTSSO}
+shared : ${SHARED_OBJECTS}
+	${COMPILER} ${SHARED_LINK_FLAGS} -o libsoci_sqlite3.so \
+        	${SHARED_OBJECTS} ${SHARED_LIBDIRS} ${SHARED_LIBS}
 	rm *.o
 
 blob-s.o : blob.cpp
-	${COMPILER} -c -o $@ $? ${CXXFLAGSSO} ${INCLUDEDIRS}
+	${COMPILER} -c -o $@ $? ${SHARED_CXXFLAGS} ${INCLUDEDIRS}
 
 error-s.o : error.cpp
 	${COMPILER} -c -o $@ $? ${CXXFLAGS} ${INCLUDEDIRS}
 
 common-s.o : common.cpp
-	${COMPILER} -c -o $@ $? ${CXXFLAGSSO} ${INCLUDEDIRS}
+	${COMPILER} -c -o $@ $? ${SHARED_CXXFLAGS} ${INCLUDEDIRS}
 
 factory-s.o : factory.cpp
-	${COMPILER} -c -o $@ $? ${CXXFLAGSSO} ${INCLUDEDIRS}
+	${COMPILER} -c -o $@ $? ${SHARED_CXXFLAGS} ${INCLUDEDIRS}
 
 row-id-s.o : row-id.cpp
-	${COMPILER} -c -o $@ $? ${CXXFLAGSSO} ${INCLUDEDIRS}
+	${COMPILER} -c -o $@ $? ${SHARED_CXXFLAGS} ${INCLUDEDIRS}
 
 session-s.o : session.cpp
-	${COMPILER} -c -o $@ $? ${CXXFLAGSSO} ${INCLUDEDIRS}
+	${COMPILER} -c -o $@ $? ${SHARED_CXXFLAGS} ${INCLUDEDIRS}
 
 standard-into-type-s.o : standard-into-type.cpp
-	${COMPILER} -c -o $@ $? ${CXXFLAGSSO} ${INCLUDEDIRS}
+	${COMPILER} -c -o $@ $? ${SHARED_CXXFLAGS} ${INCLUDEDIRS}
 
 standard-use-type-s.o : standard-use-type.cpp
-	${COMPILER} -c -o $@ $? ${CXXFLAGSSO} ${INCLUDEDIRS}
+	${COMPILER} -c -o $@ $? ${SHARED_CXXFLAGS} ${INCLUDEDIRS}
 
 statement-s.o : statement.cpp
-	${COMPILER} -c -o $@ $? ${CXXFLAGSSO} ${INCLUDEDIRS}
+	${COMPILER} -c -o $@ $? ${SHARED_CXXFLAGS} ${INCLUDEDIRS}
 
 vector-into-type-s.o : vector-into-type.cpp
-	${COMPILER} -c -o $@ $? ${CXXFLAGSSO} ${INCLUDEDIRS}
+	${COMPILER} -c -o $@ $? ${SHARED_CXXFLAGS} ${INCLUDEDIRS}
 
 vector-use-type-s.o : vector-use-type.cpp
-	${COMPILER} -c -o $@ $? ${CXXFLAGSSO} ${INCLUDEDIRS}
+	${COMPILER} -c -o $@ $? ${SHARED_CXXFLAGS} ${INCLUDEDIRS}
 
 
 clean :

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -182,6 +182,9 @@ sqlite3_statement_backend::load_rowset(int totalRows)
                             col.buffer_.data_ = (col.buffer_.size_ > 0 ? new char[col.buffer_.size_] : NULL);
                             memcpy(col.buffer_.data_, sqlite3_column_blob(stmt_, c), col.buffer_.size_);
                             break;
+
+                        case dt_xml:
+                            throw soci_error("XML data type is not supported");
                     }
                 }
             }
@@ -280,6 +283,9 @@ sqlite3_statement_backend::bind_and_execute(int number)
                     case dt_blob:
                         bindRes = sqlite3_bind_blob(stmt_, pos, col.buffer_.constData_, static_cast<int>(col.buffer_.size_), NULL);
                         break;
+
+                    case dt_xml:
+                        throw soci_error("XML data type is not supported");
                 }
             }
 

--- a/src/backends/sqlite3/vector-into-type.cpp
+++ b/src/backends/sqlite3/vector-into-type.cpp
@@ -77,6 +77,9 @@ void set_number_in_vector(void *p, int idx, const sqlite3_column &col)
         case dt_unsigned_long_long:
             set_in_vector(p, idx, static_cast<T>(col.int64_));
             break;
+
+        case dt_xml:
+            throw soci_error("XML data type is not supported");
     };
 }
 
@@ -147,6 +150,9 @@ void sqlite3_vector_into_type_backend::post_fetch(bool gotData, indicator * ind)
                         set_in_vector(data_, i, ss.str()[0]);
                         break;
                     }
+
+                    case dt_xml:
+                        throw soci_error("XML data type is not supported");
                 };
                 break;
             } // x_char
@@ -181,6 +187,9 @@ void sqlite3_vector_into_type_backend::post_fetch(bool gotData, indicator * ind)
                         set_in_vector(data_, i, ss.str());
                         break;
                     }
+
+                    case dt_xml:
+                        throw soci_error("XML data type is not supported");
                 };
                 break;
             } // x_stdstring
@@ -226,6 +235,9 @@ void sqlite3_vector_into_type_backend::post_fetch(bool gotData, indicator * ind)
                     case dt_long_long:
                     case dt_unsigned_long_long:
                         throw soci_error("Into element used with non-convertible type.");
+
+                    case dt_xml:
+                        throw soci_error("XML data type is not supported");
                 };
                 break;
             }
@@ -249,6 +261,9 @@ void sqlite3_vector_into_type_backend::post_fetch(bool gotData, indicator * ind)
             case dt_long_long:
             case dt_unsigned_long_long:
                 break;
+
+            case dt_xml:
+                throw soci_error("XML data type is not supported");
         }
     }
 }

--- a/src/core/soci-simple.cpp
+++ b/src/core/soci-simple.cpp
@@ -582,6 +582,8 @@ bool name_exists_check_failed(statement_wrapper & wrapper,
                 iterator const it = wrapper.use_blob.find(name);
                 name_exists = (it != wrapper.use_blob.end());
             }
+        case dt_xml:
+            // no support for xml
             break;
         }
     }
@@ -642,7 +644,8 @@ bool name_exists_check_failed(statement_wrapper & wrapper,
             }
             break;
         case dt_blob:
-            // no support for bulk load
+        case dt_xml:
+            // no support for bulk and xml load
             break;
         }
     }
@@ -1096,6 +1099,7 @@ SOCI_DECL void soci_into_resize_v(statement_handle st, int new_size)
             wrapper->into_dates_v[i].resize(new_size);
             break;
         case dt_blob:
+        case dt_xml:
             // no support for bulk blob
             break;
         }
@@ -1851,6 +1855,9 @@ SOCI_DECL void soci_prepare(statement_handle st, char const * query)
                     wrapper->st.exchange(
                         into(wrapper->into_blob[i]->blob_, wrapper->into_indicators[i]));
                     break;
+                case dt_xml:
+                    // no support for xml
+                    break;
                 }
             }
         }
@@ -1883,7 +1890,8 @@ SOCI_DECL void soci_prepare(statement_handle st, char const * query)
                         into(wrapper->into_dates_v[i], wrapper->into_indicators_v[i]));
                     break;
                 case dt_blob:
-                    // no support for bulk blob
+                case dt_xml:
+                    // no support for bulk blob and xml
                     break;
                 }
             }

--- a/src/core/use-type.cpp
+++ b/src/core/use-type.cpp
@@ -100,6 +100,14 @@ void standard_use_type::dump_value(std::ostream& os) const
         case x_blob:
             os << "<blob>";
             return;
+
+        case x_xmltype:
+            os << "<xml>";
+            return;
+
+        case x_longstring:
+            os << "<long string>";
+            return;
     }
 
     // This is normally unreachable, but avoid throwing from here as we're

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -1188,6 +1188,7 @@ TEST_CASE("Oracle DDL with metadata", "[oracle][ddl]")
     }
 
     sql.add_column(ddl_t1, "K", soci::dt_integer);
+    sql.add_column(ddl_t1, "BIG", soci::dt_string, 0); // "unlimited" length -> CLOB
     sql.drop_column(ddl_t1, "I");
 
     // or with constraint as in t2:
@@ -1224,6 +1225,7 @@ TEST_CASE("Oracle DDL with metadata", "[oracle][ddl]")
     i_found = false;
     j_found = false;
     bool k_found = false;
+    bool big_found = false;
     other_found = false;
     soci::statement st3 = (sql.prepare_column_descriptions(ddl_t1), into(ci));
     st3.execute();
@@ -1241,6 +1243,12 @@ TEST_CASE("Oracle DDL with metadata", "[oracle][ddl]")
             CHECK(ci.nullable);
             k_found = true;
         }
+        else if (ci.name == "BIG")
+        {
+            CHECK(ci.type == soci::dt_string);
+            CHECK(ci.precision == 0); // "unlimited" for strings
+            big_found = true;
+        }
         else
         {
             other_found = true;
@@ -1250,6 +1258,7 @@ TEST_CASE("Oracle DDL with metadata", "[oracle][ddl]")
     CHECK(i_found == false);
     CHECK(j_found);
     CHECK(k_found);
+    CHECK(big_found);
     CHECK(other_found == false);
     
     // check if ddl_t2 has the right structure:

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -805,6 +805,7 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
     }
 
     sql.add_column(ddl_t1, "k", soci::dt_integer);
+    sql.add_column(ddl_t1, "big", soci::dt_string, 0); // "unlimited" length -> text
     sql.drop_column(ddl_t1, "i");
 
     // or with constraint as in t2:
@@ -841,6 +842,7 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
     i_found = false;
     j_found = false;
     bool k_found = false;
+    bool big_found = false;
     other_found = false;
     soci::statement st3 = (sql.prepare_column_descriptions(ddl_t1), into(ci));
     st3.execute();
@@ -858,6 +860,12 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
             CHECK(ci.nullable);
             k_found = true;
         }
+        else if (ci.name == "big")
+        {
+            CHECK(ci.type == soci::dt_string);
+            CHECK(ci.precision == 0); // "unlimited" for strings
+            big_found = true;
+        }
         else
         {
             other_found = true;
@@ -867,6 +875,7 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
     CHECK(i_found == false);
     CHECK(j_found);
     CHECK(k_found);
+    CHECK(big_found);
     CHECK(other_found == false);
     
     // check if ddl_t2 has the right structure:

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -729,7 +729,7 @@ TEST_CASE("PostgreSQL ORM cast", "[postgresql][orm]")
 }
 
 // Test the DDL and metadata functionality
-TEST_CASE("PostgreSQL DDL with metadata", "[postfresql][ddl]")
+TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
 {
     soci::session sql(backEnd, connectString);
 
@@ -940,7 +940,7 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postfresql][ddl]")
 }
 
 // Test the bulk iterators functionality
-TEST_CASE("Bulk iterators", "[postfresql][bulkiters]")
+TEST_CASE("Bulk iterators", "[postgresql][bulkiters]")
 {
     soci::session sql(backEnd, connectString);
 
@@ -1019,6 +1019,28 @@ TEST_CASE("Bulk iterators", "[postfresql][bulkiters]")
     }
 
     sql << "drop table t";
+}
+
+// Test support for XML wrapper type
+TEST_CASE("XML wrapper type", "[postgresql][xml]")
+{
+    session sql(backEnd, connectString);
+
+    sql << "create table xml_test (id integer, x xml)";
+
+    int id = 1;
+    xml_type xml;
+    xml.value = "<file>abc</file>";
+
+    sql << "insert into xml_test (id, x) values (:1, :2)", use(id), use(xml);
+
+    xml_type xml2;
+
+    sql << "select x from xml_test where id = :1", into(xml2), use(id);
+
+    CHECK(xml.value == xml2.value);
+
+    sql << "drop table xml_test";
 }
 
 //

--- a/tests/sqlite3/Makefile.basic
+++ b/tests/sqlite3/Makefile.basic
@@ -1,0 +1,12 @@
+COMPILER = g++
+CXXFLAGS = -Wall -pedantic -Wno-long-long
+INCLUDEDIRS = -I../../include -I../../include/private -I.. -I/usr/include/sqlite3
+LIBDIRS = -L../../src/core -L../../src/backends/sqlite3 -L/usr/lib/x86_64-linux-gnu
+LIBS = -lsoci_sqlite3 -lsoci_core -ldl -lsqlite3
+
+test-sqlite3 : test-sqlite3.cpp
+	${COMPILER} $? -o $@ ${INCLUDEDIRS} ${LIBDIRS} ${LIBS}
+
+
+clean :
+	rm -f test-sqlite3


### PR DESCRIPTION
This PR adds support for big strings and XML values for Oracle and PostgreSQL.

The problem with large strings is that in Oracle they have to be bound differently from regular std::string values and the target database type has to be different as well (CLOB instead of varchar).
Interestingly, large string values sometimes happen to be XML values, which have their own dedicated target types as well, in both Oracle and PostgreSQL.
In order to accommodate these differences in a more-or-less portable way, two wrapper types were added and the rest of the code was extended appropriately.
See the added test cases and the basic docs additional to see the general idea behind these features.
