### PR TITLE
More XML/CLOB-related changes, including ODBC "support"

### DIFF
--- a/docs/lobs.md
+++ b/docs/lobs.md
@@ -54,3 +54,10 @@ For PostgreSQL, these types are:
 
 For Firebird, there is no special XML support, but `BLOB SUB_TYPE TEXT` can be
 used for storing it, as well as long strings.
+
+For ODBC backend, these types depend on the type of the database connected to.
+In particularly important special case of Microsoft SQL Server, these types
+are:
+
+* `xml`
+* `text`

--- a/docs/lobs.md
+++ b/docs/lobs.md
@@ -61,3 +61,11 @@ are:
 
 * `xml`
 * `text`
+
+When using ODBC backend to connect to a PostgreSQL database, please be aware
+that by default PostgreSQL ODBC driver truncates all "unknown" types, such as
+XML, to maximal varchar type size which is just 256 bytes and so is often
+insufficient for XML values in practice. It is advised to set the
+`UnknownsAsLongVarchar` connection option to 1 to avoid truncating XML strings
+or use PostgreSQL ODBC driver 9.6.300 or later, which allows the backend to set
+this option to 1 automatically on connection.

--- a/docs/lobs.md
+++ b/docs/lobs.md
@@ -51,3 +51,6 @@ For PostgreSQL, these types are:
 
 * `XML`
 * `text`
+
+For Firebird, there is no special XML support, but `BLOB SUB_TYPE TEXT` can be
+used for storing it, as well as long strings.

--- a/include/private/soci-exchange-cast.h
+++ b/include/private/soci-exchange-cast.h
@@ -9,6 +9,7 @@
 #define SOCI_EXCHANGE_CAST_H_INCLUDED
 
 #include "soci/soci-backend.h"
+#include "soci/type-wrappers.h"
 
 #include <ctime>
 
@@ -67,6 +68,18 @@ template <>
 struct exchange_type_traits<x_stdtm>
 {
   typedef std::tm value_type;
+};
+
+template <>
+struct exchange_type_traits<x_longstring>
+{
+  typedef long_string value_type;
+};
+
+template <>
+struct exchange_type_traits<x_xmltype>
+{
+  typedef xml_type value_type;
 };
 
 // exchange_type_traits not defined for x_statement, x_rowid and x_blob here.

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -177,6 +177,15 @@ struct odbc_standard_use_type_backend : details::standard_use_type_backend,
     details::exchange_type type_;
     char *buf_;
     SQLLEN indHolder_;
+
+private:
+    // Copy string data to buf_ and set size, sqlType and cType to the values
+    // appropriate for strings.
+    void copy_from_string(std::string const& s,
+                          SQLLEN& size,
+                          SQLSMALLINT& sqlType,
+                          SQLSMALLINT& cType);
+
 };
 
 struct odbc_vector_use_type_backend : details::vector_use_type_backend,

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -204,6 +204,10 @@ struct postgresql_standard_use_type_backend : details::standard_use_type_backend
     int position_;
     std::string name_;
     char * buf_;
+
+private:
+    // Allocate buf_ of appropriate size and copy string data into it.
+    void copy_from_string(std::string const& s);
 };
 
 struct postgresql_vector_use_type_backend : details::vector_use_type_backend

--- a/src/backends/firebird/standard-into-type.cpp
+++ b/src/backends/firebird/standard-into-type.cpp
@@ -123,19 +123,11 @@ void firebird_standard_into_type_backend::exchangeData()
             break;
 
         case x_longstring:
-            {
-                long_string* const dst = static_cast<long_string*>(data_);
-
-                copy_from_blob(dst->value);
-            }
+            copy_from_blob(exchange_type_cast<x_longstring>(data_).value);
             break;
 
         case x_xmltype:
-            {
-                xml_type* const dst = static_cast<xml_type*>(data_);
-
-                copy_from_blob(dst->value);
-            }
+            copy_from_blob(exchange_type_cast<x_xmltype>(data_).value);
             break;
 
         default:

--- a/src/backends/firebird/standard-use-type.cpp
+++ b/src/backends/firebird/standard-use-type.cpp
@@ -149,19 +149,11 @@ void firebird_standard_use_type_backend::exchangeData()
             break;
 
         case x_longstring:
-            {
-                long_string const* const src = static_cast<long_string*>(data_);
-
-                copy_to_blob(src->value);
-            }
+            copy_to_blob(exchange_type_cast<x_longstring>(data_).value);
             break;
 
         case x_xmltype:
