### PR TITLE
Skip running Oracle tests for PR builds on Travis CI

### DIFF
--- a/scripts/travis/before_install_oracle.sh
+++ b/scripts/travis/before_install_oracle.sh
@@ -4,6 +4,11 @@
 # Uses Oracle downloader and installer from https://github.com/cbandy/travis-oracle
 #
 # set -ex
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] ; then
+    echo "Skipping Oracle installation for PR builds"
+    exit 0
+fi
+
 source ${TRAVIS_BUILD_DIR}/scripts/travis/oracle.sh
 
 # Install Oracle and travis-oracle requirements

--- a/scripts/travis/before_script_oracle.sh
+++ b/scripts/travis/before_script_oracle.sh
@@ -7,6 +7,11 @@
 # Changes:
 # - Check connection as user for testing
 #
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] ; then
+    echo "Skipping Oracle database creation for PR builds"
+    exit 0
+fi
+
 source ${TRAVIS_BUILD_DIR}/scripts/travis/oracle.sh
 echo "ORACLE_HOME=${ORACLE_HOME}"
 echo "ORACLE_SID=${ORACLE_SID}"

--- a/scripts/travis/script_oracle.sh
+++ b/scripts/travis/script_oracle.sh
@@ -3,6 +3,11 @@
 #
 # Copyright (c) 2013 Mateusz Loskot <mateusz@loskot.net>
 #
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] ; then
+    echo "Skipping Oracle build for PR builds"
+    exit 0
+fi
+
 source ${TRAVIS_BUILD_DIR}/scripts/travis/common.sh
 source ${TRAVIS_BUILD_DIR}/scripts/travis/oracle.sh
 


### PR DESCRIPTION
This doesn't work currently because Oracle installation requires access
to secret environment variables which are unavailable for the PR builds
for the security purposes, so skip trying to do it to at least avoid
failing all PR builds.