### PR TITLE
Switch Travis CI to Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@
 #
 # Copyright (c) 2013 Mateusz Loskot <mateusz@loskot.net>
 #
-# TODO: Switch to Trusty https://github.com/SOCI/soci/issues/574
-dist: precise
-language: cpp
+dist: trusty
 
 sudo: required
+
+language: cpp
 
 compiler:
   - g++
@@ -34,13 +34,18 @@ matrix:
         - env: SOCI_TRAVIS_BACKEND=oracle WITH_BOOST=OFF
 
 addons:
-  coverity_scan:
-    project:
-      name: "SOCI/soci"
-    notification_email: soci-devel@lists.sourceforge.net
-    build_command_prepend: "sh ${TRAVIS_BUILD_DIR}/scripts/travis/install_cmake.sh; mkdir build.cov; cd build.cov; cmake .."
-    build_command: "make -j 4"
-    branch_pattern: coverity_scan
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - cmake
+    coverity_scan:
+        project:
+            name: "SOCI/soci"
+        notification_email: soci-devel@lists.sourceforge.net
+        build_command_prepend: "mkdir build.cov; cd build.cov; cmake .."
+        build_command: "make -j 4"
+        branch_pattern: coverity_scan
 
 before_install: ./scripts/travis/before_install.sh
 before_script: ./scripts/travis/before_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,18 @@ env:
     - secure: "I7/28jg7R24y64426d5XsfILrd/VW0BdwFbNpEgBfW1qNk9GpkNGTvp/ET6hKwBVrW5jmN9QdEviGcPpQRIAlMj6g9GvZeAUxM+VZTcXD2u30REUPPxNTJMRVHPfL9DA7EMFCST8SjBCgMdTHFwqLV4vSQEF4NTXbntley/IPfM="
 
 matrix:
-    include:
-        - env: SOCI_TRAVIS_BACKEND=db2
-        - env: SOCI_TRAVIS_BACKEND=empty
-        - env: SOCI_TRAVIS_BACKEND=firebird
-        - env: SOCI_TRAVIS_BACKEND=mysql
-        - env: SOCI_TRAVIS_BACKEND=odbc
-        - env: SOCI_TRAVIS_BACKEND=postgresql
-        - env: SOCI_TRAVIS_BACKEND=sqlite3
-        - env: SOCI_TRAVIS_BACKEND=valgrind
-        - env: SOCI_TRAVIS_BACKEND=oracle WITH_BOOST=OFF
+  include:
+    - env: SOCI_TRAVIS_BACKEND=db2
+    - env: SOCI_TRAVIS_BACKEND=empty
+    - env: SOCI_TRAVIS_BACKEND=firebird
+    - env: SOCI_TRAVIS_BACKEND=mysql
+    - env: SOCI_TRAVIS_BACKEND=odbc
+    - env: SOCI_TRAVIS_BACKEND=postgresql
+    - env: SOCI_TRAVIS_BACKEND=sqlite3
+    - env: SOCI_TRAVIS_BACKEND=valgrind
+    - env: SOCI_TRAVIS_BACKEND=oracle WITH_BOOST=OFF
+  allow_failures:
+    - env: SOCI_TRAVIS_BACKEND=valgrind
 
 addons:
     apt:

--- a/scripts/travis/before_install.sh
+++ b/scripts/travis/before_install.sh
@@ -8,8 +8,6 @@ source ${TRAVIS_BUILD_DIR}/scripts/travis/common.sh
 sudo apt-get update -qq -y
 sudo apt-get install -qq -y libboost-dev libboost-date-time-dev valgrind
 
-sh ${TRAVIS_BUILD_DIR}/scripts/travis/install_cmake.sh
-
 before_install="${TRAVIS_BUILD_DIR}/scripts/travis/before_install_${SOCI_TRAVIS_BACKEND}.sh"
 if [ -x ${before_install} ]; then
 	echo "Running ${before_install}"

--- a/scripts/travis/before_script_mysql.sh
+++ b/scripts/travis/before_script_mysql.sh
@@ -6,4 +6,5 @@
 source ${TRAVIS_BUILD_DIR}/scripts/travis/common.sh
 
 mysql --version
-mysql -e 'create database soci_test;'
+mysql -u root -e "CREATE DATABASE soci_test;"
+mysql -u root -e "GRANT ALL PRIVILEGES ON soci_test.* TO 'travis'@'%';";

--- a/scripts/travis/before_script_odbc.sh
+++ b/scripts/travis/before_script_odbc.sh
@@ -6,6 +6,7 @@
 source ${TRAVIS_BUILD_DIR}/scripts/travis/common.sh
 
 mysql --version
-mysql -e 'create database soci_test;'
+mysql -u root -e "CREATE DATABASE soci_test;"
+mysql -u root -e "GRANT ALL PRIVILEGES ON soci_test.* TO 'travis'@'%';";
 psql --version
 psql -c 'create database soci_test;' -U postgres

--- a/scripts/travis/before_script_valgrind.sh
+++ b/scripts/travis/before_script_valgrind.sh
@@ -7,6 +7,7 @@
 source ${TRAVIS_BUILD_DIR}/scripts/travis/common.sh
 
 mysql --version
-mysql -e 'create database soci_test;'
+mysql -u root -e "CREATE DATABASE soci_test;"
+mysql -u root -e "GRANT ALL PRIVILEGES ON soci_test.* TO 'travis'@'%';";
 psql --version
 psql -c 'create database soci_test;' -U postgres

--- a/scripts/travis/install_cmake.sh
+++ b/scripts/travis/install_cmake.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -x
-
-wget -q https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.sh
-sudo sh cmake-3.11.0-Linux-x86_64.sh -- --skip-license --prefix=/usr/local
-cmake --version


### PR DESCRIPTION
Update/Remove outdated PPA repositories.
Corret Firebird post-installation steps to set password correctly.
Grant MySQL privileges to travis user explicitly (see travis-ci/travis-ci#8331)

Allow valgrind job to fail because ODBC backend tests are failing with valgrind.
Turns out on Trusty, ODBC is enabled by default because all client libraries are available.

Closes #574