### PR TITLE
Compatibility with C++11 on release branch 3.2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,10 @@ soci_version(MAJOR 3 MINOR 2 PATCH 3)
 include(SociSystemInfo)
 include(SociConfig)
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+  add_definitions(-std=gnu++0x)
+endif()
+
 boost_report_value(SOCI_PLATFORM_NAME)
 boost_report_value(SOCI_COMPILER_NAME)
 

--- a/src/core/rowset.h
+++ b/src/core/rowset.h
@@ -154,8 +154,8 @@ private:
 
     unsigned int refs_;
 
-    const std::auto_ptr<statement> st_;
-    const std::auto_ptr<T> define_;
+    const std::unique_ptr<statement> st_;
+    const std::unique_ptr<T> define_;
 
     // Non-copyable
     rowset_impl(rowset_impl const &);

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -235,11 +235,11 @@ std::string session::get_query() const
 }
 
 void session::set_query_transformation_(
-        std::auto_ptr<details::query_transformation_function> qtf)
+        std::unique_ptr<details::query_transformation_function> qtf)
 {
     if (isFromPool_)
     {
-        pool_->at(poolPosition_).set_query_transformation_(qtf);
+        pool_->at(poolPosition_).set_query_transformation_(std::move(qtf));
     }
     else
     {

--- a/src/core/session.h
+++ b/src/core/session.h
@@ -40,7 +40,7 @@ class SOCI_DECL session
 {
 private:
 
-    void set_query_transformation_(std::auto_ptr<details::query_transformation_function> qtf);
+    void set_query_transformation_(std::unique_ptr<details::query_transformation_function> qtf);
 
 public:
     session();
@@ -77,8 +77,8 @@ public:
     template <typename T>
     void set_query_transformation(T callback)
     {
-        std::auto_ptr<details::query_transformation_function> qtf(new details::query_transformation<T>(callback));
-        set_query_transformation_(qtf);
+        std::unique_ptr<details::query_transformation_function> qtf(new details::query_transformation<T>(callback));
+        set_query_transformation_(std::move(qtf));
 
         assert(qtf.get() == NULL);
     }

--- a/src/core/test/common-tests.h
+++ b/src/core/test/common-tests.h
@@ -350,7 +350,7 @@ private:
     backend_factory const &backEndFactory_;
     std::string const connectString_;
 
-typedef std::auto_ptr<table_creator_base> auto_table_creator;
+typedef std::unique_ptr<table_creator_base> auto_table_creator;
 
 void test0()
 {


### PR DESCRIPTION
With C++11, SOCI v3.2.3 no longer compiles. Hence, on the newest releases of Linux distributions (eg, those shipping with g++ 6), SOCI can no longer be delivered. That patch allows to deliver SOCI v3.2.x (v3.2.4?) with G++ 6.
See for instance the [build of SOCI-3.2.3-9 on Fedora Rawhide](https://koji.fedoraproject.org/koji/buildinfo?buildID=833787).
