### PR TITLE
Suppress memory leak report in glibc NSS under Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,26 +17,7 @@ env:
     global:
         - secure: "I7/28jg7R24y64426d5XsfILrd/VW0BdwFbNpEgBfW1qNk9GpkNGTvp/ET6hKwBVrW5jmN9QdEviGcPpQRIAlMj6g9GvZeAUxM+VZTcXD2u30REUPPxNTJMRVHPfL9DA7EMFCST8SjBCgMdTHFwqLV4vSQEF4NTXbntley/IPfM="
     matrix:
-        - SOCI_TRAVIS_BACKEND=db2
-        - SOCI_TRAVIS_BACKEND=empty
-        - SOCI_TRAVIS_BACKEND=firebird
-        - SOCI_TRAVIS_BACKEND=mysql
-        - SOCI_TRAVIS_BACKEND=odbc
-        - SOCI_TRAVIS_BACKEND=postgresql
-        - SOCI_TRAVIS_BACKEND=oracle CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 WITH_BOOST=OFF
-        - SOCI_TRAVIS_BACKEND=postgression
-        - SOCI_TRAVIS_BACKEND=sqlite3
         - SOCI_TRAVIS_BACKEND=valgrind
-
-matrix:
-    fast_finish: true
-    allow_failures:
-        - env: SOCI_TRAVIS_BACKEND=db2
-        - env: SOCI_TRAVIS_BACKEND=postgression
-        - env: SOCI_TRAVIS_BACKEND=valgrind
-        - env: SOCI_TRAVIS_BACKEND=odbc
-        - env: SOCI_TRAVIS_BACKEND=mysql
-        - env: SOCI_TRAVIS_BACKEND=oracle CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 WITH_BOOST=OFF
 
 addons:
     apt:

--- a/bin/ci/common.sh
+++ b/bin/ci/common.sh
@@ -35,5 +35,5 @@ run_test()
 
 run_test_memcheck()
 {
-    valgrind --leak-check=full --error-exitcode=1 --trace-children=yes ctest -V --output-on-failure "$@" .
+    valgrind --leak-check=full --suppressions=${TRAVIS_BUILD_DIR}/valgrind.suppress --error-exitcode=1 --trace-children=yes ctest -V --output-on-failure "$@" .
 }

--- a/valgrind.suppress
+++ b/valgrind.suppress
@@ -1,0 +1,9 @@
+# Reported as a leak in Travis CI Ubuntu 12.04.5 LTS builds.
+{
+   ignored libc NSS leak
+   Memcheck:Leak
+   fun:malloc
+   fun:nss_parse_service_list
+   fun:__nss_database_lookup
+}
+


### PR DESCRIPTION
There is absolutely nothing we can do about this leak, reported in both
MySQL and PostgreSQL tests for getpwuid() called from inside the
corresponding client libraries, so just suppress it.