### PR TITLE
Add CLOB and XML support to Firebird backend

### DIFF
--- a/include/soci/firebird/soci-firebird.h
+++ b/include/soci/firebird/soci-firebird.h
@@ -85,6 +85,11 @@ struct firebird_standard_into_type_backend : details::standard_into_type_backend
 
     char *buf_;
     short indISCHolder_;
+
+private:
+    // Copy contents of a BLOB (represented by its id) in buf_ into the given
+    // string.
+    void copy_from_blob(std::string& out);
 };
 
 struct firebird_vector_into_type_backend : details::vector_into_type_backend
@@ -141,6 +146,11 @@ struct firebird_standard_use_type_backend : details::standard_use_type_backend
 
     char *buf_;
     short indISCHolder_;
+
+private:
+    // Allocate a temporary blob, fill it with the data from the provided
+    // string and copy its ID into buf_.
+    void copy_to_blob(const std::string& in);
 
     // This is used for types mapping to CLOB.
     firebird_blob_backend* blob_;

--- a/include/soci/firebird/soci-firebird.h
+++ b/include/soci/firebird/soci-firebird.h
@@ -59,6 +59,7 @@ enum BuffersType
     eStandard, eVector
 };
 
+struct firebird_blob_backend;
 struct firebird_statement_backend;
 struct firebird_standard_into_type_backend : details::standard_into_type_backend
 {
@@ -117,7 +118,8 @@ struct firebird_vector_into_type_backend : details::vector_into_type_backend
 struct firebird_standard_use_type_backend : details::standard_use_type_backend
 {
     firebird_standard_use_type_backend(firebird_statement_backend &st)
-        : statement_(st), data_(NULL), type_(), position_(0), buf_(NULL), indISCHolder_(0)
+        : statement_(st), data_(NULL), type_(), position_(0), buf_(NULL), indISCHolder_(0),
+          blob_(NULL)
     {}
 
     virtual void bind_by_pos(int &position,
@@ -139,6 +141,9 @@ struct firebird_standard_use_type_backend : details::standard_use_type_backend
 
     char *buf_;
     short indISCHolder_;
+
+    // This is used for types mapping to CLOB.
+    firebird_blob_backend* blob_;
 };
 
 struct firebird_vector_use_type_backend : details::vector_use_type_backend

--- a/src/backends/firebird/standard-into-type.cpp
+++ b/src/backends/firebird/standard-into-type.cpp
@@ -126,26 +126,39 @@ void firebird_standard_into_type_backend::exchangeData()
             {
                 long_string* const dst = static_cast<long_string*>(data_);
 
-                firebird_blob_backend blob(statement_.session_);
-                blob.assign(*reinterpret_cast<ISC_QUAD*>(buf_));
+                copy_from_blob(dst->value);
+            }
+            break;
 
-                std::size_t const len_total = blob.get_len();
-                dst->value.resize(len_total);
+        case x_xmltype:
+            {
+                xml_type* const dst = static_cast<xml_type*>(data_);
 
-                std::size_t len_read = blob.read(0, &dst->value[0], len_total);
-                if (len_read != len_total)
-                {
-                    std::ostringstream os;
-                    os << "Read " << len_read << " bytes instead of expected "
-                       << len_total << " from Firebird text blob object";
-                    throw soci_error(os.str());
-                }
+                copy_from_blob(dst->value);
             }
             break;
 
         default:
             throw soci_error("Into element used with non-supported type.");
     } // switch
+}
+
+void firebird_standard_into_type_backend::copy_from_blob(std::string& out)
+{
+    firebird_blob_backend blob(statement_.session_);
+    blob.assign(*reinterpret_cast<ISC_QUAD*>(buf_));
+
+    std::size_t const len_total = blob.get_len();
+    out.resize(len_total);
+
+    std::size_t const len_read = blob.read(0, &out[0], len_total);
+    if (len_read != len_total)
+    {
+        std::ostringstream os;
+        os << "Read " << len_read << " bytes instead of expected "
+           << len_total << " from Firebird text blob object";
+        throw soci_error(os.str());
+    }
 }
 
 void firebird_standard_into_type_backend::clean_up()

--- a/src/backends/firebird/standard-into-type.cpp
+++ b/src/backends/firebird/standard-into-type.cpp
@@ -11,6 +11,8 @@
 #include "firebird/common.h"
 #include "soci/soci.h"
 
+#include <sstream>
+
 using namespace soci;
 using namespace soci::details;
 using namespace soci::details::firebird;