-            {
-                xml_type const* const src = static_cast<xml_type*>(data_);
-
-                copy_to_blob(src->value);
-            }
+            copy_to_blob(exchange_type_cast<x_xmltype>(data_).value);
             break;
 
         default:

--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -133,6 +133,23 @@ void odbc_session_backend::configure_connection()
             throw odbc_soci_error(SQL_HANDLE_DBC, henv_,
                                   "setting extra_float_digits for PostgreSQL");
         }
+
+        // This is extracted from pgapifunc.h header from psqlODBC driver.
+        enum
+        {
+            SQL_ATTR_PGOPT_UNKNOWNSASLONGVARCHAR = 65544
+        };
+
+        // Also configure the driver to handle unknown types, such as "xml",
+        // that we use for x_xmltype, as long varchar instead of limiting them
+        // to 256 characters (by default).
+        rc = SQLSetConnectAttr(hdbc_, SQL_ATTR_PGOPT_UNKNOWNSASLONGVARCHAR, (SQLPOINTER)1, 0);
+
+        // Ignore the error from this one, failure to set it is not fatal and
+        // the attribute is only supported in very recent version of the driver
+        // (>= 9.6.300). Using "UnknownsAsLongVarchar=1" in odbc.ini (or
+        // setting the corresponding option in the driver dialog box) should
+        // work with all versions however.
     }
 }
 

--- a/src/backends/odbc/standard-into-type.cpp
+++ b/src/backends/odbc/standard-into-type.cpp
@@ -33,6 +33,8 @@ void odbc_standard_into_type_backend::define_by_pos(
         data = buf_;
         break;
     case x_stdstring:
+    case x_longstring:
+    case x_xmltype:
         odbcType_ = SQL_C_CHAR;
         // Patch: set to min between column size and 100MB (used ot be 32769)
         // Column size for text data type can be too large for buffer allocation
@@ -158,6 +160,14 @@ void odbc_standard_into_type_backend::post_fetch(
             {
                 throw soci_error("Buffer size overflow; maybe got too large string");
             }
+        }
+        else if (type_ == x_longstring)
+        {
+            exchange_type_cast<x_longstring>(data_).value = buf_;
+        }
+        else if (type_ == x_xmltype)
+        {
+            exchange_type_cast<x_xmltype>(data_).value = buf_;
         }
         else if (type_ == x_stdtm)
         {

--- a/src/backends/odbc/standard-use-type.cpp
+++ b/src/backends/odbc/standard-use-type.cpp
@@ -86,13 +86,8 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
     case x_stdstring:
     {
         std::string const& s = exchange_type_cast<x_stdstring>(data_);
-        sqlType = SQL_VARCHAR;
-        cType = SQL_C_CHAR;
-        size = s.size();
-        buf_ = new char[size+1];
-        memcpy(buf_, s.c_str(), size);
-        buf_[size++] = '\0';
-        indHolder_ = SQL_NTS;
+
+        copy_from_string(s, size, sqlType, cType);
     }
     break;
     case x_stdtm:
@@ -126,6 +121,22 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
     // Return either the pointer to C++ data itself or the buffer that we
     // allocated, if any.
     return buf_ ? buf_ : data_;
+}
+
+void odbc_standard_use_type_backend::copy_from_string(
+        std::string const& s,
+        SQLLEN& size,
+        SQLSMALLINT& sqlType,
+        SQLSMALLINT& cType
+    )
+{
+    sqlType = SQL_VARCHAR;
+    cType = SQL_C_CHAR;
+    size = s.size();
+    buf_ = new char[size+1];
+    memcpy(buf_, s.c_str(), size);
+    buf_[size++] = '\0';
+    indHolder_ = SQL_NTS;
 }
 
 void odbc_standard_use_type_backend::bind_by_pos(

--- a/src/backends/odbc/standard-use-type.cpp
+++ b/src/backends/odbc/standard-use-type.cpp
@@ -113,6 +113,15 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
     }
     break;
 
+    case x_longstring:
+        copy_from_string(exchange_type_cast<x_longstring>(data_).value,
+                         size, sqlType, cType);
+        break;
+    case x_xmltype:
+        copy_from_string(exchange_type_cast<x_xmltype>(data_).value,
+                         size, sqlType, cType);
+        break;
+
     // unsupported types
     default:
         throw soci_error("Use element used with non-supported type.");

--- a/src/backends/oracle/standard-into-type.cpp
+++ b/src/backends/oracle/standard-into-type.cpp
@@ -297,9 +297,8 @@ void oracle_standard_into_type_backend::post_fetch(
             if (indOCIHolder_ != -1)
             {
                 OCILobLocator * lobp = static_cast<OCILobLocator *>(ociData_);
-                xml_type * xml = static_cast<xml_type *>(data_);
 
-                read_from_lob(lobp, xml->value);
+                read_from_lob(lobp, exchange_type_cast<x_xmltype>(data_).value);
             }
         }
         else if (type_ == x_longstring)
@@ -307,9 +306,8 @@ void oracle_standard_into_type_backend::post_fetch(
             if (indOCIHolder_ != -1)
             {
                 OCILobLocator * lobp = static_cast<OCILobLocator *>(ociData_);
-                long_string * ls = static_cast<long_string *>(data_);
-                
-                read_from_lob(lobp, ls->value);
+
+                read_from_lob(lobp, exchange_type_cast<x_longstring>(data_).value);
             }
         }
     }

