### PR TITLE
Try adding back fast_finish=true to Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@
 #
 language: cpp
 
+# Several scripts hard code Precise and don't currently work in any other
+# environment (e.g. the default Trusty).
+dist: precise
+
+sudo: required
+
 compiler:
     - g++
     - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ services:
 env:
     global:
         - secure: "I7/28jg7R24y64426d5XsfILrd/VW0BdwFbNpEgBfW1qNk9GpkNGTvp/ET6hKwBVrW5jmN9QdEviGcPpQRIAlMj6g9GvZeAUxM+VZTcXD2u30REUPPxNTJMRVHPfL9DA7EMFCST8SjBCgMdTHFwqLV4vSQEF4NTXbntley/IPfM="
+    fast_finish: true
     matrix:
         - SOCI_TRAVIS_BACKEND=db2
         - SOCI_TRAVIS_BACKEND=empty


### PR DESCRIPTION
Somehow the changes of f938c0133c9f213cc31939a36a160e036e09614a resulted
in Travis moving all the builds from Ubuntu Precise to Ubuntu Trusty,
which is not supported by many of our scripts.

Try restoring fast_finish option, removed by this commit, to see if it
could be due to it.