### PR TITLE
Restore Oracle build job on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 #
 # Copyright (c) 2013 Mateusz Loskot <mateusz@loskot.net>
 #
-# TODO: Switc to Trusty https://github.com/SOCI/soci/issues/574
+# TODO: Switch to Trusty https://github.com/SOCI/soci/issues/574
 dist: precise
 language: cpp
 
@@ -29,9 +29,7 @@ env:
         - SOCI_TRAVIS_BACKEND=postgresql
         - SOCI_TRAVIS_BACKEND=sqlite3
         - SOCI_TRAVIS_BACKEND=valgrind
-
-# This build is disabled because Oracle setup is currently broken, see #554.
-# - SOCI_TRAVIS_BACKEND=oracle CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 WITH_BOOST=OFF
+        - SOCI_TRAVIS_BACKEND=oracle WITH_BOOST=OFF
 
 addons:
     apt:

--- a/scripts/travis/before_install_oracle.sh
+++ b/scripts/travis/before_install_oracle.sh
@@ -1,123 +1,23 @@
 #!/bin/bash
-# Script performs non-interactive installation of Oracle XE 10g on Debian
+# Script performs non-interactive installation of Oracle XE on Linux
 #
-# Based on oracle10g-update.sh from HTSQL project:
-# https://bitbucket.org/prometheus/htsql
-#
-# Modified by Mateusz Loskot <mateusz@loskot.net>
-# Changes:
-# - Add fake swap support (backup /usr/bin/free manually anyway!)
-# - Increase Oracle XE's PROCESSES parameter to value from range 100-200.
-#   Required to prevent random ORA-12520 errors while running tests.
-#
-# Modified by Peter Butkovic <butkovic@gmail.com> to enable i386 install on amd64 architecture (precise 64)
-# based on: http://www.ubuntugeek.com/how-to-install-oracle-10g-xe-in-64-bit-ubuntu.html
+# Uses Oracle downloader and installer from https://github.com/cbandy/travis-oracle
 #
 # set -ex
-source ${TRAVIS_BUILD_DIR}/scripts/travis/common.sh
+source ${TRAVIS_BUILD_DIR}/scripts/travis/oracle.sh
 
-#
-# Utilities
-#
-function free_backup()
-{
-    # Multiple copies to be on safe side
-    sudo cp /usr/bin/free /root
-    sudo mv /usr/bin/free /usr/bin/free.original
-}
+# Install Oracle and travis-oracle requirements
+sudo apt-get install -y libaio1 rpm
 
-function free_restore()
-{
-    sudo cp /usr/bin/free.original /usr/bin/free
-}
+curl -s -o $HOME/.nvm/nvm.sh https://raw.githubusercontent.com/creationix/nvm/v0.31.0/nvm.sh
+source $HOME/.nvm/nvm.sh
+nvm install stable
+node --version
 
-# Install fake free
-# http://www.axelog.de/2010/02/7-oracle-ee-refused-to-install-into-openvz/
-free_backup
+# Install Oracle
+wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.2.tar.gz'
+mkdir -p .travis/oracle
+tar x -C .travis/oracle --strip-components=1 -f v2.0.2.tar.gz
 
-sudo tee /usr/bin/free <<EOF > /dev/null
-#!/bin/sh
-cat <<__eof
-             total       used       free     shared    buffers     cached
-Mem:       1048576     327264     721312          0          0          0
--/+ buffers/cache:     327264     721312
-Swap:      2000000          0    2000000
-__eof
-exit
-EOF
-
-sudo chmod 755 /usr/bin/free
-
-#
-# ok, bc, is the dependency that is required by DB2 as well => let's remove it from oracle xe dependencies and provide 64bit one only
-#
-
-# Install the Oracle 10g dependant packages
-sudo apt-fast install -qq -y --force-yes libc6:i386
-# travis needs the "apt-transport-https" to enable https transport
-sudo apt-fast install -qq -y bc apt-transport-https
-
-# add Oracle repo + key (please note https is a must here, otherwise "apt-get update" fails for this repo with the "Undetermined error")
-sudo bash -c 'echo "deb https://oss.oracle.com/debian/ unstable main non-free" >/etc/apt/sources.list.d/oracle.list'
-wget -q https://oss.oracle.com/el4/RPM-GPG-KEY-oracle -O- | sudo apt-key add -
-sudo apt-fast update -qq -y
-
-# only download the package, to manually install afterwards
-sudo apt-fast install -qq -y --force-yes -d oracle-xe-universal:i386
-sudo apt-fast install -qq -y --force-yes libaio:i386
-
-# remove key + repo (to prevent failures on next updates)
-sudo apt-key del B38A8516
-sudo bash -c 'rm -rf /etc/apt/sources.list.d/oracle.list'
-sudo apt-fast update -qq -y
-sudo apt-get autoremove -qq
-
-# remove bc from the dependencies of the oracle-xe-universal package (to keep 64bit one installed)
-mkdir /tmp/oracle_unpack
-dpkg-deb -x /var/cache/apt/archives/oracle-xe-universal_10.2.0.1-1.1_i386.deb /tmp/oracle_unpack
-cd /tmp/oracle_unpack
-dpkg-deb --control /var/cache/apt/archives/oracle-xe-universal_10.2.0.1-1.1_i386.deb
-sed -i "s/,\ bc//g" /tmp/oracle_unpack/DEBIAN/control
-mkdir /tmp/oracle_repack
-dpkg -b /tmp/oracle_unpack /tmp/oracle_repack/oracle-xe-universal_fixed_10.2.0.1-1.1_i386.deb
-
-# install Oracle 10g with the fixed dependencies, to prevent i386/amd64 conflicts on bc package
-sudo dpkg -i --force-architecture /tmp/oracle_repack/oracle-xe-universal_fixed_10.2.0.1-1.1_i386.deb
-
-# Fix the problem when the configuration script eats the last
-# character of the password if it is 'n': replace IFS="\n" with IFS=$'\n'.
-sudo sed -i -e s/IFS=\"\\\\n\"/IFS=\$\'\\\\n\'/ /etc/init.d/oracle-xe
-
-# Configure the server; provide the answers for the following questions:
-# The HTTP port for Oracle Application Express: 8080
-# A port for the database listener: 1521
-# The password for the SYS and SYSTEM database accounts: admin
-# Start the server on boot: yes
-sudo /etc/init.d/oracle-xe configure <<END
-8080
-1521
-admin
-admin
-y
-END
-
-# Load Oracle environment variables so that we could run `sqlplus`.
-. /usr/lib/oracle/xe/app/oracle/product/10.2.0/server/bin/oracle_env.sh
-
-# Increase the number of connections.
-echo "ALTER SYSTEM SET PROCESSES=200 SCOPE=SPFILE;" | \
-sqlplus -S -L sys/admin AS SYSDBA
-
-# need to restart, to apply connection number update
-sudo /etc/init.d/oracle-xe restart
-
-# Set Oracle environment variables on login.
-# NOTE, mloskot: On Travis CI, fails with Permission denied
-#sudo cat <<END >>/root/.bashrc
-#. /usr/lib/oracle/xe/app/oracle/product/10.2.0/server/bin/oracle_env.sh
-#END
-
-free_restore
-
-# Install development toolset for 32-bit for Travis CI 64-bit
-sudo apt-fast install -qq -y g++-multilib
+bash .travis/oracle/download.sh
+bash .travis/oracle/install.sh