--- a/src/backends/oracle/standard-use-type.cpp
+++ b/src/backends/oracle/standard-use-type.cpp
@@ -292,9 +292,8 @@ void oracle_standard_use_type_backend::pre_exec(int /* num */)
             lazy_temp_lob_init();
             
             OCILobLocator * lobp = static_cast<OCILobLocator *>(ociData_);
-            xml_type * xml = static_cast<xml_type *>(data_);
 
-            write_to_lob(lobp, xml->value);
+            write_to_lob(lobp, exchange_type_cast<x_xmltype>(data_).value);
         }
         break;
     case x_longstring:
@@ -304,9 +303,8 @@ void oracle_standard_use_type_backend::pre_exec(int /* num */)
             lazy_temp_lob_init();
             
             OCILobLocator * lobp = static_cast<OCILobLocator *>(ociData_);
-            long_string * ls = static_cast<long_string *>(data_);
 
-            write_to_lob(lobp, ls->value);
+            write_to_lob(lobp, exchange_type_cast<x_longstring>(data_).value);
         }
         break;
     default:

--- a/src/backends/postgresql/standard-into-type.cpp
+++ b/src/backends/postgresql/standard-into-type.cpp
@@ -153,20 +153,10 @@ void postgresql_standard_into_type_backend::post_fetch(
             }
             break;
         case x_xmltype:
-            {
-                xml_type * xml = static_cast<xml_type *>(data_);
-                std::string * dest = &(xml->value);
-                
-                dest->assign(buf);
-            }
+            exchange_type_cast<x_xmltype>(data_).value.assign(buf);
             break;
         case x_longstring:
-            {
-                long_string * ls = static_cast<long_string *>(data_);
-                std::string * dest = &(ls->value);
-                
-                dest->assign(buf);
-            }
+            exchange_type_cast<x_longstring>(data_).value.assign(buf);
             break;
 
         default:

--- a/src/backends/postgresql/standard-use-type.cpp
+++ b/src/backends/postgresql/standard-use-type.cpp
@@ -71,11 +71,7 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
             }
             break;
         case x_stdstring:
-            {
-                std::string const& s = exchange_type_cast<x_stdstring>(data_);
-                buf_ = new char[s.size() + 1];
-                std::strcpy(buf_, s.c_str());
-            }
+            copy_from_string(exchange_type_cast<x_stdstring>(data_));
             break;
         case x_short:
             {
@@ -114,12 +110,7 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
             }
             break;
         case x_double:
-            {
-                std::string const s = double_to_cstring(exchange_type_cast<x_double>(data_));
-
-                buf_ = new char[s.size() + 1];
-                std::strcpy(buf_, s.c_str());
-            }
+            copy_from_string(double_to_cstring(exchange_type_cast<x_double>(data_)));
             break;
         case x_stdtm:
             {
@@ -163,19 +154,13 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
         case x_xmltype:
             {
                 xml_type * xml = static_cast<xml_type *>(data_);
-                std::string * s = &(xml->value);
-                
-                buf_ = new char[s->size() + 1];
-                std::strcpy(buf_, s->c_str());
+                copy_from_string(xml->value);
             }
             break;
         case x_longstring:
             {
                 long_string * ls = static_cast<long_string *>(data_);
-                std::string * s = &(ls->value);
-                
-                buf_ = new char[s->size() + 1];
-                std::strcpy(buf_, s->c_str());
+                copy_from_string(xml->value);
             }
             break;
             
@@ -216,4 +201,10 @@ void postgresql_standard_use_type_backend::clean_up()
         delete [] buf_;
         buf_ = NULL;
     }
