### PR TITLE
Remove warning when building with gcc -Wall -Wextra

### DIFF
--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -226,8 +226,8 @@ public:
     virtual std::size_t read(std::size_t offset, char* buf,
         std::size_t toRead) = 0;
     
-    virtual std::size_t read_from_start(char * buf, std::size_t toRead,
-        std::size_t offset)
+    virtual std::size_t read_from_start(char * /* buf */, std::size_t /* toRead */,
+        std::size_t /* offset */)
     {
         throw soci_error("read_from_start is not implemented for this backend");
     }
@@ -235,8 +235,8 @@ public:
     virtual std::size_t write(std::size_t offset, char const* buf,
         std::size_t toWrite) = 0;
     
-    virtual std::size_t write_from_start(const char * buf, std::size_t toWrite,
-        std::size_t offset)
+    virtual std::size_t write_from_start(const char * /* buf */, std::size_t /* toWrite */,
+        std::size_t /* offset */)
     {
         throw soci_error("write_from_start is not implemented for this backend");
     }


### PR DESCRIPTION
For 4.0 release :)

avoid such warnings:
```warning: unused parameter ‘begin’```