### PR TITLE
Consistently check for connection in the session object methods

### DIFF
--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -151,10 +151,7 @@ public:
     std::string nvl();
 
     // Sets the failover callback object.
-    void set_failover_callback(failover_callback & callback)
-    {
-        backEnd_->set_failover_callback(callback, *this);
-    }
+    void set_failover_callback(failover_callback & callback);
     
     // for diagnostics and advanced users
     // (downcast it to expected back-end session class)

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -361,16 +361,22 @@ bool session::get_last_insert_id(std::string const & sequence, long & value)
 
 details::once_temp_type session::get_table_names()
 {
+    ensureConnected(backEnd_);
+
     return once << backEnd_->get_table_names_query();
 }
 
 details::prepare_temp_type session::prepare_table_names()
 {
+    ensureConnected(backEnd_);
+
     return prepare << backEnd_->get_table_names_query();
 }
 
 details::prepare_temp_type session::prepare_column_descriptions(std::string & table_name)
 {
+    ensureConnected(backEnd_);
+
     return prepare << backEnd_->get_column_descriptions_query(), use(table_name, "t");
 }
     
@@ -386,11 +392,15 @@ ddl_type session::create_table(const std::string & tableName)
 
 void session::drop_table(const std::string & tableName)
 {
+    ensureConnected(backEnd_);
+
     once << backEnd_->drop_table(tableName);
 }
 
 void session::truncate_table(const std::string & tableName)
 {
+    ensureConnected(backEnd_);
+
     once << backEnd_->truncate_table(tableName);
 }
 
@@ -428,12 +438,23 @@ ddl_type session::drop_column(const std::string & tableName,
 
 std::string session::empty_blob()
 {
+    ensureConnected(backEnd_);
+
     return backEnd_->empty_blob();
 }
 
 std::string session::nvl()
 {
+    ensureConnected(backEnd_);
+
     return backEnd_->nvl();
+}
+
+void session::set_failover_callback(failover_callback & callback)
+{
+    ensureConnected(backEnd_);
+
+    backEnd_->set_failover_callback(callback, *this);
 }
 
 std::string session::get_backend_name() const


### PR DESCRIPTION
This was done for most, but not all, of them.

Add missing checks to ensure consistent and safer (exception instead of
a null pointer dereference) behaviour in all cases.

---

Just some cleanup before submitting more changes to the same code.