### PR TITLE
fix some of warnings from fresh Coverity report

### DIFF
--- a/include/soci/firebird/soci-firebird.h
+++ b/include/soci/firebird/soci-firebird.h
@@ -63,7 +63,7 @@ struct firebird_statement_backend;
 struct firebird_standard_into_type_backend : details::standard_into_type_backend
 {
     firebird_standard_into_type_backend(firebird_statement_backend &st)
-        : statement_(st), buf_(NULL), indISCHolder_(0)
+        : statement_(st), data_(NULL), type_(), position_(0), buf_(NULL), indISCHolder_(0)
     {}
 
     virtual void define_by_pos(int &position,
@@ -89,7 +89,7 @@ struct firebird_standard_into_type_backend : details::standard_into_type_backend
 struct firebird_vector_into_type_backend : details::vector_into_type_backend
 {
     firebird_vector_into_type_backend(firebird_statement_backend &st)
-        : statement_(st), buf_(NULL), indISCHolder_(0)
+        : statement_(st), data_(NULL), type_(), position_(0), buf_(NULL), indISCHolder_(0)
     {}
 
     virtual void define_by_pos(int &position,
@@ -117,7 +117,7 @@ struct firebird_vector_into_type_backend : details::vector_into_type_backend
 struct firebird_standard_use_type_backend : details::standard_use_type_backend
 {
     firebird_standard_use_type_backend(firebird_statement_backend &st)
-        : statement_(st), buf_(NULL), indISCHolder_(0)
+        : statement_(st), data_(NULL), type_(), position_(0), buf_(NULL), indISCHolder_(0)
     {}
 
     virtual void bind_by_pos(int &position,
@@ -144,7 +144,7 @@ struct firebird_standard_use_type_backend : details::standard_use_type_backend
 struct firebird_vector_use_type_backend : details::vector_use_type_backend
 {
     firebird_vector_use_type_backend(firebird_statement_backend &st)
-        : statement_(st), inds_(NULL), buf_(NULL), indISCHolder_(0)
+        : statement_(st), data_(NULL), type_(), position_(0), buf_(NULL), indISCHolder_(0)
     {}
 
     virtual void bind_by_pos(int &position,

--- a/src/backends/firebird/blob.cpp
+++ b/src/backends/firebird/blob.cpp
@@ -13,8 +13,8 @@ using namespace soci;
 using namespace soci::details::firebird;
 
 firebird_blob_backend::firebird_blob_backend(firebird_session_backend &session)
-        : session_(session), from_db_(false), bhp_(0), loaded_(false),
-        max_seg_size_(0)
+	  : session_(session), bid_(), from_db_(false), bhp_(0), data_(),
+		loaded_(false), max_seg_size_(0)
 {}
 
 firebird_blob_backend::~firebird_blob_backend()


### PR DESCRIPTION
I just got fresh Coverity report & decided to fix new warnings about not initialized variables