### PR TITLE
Firebird blob bug

### DIFF
--- a/src/backends/firebird/blob.cpp
+++ b/src/backends/firebird/blob.cpp
@@ -247,13 +247,26 @@ void firebird_blob_backend::save()
     if (data_.size() > 0)
     {
         // write data
-        if (isc_put_segment(stat, &bhp_,
-                            static_cast<unsigned short>(data_.size()), &data_[0]))
+        size_t size = data_.size();
+        size_t offset = 0;
+        // Segment Size : Specifying the BLOB segment is throwback to times past, when applications for working 
+        // with BLOB data were written in C(Embedded SQL) with the help of the gpre pre - compiler.
+        // Nowadays, it is effectively irrelevant.The segment size for BLOB data is determined by the client side and is usually larger than the data page size, 
+        // in any case.
+        do
         {
-            throw_iscerror(stat);
-        }
+            unsigned short segmentSize = 0xFFFF; //last unsigned short number
+            if (size - offset < segmentSize) //if content size is less than max segment size or last data segment is about to be written
+                segmentSize = static_cast<unsigned short>(size - offset); 
+            //write segment
+            if (isc_put_segment(stat, &bhp_, segmentSize, &data_[0]+offset))
+            {
+                throw_iscerror(stat);
+            }
+            offset += segmentSize;
+        } 
+        while (offset < size);
     }
-
     cleanUp();
     from_db_ = true;
 }

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -614,6 +614,23 @@ TEST_CASE("Firebird blobs", "[firebird][blob]")
         CHECK(ind==i_null);
     }
 
+    {
+        //create large blob
+        const int blobSize = 65536; //max segment size is 65535(unsigned short) 
+        std::vector<char> data(blobSize); 
+        blob b(sql);
+        b.write(0, data.data(), blobSize);
+        sql << "insert into test7(id, img) values(3,?)", use(b);
+
+        //now read blob back from database and make sure it has correct content and size
+        blob br(sql);
+        sql << "select img from test7 where id = 3", into(br);
+        std::vector<char> data2(br.get_len());
+        if(br.get_len()>0)
+            br.read(0, data2.data(), br.get_len());
+        CHECK(data == data2);
+    }
+
     sql << "drop table test7";
 }
 


### PR DESCRIPTION
I have discovered bug in Firebird BLOB backend save method. It is currently not possible to write data larger than max `unsigned short` 0xFFFF. The problem is that Firebird API accepts only `unsigned short` as data size and expects that `isc_put_segment` is called in loop until all data has been written meaning only 0xFFFF can be written at once.

PR consists of 2 commits. 

First one add additional Firebird test to indicate the problem. I tried to write byte sequence of size 0x10000 (out of unsigned short range). Cast to `unsigned short` results in 0 and therefore no data is written to blob.

Second commit resolves the issue.
