### PR TITLE
Pull request for issues 511 and 473

### DIFF
--- a/src/backends/oracle/error.cpp
+++ b/src/backends/oracle/error.cpp
@@ -58,6 +58,7 @@ void soci::details::oracle::get_error_details(sword res, OCIError *errhp,
         msg = "soci error: No data";
         break;
     case OCI_ERROR:
+    case OCI_SUCCESS_WITH_INFO:
         OCIErrorGet(errhp, 1, 0, &errcode,
              errbuf, sizeof(errbuf), OCI_HTYPE_ERROR);
         msg = reinterpret_cast<char*>(errbuf);

--- a/src/backends/oracle/statement.cpp
+++ b/src/backends/oracle/statement.cpp
@@ -295,6 +295,9 @@ void oracle_statement_backend::describe_column(int colNum, data_type &type,
     case SQLT_DAT:
         type = dt_date;
         break;
+    default:
+        // Unknown oracle types will just be represented by a string
+        type = dt_string;
     }
 }
 


### PR DESCRIPTION
Pull request to address issues:
https://github.com/SOCI/soci/issues/511
https://github.com/SOCI/soci/issues/473

To correctly handle the OCI_SUCCESS_WITH_INFO return code we are likely going to need to ability to handle cases where the backend does not completely fail an operation with an assert but wants to log some warning or information message back to the user of the API. This happens on Oracle database connections when the users password is about to expire. With this patch the call will still fail but rather than getting a "soci error: Unknown error code" exception the caller will get an exception with a message saying the password is about to expire.