### PR TITLE
[CMake] Add SOCI_POSTGRESQL_NOSINLGEROWMODE option (default OFF)

### DIFF
--- a/docs/backends/postgresql.md
+++ b/docs/backends/postgresql.md
@@ -168,3 +168,4 @@ To support older PostgreSQL versions, the following configuration macros are rec
 * `SOCI_POSTGRESQL_NOBINDBYNAME` - switches off the query rewriting.
 * `SOCI_POSTGRESQL_NOPARAMS` - disables support for parameterized queries (binding of use elements),automatically imposes also the `SOCI_POSTGRESQL_NOBINDBYNAME` macro. It is necessary for PostgreSQL 7.3.
 * `SOCI_POSTGRESQL_NOPREPARE` - disables support for separate query preparation, which in this backend is significant only in terms of optimization. It is necessary for PostgreSQL 7.3 and 7.4.
+* `SOCI_POSTGRESQL_NOSINLGEROWMODE` - disable single mode retrieving query results row-by-row. It is necessary for PostgreSQL prior to version 9.

--- a/src/backends/postgresql/CMakeLists.txt
+++ b/src/backends/postgresql/CMakeLists.txt
@@ -11,6 +11,10 @@
 
 include(CMakeDependentOption)
 
+option(SOCI_POSTGRESQL_NOSINLGEROWMODE
+  "Do not use single row mode. PostgreSQL <9 portability."
+  OFF)
+
 option(SOCI_POSTGRESQL_NOPARAMS
   "Do not use input parameters. PostgreSQL 7.x portability."
   OFF)
@@ -35,6 +39,14 @@ if(SOCI_POSTGRESQL_NOPREPARE)
   add_definitions(-DSOCI_POSTGRESQL_NOPREPARE=1)
 endif()
 
+if (POSTGRESQL_VERSION VERSION_LESS "9.0.0")
+  set(SOCI_POSTGRESQL_NOSINLGEROWMODE ON CACHE BOOL "Use single row mode for PostgreSQL 9+" FORCE)
+endif()
+
+if(SOCI_POSTGRESQL_NOSINLGEROWMODE)
+  add_definitions(-DSOCI_POSTGRESQL_NOSINLGEROWMODE=1)
+endif()
+
 soci_backend(PostgreSQL
   DEPENDS PostgreSQL
   DESCRIPTION "SOCI backend for PostgreSQL"
@@ -44,3 +56,4 @@ soci_backend(PostgreSQL
 boost_report_value(SOCI_POSTGRESQL_NOPARAMS)
 boost_report_value(SOCI_POSTGRESQL_NOBINDBYNAME)
 boost_report_value(SOCI_POSTGRESQL_NOPREPARE)
+boost_report_value(SOCI_POSTGRESQL_NOSINLGEROWMODE)


### PR DESCRIPTION
By default, retrieving query results row-by-row is enabled.

CMake tries to detect version of PostgreSQL (libpq) used to build SOCI
and if detected version is less than 9.x.x, then the option is
flipped to ON for backward compatibility.

Complements #571