@@ -119,6 +121,28 @@ void firebird_standard_into_type_backend::exchangeData()
                 blob->assign(*reinterpret_cast<ISC_QUAD*>(buf_));
             }
             break;
+
+        case x_longstring:
+            {
+                long_string* const dst = static_cast<long_string*>(data_);
+
+                firebird_blob_backend blob(statement_.session_);
+                blob.assign(*reinterpret_cast<ISC_QUAD*>(buf_));
+
+                std::size_t const len_total = blob.get_len();
+                dst->value.resize(len_total);
+
+                std::size_t len_read = blob.read(0, &dst->value[0], len_total);
+                if (len_read != len_total)
+                {
+                    std::ostringstream os;
+                    os << "Read " << len_read << " bytes instead of expected "
+                       << len_total << " from Firebird text blob object";
+                    throw soci_error(os.str());
+                }
+            }
+            break;
+
         default:
             throw soci_error("Into element used with non-supported type.");
     } // switch

--- a/src/backends/firebird/standard-use-type.cpp
+++ b/src/backends/firebird/standard-use-type.cpp
@@ -147,6 +147,18 @@ void firebird_standard_use_type_backend::exchangeData()
                 memcpy(buf_, &blob->bid_, var->sqllen);
             }
             break;
+
+        case x_longstring:
+            {
+                long_string const* const src = static_cast<long_string*>(data_);
+
+                blob_ = new firebird_blob_backend(statement_.session_);
+                blob_->append(src->value.c_str(), src->value.length());
+                blob_->save();
+                memcpy(buf_, &blob_->bid_, var->sqllen);
+            }
+            break;
+
         default:
             throw soci_error("Use element used with non-supported type.");
     } // switch
@@ -175,6 +187,13 @@ void firebird_standard_use_type_backend::clean_up()
         delete [] buf_;
         buf_ = NULL;
     }
+
+    if (blob_)
+    {
+        delete blob_;
+        blob_ = NULL;
+    }
+
     std::vector<void*>::iterator it =
         std::find(statement_.uses_.begin(), statement_.uses_.end(), this);
     if (it != statement_.uses_.end())

--- a/src/backends/firebird/standard-use-type.cpp
+++ b/src/backends/firebird/standard-use-type.cpp
@@ -152,16 +152,29 @@ void firebird_standard_use_type_backend::exchangeData()
             {
                 long_string const* const src = static_cast<long_string*>(data_);
 
-                blob_ = new firebird_blob_backend(statement_.session_);
-                blob_->append(src->value.c_str(), src->value.length());
-                blob_->save();
-                memcpy(buf_, &blob_->bid_, var->sqllen);
+                copy_to_blob(src->value);
+            }
+            break;
+
+        case x_xmltype:
+            {
+                xml_type const* const src = static_cast<xml_type*>(data_);
+
+                copy_to_blob(src->value);
             }
             break;
 
         default:
             throw soci_error("Use element used with non-supported type.");
     } // switch
+}
+
+void firebird_standard_use_type_backend::copy_to_blob(const std::string& in)
+{
+    blob_ = new firebird_blob_backend(statement_.session_);
+    blob_->append(in.c_str(), in.length());
+    blob_->save();
+    memcpy(buf_, &blob_->bid_, sizeof(blob_->bid_));
 }
 
 void firebird_standard_use_type_backend::post_use(

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -1285,6 +1285,17 @@ struct TableCreatorCLOB : public tests::table_creator_base
     }
 };
 
+struct TableCreatorXML : public tests::table_creator_base
+{
+    TableCreatorXML(soci::session & sql)
+            : tests::table_creator_base(sql)
+    {
+        sql << "create table soci_test(id integer, x blob sub_type text)";
+        sql.commit();
+        sql.begin();
+    }
+};
+
 class test_context : public tests::test_context_base
 {
     public:
@@ -1316,6 +1327,11 @@ class test_context : public tests::test_context_base
         tests::table_creator_base* table_creator_clob(soci::session& s) const
         {
             return new TableCreatorCLOB(s);
+        }
+
+        tests::table_creator_base* table_creator_xml(soci::session& s) const
+        {
+            return new TableCreatorXML(s);
         }
 
         std::string to_date_time(std::string const &datdt_string) const

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -1274,6 +1274,17 @@ struct TableCreator4 : public tests::table_creator_base
     }
 };
 
