### PR TITLE
Define SOCI_SQLITE3_SOURCE in all SQLite3 backend sources

### DIFF
--- a/src/backends/sqlite3/blob.cpp
+++ b/src/backends/sqlite3/blob.cpp
@@ -5,6 +5,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#define SOCI_SQLITE3_SOURCE
 #include "soci/sqlite3/soci-sqlite3.h"
 
 #include <algorithm>

--- a/src/backends/sqlite3/row-id.cpp
+++ b/src/backends/sqlite3/row-id.cpp
@@ -5,6 +5,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#define SOCI_SQLITE3_SOURCE
 #include "soci/sqlite3/soci-sqlite3.h"
 
 #ifdef _MSC_VER

--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -5,7 +5,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
-
+#define SOCI_SQLITE3_SOURCE
 #include "soci/sqlite3/soci-sqlite3.h"
 
 #include "soci/connection-parameters.h"

--- a/src/backends/sqlite3/standard-into-type.cpp
+++ b/src/backends/sqlite3/standard-into-type.cpp
@@ -5,6 +5,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#define SOCI_SQLITE3_SOURCE
 #include "soci/soci-platform.h"
 #include "soci/sqlite3/soci-sqlite3.h"
 #include "soci/rowid.h"

--- a/src/backends/sqlite3/standard-use-type.cpp
+++ b/src/backends/sqlite3/standard-use-type.cpp
@@ -5,6 +5,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#define SOCI_SQLITE3_SOURCE
 #include "soci/soci-platform.h"
 #include "soci/sqlite3/soci-sqlite3.h"
 #include "soci/rowid.h"

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -4,6 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
+
+#define SOCI_SQLITE3_SOURCE
 #include "soci/sqlite3/soci-sqlite3.h"
 // std
 #include <algorithm>

--- a/src/backends/sqlite3/vector-into-type.cpp
+++ b/src/backends/sqlite3/vector-into-type.cpp
@@ -9,6 +9,7 @@
 #pragma warning(disable : 4512)
 #endif
 
+#define SOCI_SQLITE3_SOURCE
 #include "soci-dtocstr.h"
 #include "soci-exchange-cast.h"
 #include "soci/blob.h"

--- a/src/backends/sqlite3/vector-use-type.cpp
+++ b/src/backends/sqlite3/vector-use-type.cpp
@@ -5,6 +5,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#define SOCI_SQLITE3_SOURCE
 #include "soci-exchange-cast.h"
 #include "soci/soci-platform.h"
 #include "soci/sqlite3/soci-sqlite3.h"


### PR DESCRIPTION
Not doing it in session.cpp resulted in link errors in MinGW build as
SOCI_SQLITE3_DECL wasn't defined correctly in this case and the DLL
tried to import sqlite3_soci_error class instead of exporting it.

See #528.