+}
+
+void postgresql_standard_use_type_backend::copy_from_string(std::string const& s)
+{
+    buf_ = new char[s.size() + 1];
+    std::strcpy(buf_, s.c_str());
 }

--- a/src/backends/postgresql/standard-use-type.cpp
+++ b/src/backends/postgresql/standard-use-type.cpp
@@ -152,16 +152,10 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
             }
             break;
         case x_xmltype:
-            {
-                xml_type * xml = static_cast<xml_type *>(data_);
-                copy_from_string(xml->value);
-            }
+            copy_from_string(exchange_type_cast<x_xmltype>(data_).value);
             break;
         case x_longstring:
-            {
-                long_string * ls = static_cast<long_string *>(data_);
-                copy_from_string(xml->value);
-            }
+            copy_from_string(exchange_type_cast<x_longstring>(data_).value);
             break;
             
         default:

--- a/tests/odbc/test-odbc-mssql.cpp
+++ b/tests/odbc/test-odbc-mssql.cpp
@@ -116,6 +116,24 @@ struct table_creator_for_get_affected_rows : table_creator_base
     }
 };
 
+struct table_creator_for_clob : table_creator_base
+{
+    table_creator_for_clob(soci::session & sql)
+        : table_creator_base(sql)
+    {
+        sql << "create table soci_test(id integer, s text)";
+    }
+};
+
+struct table_creator_for_xml : table_creator_base
+{
+    table_creator_for_xml(soci::session & sql)
+        : table_creator_base(sql)
+    {
+        sql << "create table soci_test(id integer, x xml)";
+    }
+};
+
 //
 // Support for SOCI Common Tests
 //
@@ -145,6 +163,16 @@ public:
     table_creator_base * table_creator_4(soci::session& s) const
     {
         return new table_creator_for_get_affected_rows(s);
+    }
+
+    tests::table_creator_base* table_creator_clob(soci::session& s) const
+    {
+        return new table_creator_for_clob(s);
+    }
+
+    tests::table_creator_base* table_creator_xml(soci::session& s) const
+    {
+        return new table_creator_for_xml(s);
     }
 
     std::string to_date_time(std::string const &datdt_string) const

--- a/tests/odbc/test-odbc-postgresql.cpp
+++ b/tests/odbc/test-odbc-postgresql.cpp
@@ -128,6 +128,24 @@ struct table_creator_for_get_affected_rows : table_creator_base
     }
 };
 
+struct table_creator_for_xml : table_creator_base
+{
+    table_creator_for_xml(soci::session& sql)
+        : table_creator_base(sql)
+    {
+        sql << "create table soci_test(id integer, x xml)";
+    }
+};
+
+struct table_creator_for_clob : table_creator_base
+{
+    table_creator_for_clob(soci::session& sql)
+        : table_creator_base(sql)
+    {
+        sql << "create table soci_test(id integer, s text)";
+    }
+};
+
 //
 // Support for SOCI Common Tests
 //
@@ -161,6 +179,16 @@ public:
     table_creator_base * table_creator_4(soci::session& s) const
     {
         return new table_creator_for_get_affected_rows(s);
+    }
+
+    table_creator_base* table_creator_xml(soci::session& s) const
+    {
+        return new table_creator_for_xml(s);
+    }
+
+    table_creator_base* table_creator_clob(soci::session& s) const
+    {
+        return new table_creator_for_clob(s);
     }
 
     std::string to_date_time(std::string const &datdt_string) const

--- a/tests/odbc/test-postgresql-win64.dsn
+++ b/tests/odbc/test-postgresql-win64.dsn
@@ -6,3 +6,4 @@ Port=5432
 Database=soci_test
 UID=postgres
 PWD=Password12!
+UnknownsAsLongVarchar=1

--- a/tests/odbc/test-postgresql.dsn
+++ b/tests/odbc/test-postgresql.dsn
@@ -6,3 +6,4 @@ Port=5432
 Database=soci_test
 UID=postgres
 PWD=Password12!
+UnknownsAsLongVarchar=1


### PR DESCRIPTION
In practice, using "xml" columns in SQL Server database seems to work just fine, even without using the `SQL_SS_XML` column type specific to Microsoft ODBC driver (and not supported by e.g. FreeTDS driver which is commonly used on Unix systems).