### PR TITLE
Add missing declspec to properly export exception classes

### DIFF
--- a/include/soci/db2/soci-db2.h
+++ b/include/soci/db2/soci-db2.h
@@ -61,7 +61,7 @@ namespace soci
 
     static const std::size_t maxBuffer =  1024 * 1024 * 1024; //CLI limit is about 3 GB, but 1GB should be enough
 
-class db2_soci_error : public soci_error {
+class SOCI_DB2_DECL db2_soci_error : public soci_error {
 public:
     db2_soci_error(std::string const & msg, SQLRETURN rc) : soci_error(msg),errorCode(rc) {};
     ~db2_soci_error() throw() { };

--- a/include/soci/mysql/soci-mysql.h
+++ b/include/soci/mysql/soci-mysql.h
@@ -35,7 +35,7 @@
 namespace soci
 {
 
-class mysql_soci_error : public soci_error
+class SOCI_MYSQL_DECL mysql_soci_error : public soci_error
 {
 public:
     mysql_soci_error(std::string const & msg, int errNum)

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -31,7 +31,7 @@
 namespace soci
 {
 
-class postgresql_soci_error : public soci_error
+class SOCI_POSTGRESQL_DECL postgresql_soci_error : public soci_error
 {
 public:
     postgresql_soci_error(std::string const & msg, char const * sqlst);


### PR DESCRIPTION
Missing in MySQL, DB2 and PostgreSQL backend.