### PR TITLE
disable autosetting of SOCI_CXX_C11 to OFF

### DIFF
--- a/cmake/SociConfig.cmake
+++ b/cmake/SociConfig.cmake
@@ -27,7 +27,9 @@ endif(WIN32)
 # C++11 Option
 #
 
-set (SOCI_CXX_C11 OFF CACHE BOOL "Build to the C++11 standard")
+if (NOT SOCI_CXX_C11 ) 
+    set (SOCI_CXX_C11 OFF CACHE BOOL "Build to the C++11 standard")
+endif (NOT SOCI_CXX_C11 ) 
 
 
 #


### PR DESCRIPTION
When building SOCI as a sub-project, this file overrides the flag value set by the parent project. 

My parent project was built as C++11, but this default was causing SOCI to build as C++98.  