### PR TITLE
Use defaults for unsupported types in ODBC backend

### DIFF
--- a/src/backends/odbc/standard-use-type.cpp
+++ b/src/backends/odbc/standard-use-type.cpp
@@ -118,25 +118,9 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
     }
     break;
 
-    case x_blob:
-    {
-//         sqlType = SQL_VARBINARY;
-//         cType = SQL_C_BINARY;
-
-//         BLOB *b = static_cast<BLOB *>(data);
-
-//         odbc_blob_backend *bbe
-//         = static_cast<odbc_blob_backend *>(b->getBackEnd());
-
-//         size = 0;
-//         indHolder_ = size;
-        //TODO            data = &bbe->lobp_;
-    }
-    break;
-    case x_statement:
-    case x_rowid:
-        // Unsupported data types.
-        return NULL;
+    // unsupported types
+    default:
+        throw soci_error("Use element used with non-supported type.");
     }
 
     // Return either the pointer to C++ data itself or the buffer that we

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -173,9 +173,8 @@ void odbc_vector_into_type_backend::define_by_pos(
         }
         break;
 
-    case x_statement: break; // not supported
-    case x_rowid:     break; // not supported
-    case x_blob:      break; // not supported
+    default:
+        throw soci_error("Into element used with non-supported type.");
     }
 
     SQLRETURN rc
@@ -380,9 +379,8 @@ void odbc_vector_into_type_backend::resize(std::size_t sz)
         }
         break;
 
-    case x_statement: break; // not supported
-    case x_rowid:     break; // not supported
-    case x_blob:      break; // not supported
+    default:
+        throw soci_error("Into vector element used with non-supported type.");
     }
 }
 
@@ -446,9 +444,8 @@ std::size_t odbc_vector_into_type_backend::size()
         }
         break;
 
-    case x_statement: break; // not supported
-    case x_rowid:     break; // not supported
-    case x_blob:      break; // not supported
+    default:
+        throw soci_error("Into vector element used with non-supported type.");
     }
 
     return sz;

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -202,9 +202,9 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
         }
         break;
 
-    case x_statement: break; // not supported
-    case x_rowid:     break; // not supported
-    case x_blob:      break; // not supported
+    // not supported
+    default:
+        throw soci_error("Use vector element used with non-supported type.");
     }
 
     colSize_ = size;
@@ -438,9 +438,9 @@ std::size_t odbc_vector_use_type_backend::size()
         }
         break;
 
-    case x_statement: break; // not supported
-    case x_rowid:     break; // not supported
-    case x_blob:      break; // not supported
+    // not supported
+    default:
+        throw soci_error("Use vector element used with non-supported type.");
     }
 
     return sz;


### PR DESCRIPTION
Attempt to fix Linux build issue for ODBC backend.
Make it similar to PostgreSQL backend behavior.