+struct TableCreatorCLOB : public tests::table_creator_base
+{
+    TableCreatorCLOB(soci::session & sql)
+            : tests::table_creator_base(sql)
+    {
+        sql << "create table soci_test(id integer, s blob sub_type text)";
+        sql.commit();
+        sql.begin();
+    }
+};
+
 class test_context : public tests::test_context_base
 {
     public:
@@ -1300,6 +1311,11 @@ class test_context : public tests::test_context_base
         tests::table_creator_base* table_creator_4(soci::session& s) const
         {
             return new TableCreator4(s);
+        }
+
+        tests::table_creator_base* table_creator_clob(soci::session& s) const
+        {
+            return new TableCreatorCLOB(s);
         }
 
         std::string to_date_time(std::string const &datdt_string) const

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -1421,64 +1421,6 @@ TEST_CASE("Bulk iterators", "[oracle][bulkiters]")
     sql << "drop table t";
 }
 
-// XML and big string test
-TEST_CASE("XML and big string", "[oracle][xml]")
-{
-    session sql(backEnd, connectString);
-
-    sql << "create table xml_test (id integer, x xmltype)";
-
-    int id = 1;
-    xml_type xml;
-    xml.value = "<file>";
-    for (int i = 0; i != 200; ++i)
-    {
-        xml.value += "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    }
-    xml.value += "</file>";
-
-    sql << "insert into xml_test (id, x) values (:1, xmltype(:2))", use(id), use(xml);
-
-    xml_type xml2;
-
-    sql << "select t.x.getCLOBVal() from xml_test t where id = :1", into(xml2), use(id);
-
-    // note: getCLOBVal() returns XML value with newline added at the end
-    CHECK(xml.value + '\n' == xml2.value);
-
-    sql << "update xml_test set x = null where id = :1", use(id);
-
-    indicator ind;
-    sql << "select t.x.getCLOBVal() from xml_test t where id = :1", into(xml2, ind), use(id);
-
-    CHECK(ind == i_null);
-    
-    sql << "drop table xml_test";
-
-    // additional test for empty and non-empty long_string
-
-    sql << "create table long_string_test (id integer, s clob)";
-
-    long_string s1; // empty
-    sql << "insert into long_string_test(id, s) values (1, :s)", use(s1);
-
-    long_string s2;
-    s2.value = "hello";
-    sql << "select s from long_string_test where id = 1", into(s2);
-
-    CHECK(s2.value.size() == 0);
-
-    s1.value = xml.value; // some long value
-    
-    sql << "update long_string_test set s = :s where id = 1", use(s1);
-    
-    sql << "select s from long_string_test where id = 1", into(s2);
-
-    CHECK(s2.value == xml.value);
-    
-    sql << "drop table long_string_test";
-}
-
 //
 // Support for soci Common Tests
 //
@@ -1524,6 +1466,24 @@ struct table_creator_four : public table_creator_base
     }
 };
 
+struct table_creator_for_xml : table_creator_base
+{
+    table_creator_for_xml(soci::session& sql)
+        : table_creator_base(sql)
+    {
+        sql << "create table soci_test(id integer, x xmltype)";
+    }
+};
+
+struct table_creator_for_clob : table_creator_base
+{
+    table_creator_for_clob(soci::session& sql)
+        : table_creator_base(sql)
+    {
+        sql << "create table soci_test(id integer, s clob)";
+    }
+};
+
 class test_context :public test_context_base
 {
 public:
@@ -1549,6 +1509,28 @@ public:
     table_creator_base* table_creator_4(soci::session& s) const
     {
         return new table_creator_four(s);
+    }
+
+    table_creator_base* table_creator_clob(soci::session& s) const
+    {
+        return new table_creator_for_clob(s);
+    }
+
+    table_creator_base* table_creator_xml(soci::session& s) const
+    {
+        return new table_creator_for_xml(s);
+    }
+
+    std::string to_xml(std::string const& x) const
+    {
+        return "xmltype(" + x + ")";
+    }
+
+    std::string from_xml(std::string const& x) const
+    {
+        // Notice that using just x.getCLOBVal() doesn't work, only
+        // table.x.getCLOBVal() or (x).getCLOBVal(), as used here, does.
+        return "(" + x + ").getCLOBVal()";
     }
 
     std::string to_date_time(std::string const &datdt_string) const


### PR DESCRIPTION
This PR contains a refactoring of the existing tests and Firebird-specific changes.

I'd appreciate any comments about the need to add `blob_` to `firebird_standard_use_type_backend` in order to handle CLOBs. This seems wrong to me because it's so different from the way BLOBs are handled, but I just don't see any way to do it otherwise except changing the API and replacing the simple `long_string` struct with `clob` one similar to the existing `blob`, i.e. having its proper backend.