### PR TITLE
Avoid using overloaded virtual methods in vector type backends

### DIFF
--- a/cmake/SociConfig.cmake
+++ b/cmake/SociConfig.cmake
@@ -45,13 +45,13 @@ if (MSVC)
   if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
     string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /we4266")
   endif()
 
 else()
 
   set(SOCI_GCC_CLANG_COMMON_FLAGS
-    "-pedantic -Werror -Wno-error=parentheses -Wall -Wextra -Wpointer-arith -Wcast-align -Wcast-qual -Wfloat-equal -Wredundant-decls -Wno-long-long")
+    "-pedantic -Werror -Wno-error=parentheses -Wall -Wextra -Wpointer-arith -Wcast-align -Wcast-qual -Wfloat-equal -Woverloaded-virtual -Wredundant-decls -Wno-long-long")
 
 
   if (SOCI_CXX_C11)

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -89,10 +89,10 @@ struct oracle_vector_into_type_backend : details::vector_into_type_backend
         void *data, details::exchange_type type)
     {
         user_ranges_ = false;
-        define_by_pos(position, data, type, 0, &end_var_);
+        define_by_pos_bulk(position, data, type, 0, &end_var_);
     }
     
-    virtual void define_by_pos(
+    virtual void define_by_pos_bulk(
         int & position, void * data, details::exchange_type type,
         std::size_t begin, std::size_t * end);
 
@@ -173,20 +173,20 @@ struct oracle_vector_use_type_backend : details::vector_use_type_backend
     virtual void bind_by_pos(int & position,
         void * data, details::exchange_type type)
     {
-        bind_by_pos(position, data, type, 0, &end_var_);
+        bind_by_pos_bulk(position, data, type, 0, &end_var_);
     }
     
-    virtual void bind_by_pos(int & position,
+    virtual void bind_by_pos_bulk(int & position,
         void * data, details::exchange_type type,
         std::size_t begin, std::size_t * end);
     
     virtual void bind_by_name(const std::string & name,
         void * data, details::exchange_type type)
     {
-        bind_by_name(name, data, type, 0, &end_var_);
+        bind_by_name_bulk(name, data, type, 0, &end_var_);
     }
 
-    virtual void bind_by_name(std::string const &name,
+    virtual void bind_by_name_bulk(std::string const &name,
         void *data, details::exchange_type type,
         std::size_t begin, std::size_t * end);
 

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -155,10 +155,10 @@ struct postgresql_vector_into_type_backend : details::vector_into_type_backend
         void * data, details::exchange_type type)
     {
         user_ranges_ = false;
-        define_by_pos(position, data, type, 0, &end_var_);
+        define_by_pos_bulk(position, data, type, 0, &end_var_);
     }
 
-    virtual void define_by_pos(int & position,
+    virtual void define_by_pos_bulk(int & position,
         void * data, details::exchange_type type,
         std::size_t begin, std::size_t * end);
 
@@ -214,20 +214,20 @@ struct postgresql_vector_use_type_backend : details::vector_use_type_backend
     virtual void bind_by_pos(int & position,
         void * data, details::exchange_type type)
     {
-        bind_by_pos(position, data, type, 0, &end_var_);
+        bind_by_pos_bulk(position, data, type, 0, &end_var_);
     }
     
-    virtual void bind_by_pos(int & position,
+    virtual void bind_by_pos_bulk(int & position,
         void * data, details::exchange_type type,
         std::size_t begin, std::size_t * end);
     
     virtual void bind_by_name(std::string const & name,
         void * data, details::exchange_type type)
     {
-        bind_by_name(name, data, type, 0, &end_var_);
+        bind_by_name_bulk(name, data, type, 0, &end_var_);
     }
 
-    virtual void bind_by_name(const std::string & name,
+    virtual void bind_by_name_bulk(const std::string & name,
         void * data, details::exchange_type type,
         std::size_t begin, std::size_t * end);
     

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -88,7 +88,7 @@ public:
     vector_into_type_backend() {}
     virtual ~vector_into_type_backend() {}
 
-    virtual void define_by_pos(
+    virtual void define_by_pos_bulk(
         int & /* position */, void * /* data */, exchange_type /* type */,
         std::size_t /* begin */, std::size_t * /* end */)
     {
@@ -140,7 +140,7 @@ public:
     virtual ~vector_use_type_backend() {}
 
     virtual void bind_by_pos(int& position, void* data, exchange_type type) = 0;
-    virtual void bind_by_pos(int& /* position */, void* /* data */, exchange_type /* type */,
+    virtual void bind_by_pos_bulk(int& /* position */, void* /* data */, exchange_type /* type */,
         std::size_t /* begin */, std::size_t * /* end */)
     {
         throw soci_error("use bulk iterators are not supported with this backend");
@@ -149,7 +149,7 @@ public:
     virtual void bind_by_name(std::string const& name,
         void* data, exchange_type type) = 0;
 
-    virtual void bind_by_name(std::string const& /* name */,
+    virtual void bind_by_name_bulk(std::string const& /* name */,
         void* /* data */, exchange_type /* type */,
         std::size_t /* begin */, std::size_t * /* end */)
     {

--- a/src/backends/oracle/vector-into-type.cpp
+++ b/src/backends/oracle/vector-into-type.cpp
@@ -40,7 +40,7 @@ void oracle_vector_into_type_backend::prepare_indicators(std::size_t size)
     rCodes_.resize(size);
 }
 
-void oracle_vector_into_type_backend::define_by_pos(
+void oracle_vector_into_type_backend::define_by_pos_bulk(
     int & position, void * data, exchange_type type,
     std::size_t begin, std::size_t * end)
 {

--- a/src/backends/oracle/vector-use-type.cpp
+++ b/src/backends/oracle/vector-use-type.cpp
@@ -163,7 +163,7 @@ void oracle_vector_use_type_backend::prepare_for_bind(
     }
 }
 
-void oracle_vector_use_type_backend::bind_by_pos(int & position,
+void oracle_vector_use_type_backend::bind_by_pos_bulk(int & position,
     void * data, exchange_type type,
     std::size_t begin, std::size_t * end)
 {
@@ -196,7 +196,7 @@ void oracle_vector_use_type_backend::bind_by_pos(int & position,
     }
 }
 
-void oracle_vector_use_type_backend::bind_by_name(
+void oracle_vector_use_type_backend::bind_by_name_bulk(
     std::string const &name, void *data, exchange_type type,
     std::size_t begin, std::size_t * end)
 {

--- a/src/backends/postgresql/vector-into-type.cpp
+++ b/src/backends/postgresql/vector-into-type.cpp
@@ -30,7 +30,7 @@ using namespace soci::details;
 using namespace soci::details::postgresql;
 
 
-void postgresql_vector_into_type_backend::define_by_pos(
+void postgresql_vector_into_type_backend::define_by_pos_bulk(
     int & position, void * data, exchange_type type,
     std::size_t begin, std::size_t * end)
 {

--- a/src/backends/postgresql/vector-use-type.cpp
+++ b/src/backends/postgresql/vector-use-type.cpp
@@ -31,7 +31,7 @@ using namespace soci::details;
 using namespace soci::details::postgresql;
 
 
-void postgresql_vector_use_type_backend::bind_by_pos(int & position,
+void postgresql_vector_use_type_backend::bind_by_pos_bulk(int & position,
     void * data, exchange_type type,
     std::size_t begin, std::size_t * end)
 {
@@ -44,7 +44,7 @@ void postgresql_vector_use_type_backend::bind_by_pos(int & position,
     end_var_ = full_size();
 }
 
-void postgresql_vector_use_type_backend::bind_by_name(
+void postgresql_vector_use_type_backend::bind_by_name_bulk(
     std::string const & name, void * data, exchange_type type,
     std::size_t begin, std::size_t * end)
 {

--- a/src/core/into-type.cpp
+++ b/src/core/into-type.cpp
@@ -70,7 +70,7 @@ void vector_into_type::define(statement_impl & st, int & position)
 
     if (end_ != NULL)
     {
-        backEnd_->define_by_pos(position, data_, type_, begin_, end_);
+        backEnd_->define_by_pos_bulk(position, data_, type_, begin_, end_);
     }
     else
     {

--- a/src/core/use-type.cpp
+++ b/src/core/use-type.cpp
@@ -167,7 +167,7 @@ void vector_use_type::bind(statement_impl & st, int & position)
     {
         if (end_ != NULL)
         {
-            backEnd_->bind_by_pos(position, data_, type_, begin_, end_);
+            backEnd_->bind_by_pos_bulk(position, data_, type_, begin_, end_);
         }
         else
         {
@@ -178,7 +178,7 @@ void vector_use_type::bind(statement_impl & st, int & position)
     {
         if (end_ != NULL)
         {
-            backEnd_->bind_by_name(name_, data_, type_, begin_, end_);
+            backEnd_->bind_by_name_bulk(name_, data_, type_, begin_, end_);
         }
         else
         {


### PR DESCRIPTION
This is mostly done in order to allow SOCI headers to compile cleanly
with -Woverloaded-virtual (or corresponding MSVC warning C4266) in
effect, but it also allows to turn the same warning on for building SOCI
itself, which can be useful.

---

I'm submitting this because I'd like to avoid warnings when including `soci/odbc/soci-odbc.h` in my own project which enables this warning without having to put pragmas before/after including it and I think I might be not the only one doing this.

If renaming these methods is too contentious (I don't think there are any compatibility considerations in play here, but I could be missing something), there is also a possibility of just adding `using vector_into_type_backend::define_by_pos;` etc to all the derived classes instead.