--- a/scripts/travis/before_script_oracle.sh
+++ b/scripts/travis/before_script_oracle.sh
@@ -7,39 +7,35 @@
 # Changes:
 # - Check connection as user for testing
 #
-
-# for some reason the file is not found any more here => creating user in install script
-# Load Oracle environment variables so that we could run `sqlplus`.
-. /usr/lib/oracle/xe/app/oracle/product/10.2.0/server/bin/oracle_env.sh
+source ${TRAVIS_BUILD_DIR}/scripts/travis/oracle.sh
 echo "ORACLE_HOME=${ORACLE_HOME}"
 echo "ORACLE_SID=${ORACLE_SID}"
 
-# create user for testing
-echo "CREATE USER travis IDENTIFIED BY travis;" | \
-sqlplus -S -L sys/admin AS SYSDBA
+# travis-oracle installer created travis user w/o password
+echo "ALTER USER travis IDENTIFIED BY travis;" | \
+$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
 
 echo "grant connect, resource to travis;" | \
-sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
 
 echo "grant create session, alter any procedure to travis;" | \
-sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
 
 # to enable xa recovery, see: https://community.oracle.com/thread/378954
 echo "grant select on sys.dba_pending_transactions to travis;" | \
-sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
 echo "grant select on sys.pending_trans$ to travis;" | \
-sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
 echo "grant select on sys.dba_2pc_pending to travis;" | \
-sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
 echo "grant execute on sys.dbms_system to travis;" | \
-sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
 
 # increase default=40 value of processes to prevent ORA-12520 failures while testing
 echo "alter system set processes=100 scope=spfile;" | \
-sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
 
 # check connection as user for testing
 echo "Connecting using travis/travis@XE"
 echo "SELECT * FROM product_component_version;" | \
-sqlplus -S -L travis/travis@XE
-
+$ORACLE_HOME/bin/sqlplus -S -L travis/travis@XE

--- a/scripts/travis/oracle.sh
+++ b/scripts/travis/oracle.sh
@@ -5,10 +5,8 @@
 # Notice that this file is not executable, it is supposed to be sourced from
 # the other files.
 
-# Load Oracle environment variables
-. /usr/lib/oracle/xe/app/oracle/product/10.2.0/server/bin/oracle_env.sh
-echo "ORACLE_HOME=${ORACLE_HOME}"
-echo "ORACLE_SID=${ORACLE_SID}"
-
-LD_LIBRARY_PATH=${ORACLE_HOME}:${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH
+# Oracle environment required by https://github.com/cbandy/travis-oracle
+export ORACLE_COOKIE=sqldev
+export ORACLE_FILE=oracle11g/xe/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
+export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
+export ORACLE_SID=XE


### PR DESCRIPTION
Clones and uses scripts to install Oracle Database XE (64-bit) on Travis CI from https://github.com/cbandy/travis-oracle.
Switch Oracle backend build from 32-bit to 64-bit.
Closes #554 

------

The Oracle downloader (@cbandy/travis-oracle) requires two secret environment variables.

The CI builds for PRs do not work anymore:
> Pull requests sent from forked repositories do not have access to encrypted variables or data.
https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions

We will have to apply some workaround (eg. run Oracle build job only for regular pushes).
Meanwhile, I'm merging this PR, so we see if the Oracle build is properly triggered.