### PR TITLE
Add support for EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
+# This is the EditorConfig (http://editorconfig.org/) coding style file for SOCI.
 root = true
 
 [*]
@@ -6,6 +7,7 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+trim_trailing_whitespace = true
 
 [{Vagrantfile,CMakeLists.txt,*.cmake}]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+
+[{Vagrantfile,CMakeLists.txt,*.cmake}]
+indent_size = 2


### PR DESCRIPTION
http://editorconfig.org/ helps developers define and maintain consistent coding styles
between different editors and IDEs.  Some IDEs have this support out of box, while some
are requiring separate plugin to be installed.

I've tried to create configuration based on the project's style wiki page & checking the
different files in project.