### PR TITLE
Allow defining SOCI_POSTGRESQL_NOSINLGEROWMODE for PostgreSQL < 9

### DIFF
--- a/docs/backends/postgresql.md
+++ b/docs/backends/postgresql.md
@@ -57,6 +57,11 @@ Note that in the single-row operation:
 * bulk queries are not supported, and
 * in order to fulfill the expectations of the underlying client library, the complete rowset has to be exhausted before executing further queries on the same session.
 
+Also please note that single rows mode requires PostgreSQL 9 or later, both at
+compile- and run-time. If you need to support earlier versions of PostgreSQL,
+you can define `SOCI_POSTGRESQL_NOSINLGEROWMODE` when building the library to
+disable it.
+
 Once you have created a `session` object as shown above, you can use it to access the database, for example:
 
     int count;


### PR DESCRIPTION
Since the changes of b70a4e8b2fc5ae24494e1893e7b6a42852974203, PostgreSQL
backend is not compatible with PostgreSQL < 9, contrary to the documented
supported platforms in the documentation.

Ideal would be to continue supporting the old versions by default and use
PQsetSingleRowMode() only if it's detected as being available by CMake, but
for now at least allow disabling single mode support manually.

---

Allow to build under RHEL6 again. Notice that the docs still pretend that the library is compatible with 7.4 or later, which is definitely not the case by default.