### PR TITLE
Add SOCI_OVERRIDE macro as conditional C++11 override specifier

### DIFF
--- a/include/soci/db2/soci-db2.h
+++ b/include/soci/db2/soci-db2.h
@@ -64,7 +64,7 @@ namespace soci
 class SOCI_DB2_DECL db2_soci_error : public soci_error {
 public:
     db2_soci_error(std::string const & msg, SQLRETURN rc) : soci_error(msg),errorCode(rc) {};
-    ~db2_soci_error() throw() { };
+    ~db2_soci_error() throw() SOCI_OVERRIDE { };
 
     //We have to extract error information before exception throwing, cause CLI handles could be broken at the construction time
     static const std::string sqlState(std::string const & msg,const SQLSMALLINT htype,const SQLHANDLE hndl);
@@ -86,12 +86,12 @@ struct SOCI_DB2_DECL db2_standard_into_type_backend : details::standard_into_typ
         : statement_(st),buf(NULL)
     {}
 
-    void define_by_pos(int& position, void* data, details::exchange_type type);
+    void define_by_pos(int& position, void* data, details::exchange_type type) SOCI_OVERRIDE;
 
-    void pre_fetch();
-    void post_fetch(bool gotData, bool calledFromFetch, indicator* ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, bool calledFromFetch, indicator* ind) SOCI_OVERRIDE;
 
-    void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     db2_statement_backend& statement_;
 
@@ -109,15 +109,15 @@ struct SOCI_DB2_DECL db2_vector_into_type_backend : details::vector_into_type_ba
         : statement_(st),buf(NULL)
     {}
 
-    void define_by_pos(int& position, void* data, details::exchange_type type);
+    void define_by_pos(int& position, void* data, details::exchange_type type) SOCI_OVERRIDE;
 
-    void pre_fetch();
-    void post_fetch(bool gotData, indicator* ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, indicator* ind) SOCI_OVERRIDE;
 
-    void resize(std::size_t sz);
-    std::size_t size();
+    void resize(std::size_t sz) SOCI_OVERRIDE;
+    std::size_t size() SOCI_OVERRIDE;
 
-    void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     db2_statement_backend& statement_;
 
@@ -139,13 +139,13 @@ struct SOCI_DB2_DECL db2_standard_use_type_backend : details::standard_use_type_
         : statement_(st),buf(NULL),ind(0)
     {}
 
-    void bind_by_pos(int& position, void* data, details::exchange_type type, bool readOnly);
-    void bind_by_name(std::string const& name, void* data, details::exchange_type type, bool readOnly);
+    void bind_by_pos(int& position, void* data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
+    void bind_by_name(std::string const& name, void* data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
 
-    void pre_use(indicator const* ind);
-    void post_use(bool gotData, indicator* ind);
+    void pre_use(indicator const* ind) SOCI_OVERRIDE;
+    void post_use(bool gotData, indicator* ind) SOCI_OVERRIDE;
 
-    void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     db2_statement_backend& statement_;
 
@@ -164,14 +164,14 @@ struct SOCI_DB2_DECL db2_vector_use_type_backend : details::vector_use_type_back
     db2_vector_use_type_backend(db2_statement_backend &st)
         : statement_(st),buf(NULL) {}
 
-    void bind_by_pos(int& position, void* data, details::exchange_type type);
-    void bind_by_name(std::string const& name, void* data, details::exchange_type type);
+    void bind_by_pos(int& position, void* data, details::exchange_type type) SOCI_OVERRIDE;
+    void bind_by_name(std::string const& name, void* data, details::exchange_type type) SOCI_OVERRIDE;
 
-    void pre_use(indicator const* ind);
+    void pre_use(indicator const* ind) SOCI_OVERRIDE;
 
-    std::size_t size();
+    std::size_t size() SOCI_OVERRIDE;
 
-    void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     db2_statement_backend& statement_;
 
@@ -192,27 +192,27 @@ struct SOCI_DB2_DECL db2_statement_backend : details::statement_backend
 {
     db2_statement_backend(db2_session_backend &session);
 
-    void alloc();
-    void clean_up();
-    void prepare(std::string const& query, details::statement_type eType);
+    void alloc() SOCI_OVERRIDE;
+    void clean_up() SOCI_OVERRIDE;
+    void prepare(std::string const& query, details::statement_type eType) SOCI_OVERRIDE;
 
-    exec_fetch_result execute(int number);
-    exec_fetch_result fetch(int number);
+    exec_fetch_result execute(int number) SOCI_OVERRIDE;
+    exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    long long get_affected_rows();
-    int get_number_of_rows();
-    std::string get_parameter_name(int index) const;
+    long long get_affected_rows() SOCI_OVERRIDE;
+    int get_number_of_rows() SOCI_OVERRIDE;
+    std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
-    std::string rewrite_for_procedure_call(std::string const& query);
+    std::string rewrite_for_procedure_call(std::string const& query) SOCI_OVERRIDE;
 
-    int prepare_for_describe();
-    void describe_column(int colNum, data_type& dtype, std::string& columnName);
+    int prepare_for_describe() SOCI_OVERRIDE;
+    void describe_column(int colNum, data_type& dtype, std::string& columnName) SOCI_OVERRIDE;
     size_t column_size(int col);
 
-    db2_standard_into_type_backend* make_into_type_backend();
-    db2_standard_use_type_backend* make_use_type_backend();
-    db2_vector_into_type_backend* make_vector_into_type_backend();
-    db2_vector_use_type_backend* make_vector_use_type_backend();
+    db2_standard_into_type_backend* make_into_type_backend() SOCI_OVERRIDE;
+    db2_standard_use_type_backend* make_use_type_backend() SOCI_OVERRIDE;
+    db2_vector_into_type_backend* make_vector_into_type_backend() SOCI_OVERRIDE;
+    db2_vector_use_type_backend* make_vector_use_type_backend() SOCI_OVERRIDE;
 
     db2_session_backend& session_;
 
@@ -228,20 +228,20 @@ struct db2_rowid_backend : details::rowid_backend
 {
     db2_rowid_backend(db2_session_backend &session);
 
-    ~db2_rowid_backend();
+    ~db2_rowid_backend() SOCI_OVERRIDE;
 };
 
 struct db2_blob_backend : details::blob_backend
 {
     db2_blob_backend(db2_session_backend& session);
 
-    ~db2_blob_backend();
+    ~db2_blob_backend() SOCI_OVERRIDE;
 
-    std::size_t get_len();
-    std::size_t read(std::size_t offset, char* buf, std::size_t toRead);
-    std::size_t write(std::size_t offset, char const* buf, std::size_t toWrite);
-    std::size_t append(char const* buf, std::size_t toWrite);
-    void trim(std::size_t newLen);
+    std::size_t get_len() SOCI_OVERRIDE;
+    std::size_t read(std::size_t offset, char* buf, std::size_t toRead) SOCI_OVERRIDE;
+    std::size_t write(std::size_t offset, char const* buf, std::size_t toWrite) SOCI_OVERRIDE;
+    std::size_t append(char const* buf, std::size_t toWrite) SOCI_OVERRIDE;
+    void trim(std::size_t newLen) SOCI_OVERRIDE;
 
     db2_session_backend& session_;
 };
@@ -250,21 +250,21 @@ struct db2_session_backend : details::session_backend
 {
     db2_session_backend(connection_parameters const& parameters);
 
-    ~db2_session_backend();
+    ~db2_session_backend() SOCI_OVERRIDE;
 
-    void begin();
-    void commit();
-    void rollback();
+    void begin() SOCI_OVERRIDE;
+    void commit() SOCI_OVERRIDE;
+    void rollback() SOCI_OVERRIDE;
 
-    virtual std::string get_dummy_from_table() const { return "sysibm.sysdummy1"; }
+    std::string get_dummy_from_table() const SOCI_OVERRIDE { return "sysibm.sysdummy1"; }
 
-    std::string get_backend_name() const { return "DB2"; }
+    std::string get_backend_name() const SOCI_OVERRIDE { return "DB2"; }
 
     void clean_up();
 
-    db2_statement_backend* make_statement_backend();
-    db2_rowid_backend* make_rowid_backend();
-    db2_blob_backend* make_blob_backend();
+    db2_statement_backend* make_statement_backend() SOCI_OVERRIDE;
+    db2_rowid_backend* make_rowid_backend() SOCI_OVERRIDE;
+    db2_blob_backend* make_blob_backend() SOCI_OVERRIDE;
 
     void parseConnectString(std::string const &);
     void parseKeyVal(std::string const &);
@@ -281,7 +281,7 @@ struct SOCI_DB2_DECL db2_backend_factory : backend_factory
 {
     db2_backend_factory() {}
     db2_session_backend* make_session(
-        connection_parameters const & parameters) const;
+        connection_parameters const & parameters) const SOCI_OVERRIDE;
 };
 
 extern SOCI_DB2_DECL db2_backend_factory const db2;

--- a/include/soci/empty/soci-empty.h
+++ b/include/soci/empty/soci-empty.h
@@ -39,12 +39,12 @@ struct SOCI_EMPTY_DECL empty_standard_into_type_backend : details::standard_into
         : statement_(st)
     {}
 
-    void define_by_pos(int& position, void* data, details::exchange_type type);
+    void define_by_pos(int& position, void* data, details::exchange_type type) SOCI_OVERRIDE;
 
-    void pre_fetch();
-    void post_fetch(bool gotData, bool calledFromFetch, indicator* ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, bool calledFromFetch, indicator* ind) SOCI_OVERRIDE;
 
-    void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     empty_statement_backend& statement_;
 };
@@ -55,15 +55,15 @@ struct SOCI_EMPTY_DECL empty_vector_into_type_backend : details::vector_into_typ
         : statement_(st)
     {}
 
-    void define_by_pos(int& position, void* data, details::exchange_type type);
+    void define_by_pos(int& position, void* data, details::exchange_type type) SOCI_OVERRIDE;
 
-    void pre_fetch();
-    void post_fetch(bool gotData, indicator* ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, indicator* ind) SOCI_OVERRIDE;
 
-    void resize(std::size_t sz);
-    std::size_t size();
+    void resize(std::size_t sz) SOCI_OVERRIDE;
+    std::size_t size() SOCI_OVERRIDE;
 
-    void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     empty_statement_backend& statement_;
 };
@@ -74,13 +74,13 @@ struct SOCI_EMPTY_DECL empty_standard_use_type_backend : details::standard_use_t
         : statement_(st)
     {}
 
-    void bind_by_pos(int& position, void* data, details::exchange_type type, bool readOnly);
-    void bind_by_name(std::string const& name, void* data, details::exchange_type type, bool readOnly);
+    void bind_by_pos(int& position, void* data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
+    void bind_by_name(std::string const& name, void* data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
 
-    void pre_use(indicator const* ind);
-    void post_use(bool gotData, indicator* ind);
+    void pre_use(indicator const* ind) SOCI_OVERRIDE;
+    void post_use(bool gotData, indicator* ind) SOCI_OVERRIDE;
 
-    void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     empty_statement_backend& statement_;
 };
@@ -90,14 +90,14 @@ struct SOCI_EMPTY_DECL empty_vector_use_type_backend : details::vector_use_type_
     empty_vector_use_type_backend(empty_statement_backend &st)
         : statement_(st) {}
 
-    void bind_by_pos(int& position, void* data, details::exchange_type type);
-    void bind_by_name(std::string const& name, void* data, details::exchange_type type);
+    void bind_by_pos(int& position, void* data, details::exchange_type type) SOCI_OVERRIDE;
+    void bind_by_name(std::string const& name, void* data, details::exchange_type type) SOCI_OVERRIDE;
 
-    void pre_use(indicator const* ind);
+    void pre_use(indicator const* ind) SOCI_OVERRIDE;
 
-    std::size_t size();
+    std::size_t size() SOCI_OVERRIDE;
 
-    void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     empty_statement_backend& statement_;
 };
@@ -107,26 +107,26 @@ struct SOCI_EMPTY_DECL empty_statement_backend : details::statement_backend
 {
     empty_statement_backend(empty_session_backend &session);
 
-    void alloc();
-    void clean_up();
-    void prepare(std::string const& query, details::statement_type eType);
+    void alloc() SOCI_OVERRIDE;
+    void clean_up() SOCI_OVERRIDE;
+    void prepare(std::string const& query, details::statement_type eType) SOCI_OVERRIDE;
 
-    exec_fetch_result execute(int number);
-    exec_fetch_result fetch(int number);
+    exec_fetch_result execute(int number) SOCI_OVERRIDE;
+    exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    long long get_affected_rows();
-    int get_number_of_rows();
-    std::string get_parameter_name(int index) const;
+    long long get_affected_rows() SOCI_OVERRIDE;
+    int get_number_of_rows() SOCI_OVERRIDE;
+    std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
-    std::string rewrite_for_procedure_call(std::string const& query);
+    std::string rewrite_for_procedure_call(std::string const& query) SOCI_OVERRIDE;
 
-    int prepare_for_describe();
-    void describe_column(int colNum, data_type& dtype, std::string& columnName);
+    int prepare_for_describe() SOCI_OVERRIDE;
+    void describe_column(int colNum, data_type& dtype, std::string& columnName) SOCI_OVERRIDE;
 
-    empty_standard_into_type_backend* make_into_type_backend();
-    empty_standard_use_type_backend* make_use_type_backend();
-    empty_vector_into_type_backend* make_vector_into_type_backend();
-    empty_vector_use_type_backend* make_vector_use_type_backend();
+    empty_standard_into_type_backend* make_into_type_backend() SOCI_OVERRIDE;
+    empty_standard_use_type_backend* make_use_type_backend() SOCI_OVERRIDE;
+    empty_vector_into_type_backend* make_vector_into_type_backend() SOCI_OVERRIDE;
+    empty_vector_use_type_backend* make_vector_use_type_backend() SOCI_OVERRIDE;
 
     empty_session_backend& session_;
 };
@@ -135,20 +135,20 @@ struct empty_rowid_backend : details::rowid_backend
 {
     empty_rowid_backend(empty_session_backend &session);
 
-    ~empty_rowid_backend();
+    ~empty_rowid_backend() SOCI_OVERRIDE;
 };
 
 struct empty_blob_backend : details::blob_backend
 {
     empty_blob_backend(empty_session_backend& session);
 
-    ~empty_blob_backend();
+    ~empty_blob_backend() SOCI_OVERRIDE;
 
-    std::size_t get_len();
-    std::size_t read(std::size_t offset, char* buf, std::size_t toRead);
-    std::size_t write(std::size_t offset, char const* buf, std::size_t toWrite);
-    std::size_t append(char const* buf, std::size_t toWrite);
-    void trim(std::size_t newLen);
+    std::size_t get_len() SOCI_OVERRIDE;
+    std::size_t read(std::size_t offset, char* buf, std::size_t toRead) SOCI_OVERRIDE;
+    std::size_t write(std::size_t offset, char const* buf, std::size_t toWrite) SOCI_OVERRIDE;
+    std::size_t append(char const* buf, std::size_t toWrite) SOCI_OVERRIDE;
+    void trim(std::size_t newLen) SOCI_OVERRIDE;
 
     empty_session_backend& session_;
 };
@@ -157,27 +157,27 @@ struct empty_session_backend : details::session_backend
 {
     empty_session_backend(connection_parameters const& parameters);
 
-    ~empty_session_backend();
+    ~empty_session_backend() SOCI_OVERRIDE;
 
-    void begin();
-    void commit();
-    void rollback();
+    void begin() SOCI_OVERRIDE;
+    void commit() SOCI_OVERRIDE;
+    void rollback() SOCI_OVERRIDE;
 
-    virtual std::string get_dummy_from_table() const { return std::string(); }
+    std::string get_dummy_from_table() const SOCI_OVERRIDE { return std::string(); }
 
-    std::string get_backend_name() const { return "empty"; }
+    std::string get_backend_name() const SOCI_OVERRIDE { return "empty"; }
 
     void clean_up();
 
-    empty_statement_backend* make_statement_backend();
-    empty_rowid_backend* make_rowid_backend();
-    empty_blob_backend* make_blob_backend();
+    empty_statement_backend* make_statement_backend() SOCI_OVERRIDE;
+    empty_rowid_backend* make_rowid_backend() SOCI_OVERRIDE;
+    empty_blob_backend* make_blob_backend() SOCI_OVERRIDE;
 };
 
 struct SOCI_EMPTY_DECL empty_backend_factory : backend_factory
 {
     empty_backend_factory() {}
-    empty_session_backend* make_session(connection_parameters const& parameters) const;
+    empty_session_backend* make_session(connection_parameters const& parameters) const SOCI_OVERRIDE;
 };
 
 extern SOCI_EMPTY_DECL empty_backend_factory const empty;

--- a/include/soci/error.h
+++ b/include/soci/error.h
@@ -25,14 +25,14 @@ public:
     soci_error(soci_error const& e);
     soci_error& operator=(soci_error const& e);
 
-    virtual ~soci_error() throw();
+    ~soci_error() throw() SOCI_OVERRIDE;
 
     // Returns just the error message itself, without the context.
     std::string get_error_message() const;
 
     // Returns the full error message combining the message given to the ctor
     // with all the available context records.
-    virtual char const* what() const throw();
+    char const* what() const throw() SOCI_OVERRIDE;
 
     // This is used only by SOCI itself to provide more information about the
     // exception as it bubbles up. It can be called multiple times, with the

--- a/include/soci/firebird/soci-firebird.h
+++ b/include/soci/firebird/soci-firebird.h
@@ -49,7 +49,7 @@ public:
     firebird_soci_error(std::string const & msg,
         ISC_STATUS const * status = 0);
 
-    ~firebird_soci_error() throw() {};
+    ~firebird_soci_error() throw() SOCI_OVERRIDE {};
 
     std::vector<ISC_STATUS> status_;
 };
@@ -67,14 +67,14 @@ struct firebird_standard_into_type_backend : details::standard_into_type_backend
         : statement_(st), data_(NULL), type_(), position_(0), buf_(NULL), indISCHolder_(0)
     {}
 
-    virtual void define_by_pos(int &position,
-        void *data, details::exchange_type type);
+    void define_by_pos(int &position,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
 
-    virtual void pre_fetch();
-    virtual void post_fetch(bool gotData, bool calledFromFetch,
-        indicator *ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, bool calledFromFetch,
+        indicator *ind) SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     firebird_statement_backend &statement_;
     virtual void exchangeData();
@@ -98,16 +98,16 @@ struct firebird_vector_into_type_backend : details::vector_into_type_backend
         : statement_(st), data_(NULL), type_(), position_(0), buf_(NULL), indISCHolder_(0)
     {}
 
-    virtual void define_by_pos(int &position,
-        void *data, details::exchange_type type);
+    void define_by_pos(int &position,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
 
-    virtual void pre_fetch();
-    virtual void post_fetch(bool gotData, indicator *ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, indicator *ind) SOCI_OVERRIDE;
 
-    virtual void resize(std::size_t sz);
-    virtual std::size_t size();
+    void resize(std::size_t sz) SOCI_OVERRIDE;
+    std::size_t size() SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     firebird_statement_backend &statement_;
     virtual void exchangeData(std::size_t row);
@@ -127,15 +127,15 @@ struct firebird_standard_use_type_backend : details::standard_use_type_backend
           blob_(NULL)
     {}
 
-    virtual void bind_by_pos(int &position,
-        void *data, details::exchange_type type, bool readOnly);
-    virtual void bind_by_name(std::string const &name,
-        void *data, details::exchange_type type, bool readOnly);
+    void bind_by_pos(int &position,
+        void *data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
+    void bind_by_name(std::string const &name,
+        void *data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
 
-    virtual void pre_use(indicator const *ind);
-    virtual void post_use(bool gotData, indicator *ind);
+    void pre_use(indicator const *ind) SOCI_OVERRIDE;
+    void post_use(bool gotData, indicator *ind) SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     firebird_statement_backend &statement_;
     virtual void exchangeData();
@@ -162,16 +162,16 @@ struct firebird_vector_use_type_backend : details::vector_use_type_backend
         : statement_(st), data_(NULL), type_(), position_(0), buf_(NULL), indISCHolder_(0)
     {}
 
-    virtual void bind_by_pos(int &position,
-        void *data, details::exchange_type type);
-    virtual void bind_by_name(std::string const &name,
-        void *data, details::exchange_type type);
+    void bind_by_pos(int &position,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
+    void bind_by_name(std::string const &name,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
 
-    virtual void pre_use(indicator const *ind);
+    void pre_use(indicator const *ind) SOCI_OVERRIDE;
 
-    virtual std::size_t size();
+    std::size_t size() SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     firebird_statement_backend &statement_;
     virtual void exchangeData(std::size_t row);
@@ -190,28 +190,28 @@ struct firebird_statement_backend : details::statement_backend
 {
     firebird_statement_backend(firebird_session_backend &session);
 
-    virtual void alloc();
-    virtual void clean_up();
-    virtual void prepare(std::string const &query,
-        details::statement_type eType);
+    void alloc() SOCI_OVERRIDE;
+    void clean_up() SOCI_OVERRIDE;
+    void prepare(std::string const &query,
+        details::statement_type eType) SOCI_OVERRIDE;
 
-    virtual exec_fetch_result execute(int number);
-    virtual exec_fetch_result fetch(int number);
+    exec_fetch_result execute(int number) SOCI_OVERRIDE;
+    exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    virtual long long get_affected_rows();
-    virtual int get_number_of_rows();
-    virtual std::string get_parameter_name(int index) const;
+    long long get_affected_rows() SOCI_OVERRIDE;
+    int get_number_of_rows() SOCI_OVERRIDE;
+    std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
-    virtual std::string rewrite_for_procedure_call(std::string const &query);
+    std::string rewrite_for_procedure_call(std::string const &query) SOCI_OVERRIDE;
 
-    virtual int prepare_for_describe();
-    virtual void describe_column(int colNum, data_type &dtype,
-        std::string &columnName);
+    int prepare_for_describe() SOCI_OVERRIDE;
+    void describe_column(int colNum, data_type &dtype,
+        std::string &columnName) SOCI_OVERRIDE;
 
-    virtual firebird_standard_into_type_backend * make_into_type_backend();
-    virtual firebird_standard_use_type_backend * make_use_type_backend();
-    virtual firebird_vector_into_type_backend * make_vector_into_type_backend();
-    virtual firebird_vector_use_type_backend * make_vector_use_type_backend();
+    firebird_standard_into_type_backend * make_into_type_backend() SOCI_OVERRIDE;
+    firebird_standard_use_type_backend * make_use_type_backend() SOCI_OVERRIDE;
+    firebird_vector_into_type_backend * make_vector_into_type_backend() SOCI_OVERRIDE;
+    firebird_vector_use_type_backend * make_vector_use_type_backend() SOCI_OVERRIDE;
 
     firebird_session_backend &session_;
 
@@ -257,15 +257,15 @@ struct firebird_blob_backend : details::blob_backend
 {
     firebird_blob_backend(firebird_session_backend &session);
 
-    ~firebird_blob_backend();
+    ~firebird_blob_backend() SOCI_OVERRIDE;
 
-    virtual std::size_t get_len();
-    virtual std::size_t read(std::size_t offset, char *buf,
-        std::size_t toRead);
-    virtual std::size_t write(std::size_t offset, char const *buf,
-        std::size_t toWrite);
-    virtual std::size_t append(char const *buf, std::size_t toWrite);
-    virtual void trim(std::size_t newLen);
+    std::size_t get_len() SOCI_OVERRIDE;
+    std::size_t read(std::size_t offset, char *buf,
+        std::size_t toRead) SOCI_OVERRIDE;
+    std::size_t write(std::size_t offset, char const *buf,
+        std::size_t toWrite) SOCI_OVERRIDE;
+    std::size_t append(char const *buf, std::size_t toWrite) SOCI_OVERRIDE;
+    void trim(std::size_t newLen) SOCI_OVERRIDE;
 
     firebird_session_backend &session_;
 
@@ -308,24 +308,24 @@ struct firebird_session_backend : details::session_backend
 {
     firebird_session_backend(connection_parameters const & parameters);
 
-    ~firebird_session_backend();
+    ~firebird_session_backend() SOCI_OVERRIDE;
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    void begin() SOCI_OVERRIDE;
+    void commit() SOCI_OVERRIDE;
+    void rollback() SOCI_OVERRIDE;
 
-    virtual bool get_next_sequence_value(session & s,
-        std::string const & sequence, long & value);
+    bool get_next_sequence_value(session & s,
+        std::string const & sequence, long & value) SOCI_OVERRIDE;
 
-    virtual std::string get_dummy_from_table() const { return "rdb$database"; }
+    std::string get_dummy_from_table() const SOCI_OVERRIDE { return "rdb$database"; }
 
-    virtual std::string get_backend_name() const { return "firebird"; }
+    std::string get_backend_name() const SOCI_OVERRIDE { return "firebird"; }
 
     void cleanUp();
 
-    virtual firebird_statement_backend * make_statement_backend();
-    virtual details::rowid_backend* make_rowid_backend();
-    virtual firebird_blob_backend * make_blob_backend();
+    firebird_statement_backend * make_statement_backend() SOCI_OVERRIDE;
+    details::rowid_backend* make_rowid_backend() SOCI_OVERRIDE;
+    firebird_blob_backend * make_blob_backend() SOCI_OVERRIDE;
 
     bool get_option_decimals_as_strings() { return decimals_as_strings_; }
 
@@ -345,8 +345,8 @@ private:
 struct firebird_backend_factory : backend_factory
 {
     firebird_backend_factory() {}
-    virtual firebird_session_backend * make_session(
-        connection_parameters const & parameters) const;
+    firebird_session_backend * make_session(
+        connection_parameters const & parameters) const SOCI_OVERRIDE;
 };
 
 extern SOCI_FIREBIRD_DECL firebird_backend_factory const firebird;

--- a/include/soci/into-type.h
+++ b/include/soci/into-type.h
@@ -57,18 +57,18 @@ public:
     standard_into_type(void * data, exchange_type type, indicator & ind)
         : data_(data), type_(type), ind_(&ind), backEnd_(NULL) {}
 
-    virtual ~standard_into_type();
+    ~standard_into_type() SOCI_OVERRIDE;
 
 protected:
-    virtual void post_fetch(bool gotData, bool calledFromFetch);
+    void post_fetch(bool gotData, bool calledFromFetch) SOCI_OVERRIDE;
 
 private:
-    virtual void define(statement_impl & st, int & position);
-    virtual void pre_exec(int num);
-    virtual void pre_fetch();
-    virtual void clean_up();
+    void define(statement_impl & st, int & position) SOCI_OVERRIDE;
+    void pre_exec(int num) SOCI_OVERRIDE;
+    void pre_fetch() SOCI_OVERRIDE;
+    void clean_up() SOCI_OVERRIDE;
 
-    virtual std::size_t size() const { return 1; }
+    std::size_t size() const SOCI_OVERRIDE { return 1; }
 
     // conversion hook (from base type to arbitrary user type)
     virtual void convert_from_base() {}
@@ -104,17 +104,17 @@ public:
         : data_(data), type_(type), indVec_(&ind),
         begin_(begin), end_(end), backEnd_(NULL) {}
 
-    ~vector_into_type();
+    ~vector_into_type() SOCI_OVERRIDE;
 
 protected:
-    virtual void post_fetch(bool gotData, bool calledFromFetch);
+    void post_fetch(bool gotData, bool calledFromFetch) SOCI_OVERRIDE;
 
-    virtual void define(statement_impl & st, int & position);
-    virtual void pre_exec(int num);
-    virtual void pre_fetch();
-    virtual void clean_up();
-    virtual void resize(std::size_t sz);
-    virtual std::size_t size() const;
+    void define(statement_impl & st, int & position) SOCI_OVERRIDE;
+    void pre_exec(int num) SOCI_OVERRIDE;
+    void pre_fetch() SOCI_OVERRIDE;
+    void clean_up() SOCI_OVERRIDE;
+    void resize(std::size_t sz) SOCI_OVERRIDE;
+    std::size_t size() const SOCI_OVERRIDE;
 
     void * data_;
     exchange_type type_;
@@ -149,16 +149,16 @@ public:
     into_type(std::vector<T> & v)
         : vector_into_type(&v,
             static_cast<exchange_type>(exchange_traits<T>::x_type)) {}
-    
+
     into_type(std::vector<T> & v, std::size_t begin, std::size_t * end)
         : vector_into_type(&v,
             static_cast<exchange_type>(exchange_traits<T>::x_type),
             begin, end) {}
-    
+
     into_type(std::vector<T> & v, std::vector<indicator> & ind)
         : vector_into_type(&v,
             static_cast<exchange_type>(exchange_traits<T>::x_type), ind) {}
-    
+
     into_type(std::vector<T> & v, std::vector<indicator> & ind,
         std::size_t begin, std::size_t * end)
         : vector_into_type(&v,

--- a/include/soci/mysql/soci-mysql.h
+++ b/include/soci/mysql/soci-mysql.h
@@ -50,14 +50,14 @@ struct mysql_standard_into_type_backend : details::standard_into_type_backend
     mysql_standard_into_type_backend(mysql_statement_backend &st)
         : statement_(st) {}
 
-    virtual void define_by_pos(int &position,
-        void *data, details::exchange_type type);
+    void define_by_pos(int &position,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
 
-    virtual void pre_fetch();
-    virtual void post_fetch(bool gotData, bool calledFromFetch,
-        indicator *ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, bool calledFromFetch,
+        indicator *ind) SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     mysql_statement_backend &statement_;
 
@@ -71,16 +71,16 @@ struct mysql_vector_into_type_backend : details::vector_into_type_backend
     mysql_vector_into_type_backend(mysql_statement_backend &st)
         : statement_(st) {}
 
-    virtual void define_by_pos(int &position,
-        void *data, details::exchange_type type);
+    void define_by_pos(int &position,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
 
-    virtual void pre_fetch();
-    virtual void post_fetch(bool gotData, indicator *ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, indicator *ind) SOCI_OVERRIDE;
 
-    virtual void resize(std::size_t sz);
-    virtual std::size_t size();
+    void resize(std::size_t sz) SOCI_OVERRIDE;
+    std::size_t size() SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     mysql_statement_backend &statement_;
 
@@ -94,15 +94,15 @@ struct mysql_standard_use_type_backend : details::standard_use_type_backend
     mysql_standard_use_type_backend(mysql_statement_backend &st)
         : statement_(st), position_(0), buf_(NULL) {}
 
-    virtual void bind_by_pos(int &position,
-        void *data, details::exchange_type type, bool readOnly);
-    virtual void bind_by_name(std::string const &name,
-        void *data, details::exchange_type type, bool readOnly);
+    void bind_by_pos(int &position,
+        void *data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
+    void bind_by_name(std::string const &name,
+        void *data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
 
-    virtual void pre_use(indicator const *ind);
-    virtual void post_use(bool gotData, indicator *ind);
+    void pre_use(indicator const *ind) SOCI_OVERRIDE;
+    void post_use(bool gotData, indicator *ind) SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     mysql_statement_backend &statement_;
 
@@ -118,16 +118,16 @@ struct mysql_vector_use_type_backend : details::vector_use_type_backend
     mysql_vector_use_type_backend(mysql_statement_backend &st)
         : statement_(st), position_(0) {}
 
-    virtual void bind_by_pos(int &position,
-        void *data, details::exchange_type type);
-    virtual void bind_by_name(std::string const &name,
-        void *data, details::exchange_type type);
+    void bind_by_pos(int &position,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
+    void bind_by_name(std::string const &name,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
 
-    virtual void pre_use(indicator const *ind);
+    void pre_use(indicator const *ind) SOCI_OVERRIDE;
 
-    virtual std::size_t size();
+    std::size_t size() SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     mysql_statement_backend &statement_;
 
@@ -143,28 +143,28 @@ struct mysql_statement_backend : details::statement_backend
 {
     mysql_statement_backend(mysql_session_backend &session);
 
-    virtual void alloc();
-    virtual void clean_up();
-    virtual void prepare(std::string const &query,
-        details::statement_type eType);
+    void alloc() SOCI_OVERRIDE;
+    void clean_up() SOCI_OVERRIDE;
+    void prepare(std::string const &query,
+        details::statement_type eType) SOCI_OVERRIDE;
 
-    virtual exec_fetch_result execute(int number);
-    virtual exec_fetch_result fetch(int number);
+    exec_fetch_result execute(int number) SOCI_OVERRIDE;
+    exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    virtual long long get_affected_rows();
-    virtual int get_number_of_rows();
-    virtual std::string get_parameter_name(int index) const;
+    long long get_affected_rows() SOCI_OVERRIDE;
+    int get_number_of_rows() SOCI_OVERRIDE;
+    std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
-    virtual std::string rewrite_for_procedure_call(std::string const &query);
+    std::string rewrite_for_procedure_call(std::string const &query) SOCI_OVERRIDE;
 
-    virtual int prepare_for_describe();
-    virtual void describe_column(int colNum, data_type &dtype,
-        std::string &columnName);
+    int prepare_for_describe() SOCI_OVERRIDE;
+    void describe_column(int colNum, data_type &dtype,
+        std::string &columnName) SOCI_OVERRIDE;
 
-    virtual mysql_standard_into_type_backend * make_into_type_backend();
-    virtual mysql_standard_use_type_backend * make_use_type_backend();
-    virtual mysql_vector_into_type_backend * make_vector_into_type_backend();
-    virtual mysql_vector_use_type_backend * make_vector_use_type_backend();
+    mysql_standard_into_type_backend * make_into_type_backend() SOCI_OVERRIDE;
+    mysql_standard_use_type_backend * make_use_type_backend() SOCI_OVERRIDE;
+    mysql_vector_into_type_backend * make_vector_into_type_backend() SOCI_OVERRIDE;
+    mysql_vector_use_type_backend * make_vector_use_type_backend() SOCI_OVERRIDE;
 
     mysql_session_backend &session_;
 
@@ -209,22 +209,22 @@ struct mysql_rowid_backend : details::rowid_backend
 {
     mysql_rowid_backend(mysql_session_backend &session);
 
-    ~mysql_rowid_backend();
+    ~mysql_rowid_backend() SOCI_OVERRIDE;
 };
 
 struct mysql_blob_backend : details::blob_backend
 {
     mysql_blob_backend(mysql_session_backend &session);
 
-    ~mysql_blob_backend();
+    ~mysql_blob_backend() SOCI_OVERRIDE;
 
-    virtual std::size_t get_len();
-    virtual std::size_t read(std::size_t offset, char *buf,
-        std::size_t toRead);
-    virtual std::size_t write(std::size_t offset, char const *buf,
-        std::size_t toWrite);
-    virtual std::size_t append(char const *buf, std::size_t toWrite);
-    virtual void trim(std::size_t newLen);
+    std::size_t get_len() SOCI_OVERRIDE;
+    std::size_t read(std::size_t offset, char *buf,
+        std::size_t toRead) SOCI_OVERRIDE;
+    std::size_t write(std::size_t offset, char const *buf,
+        std::size_t toWrite) SOCI_OVERRIDE;
+    std::size_t append(char const *buf, std::size_t toWrite) SOCI_OVERRIDE;
+    void trim(std::size_t newLen) SOCI_OVERRIDE;
 
     mysql_session_backend &session_;
 };
@@ -233,25 +233,25 @@ struct mysql_session_backend : details::session_backend
 {
     mysql_session_backend(connection_parameters const & parameters);
 
-    ~mysql_session_backend();
+    ~mysql_session_backend() SOCI_OVERRIDE;
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    void begin() SOCI_OVERRIDE;
+    void commit() SOCI_OVERRIDE;
+    void rollback() SOCI_OVERRIDE;
 
-    virtual bool get_last_insert_id(session&, std::string const&, long&);
+    bool get_last_insert_id(session&, std::string const&, long&) SOCI_OVERRIDE;
 
     // Note that MySQL supports both "SELECT 2+2" and "SELECT 2+2 FROM DUAL"
     // syntaxes, but there doesn't seem to be any reason to use the longer one.
-    virtual std::string get_dummy_from_table() const { return std::string(); }
+    std::string get_dummy_from_table() const SOCI_OVERRIDE { return std::string(); }
 
-    virtual std::string get_backend_name() const { return "mysql"; }
+    std::string get_backend_name() const SOCI_OVERRIDE { return "mysql"; }
 
     void clean_up();
 
-    virtual mysql_statement_backend * make_statement_backend();
-    virtual mysql_rowid_backend * make_rowid_backend();
-    virtual mysql_blob_backend * make_blob_backend();
+    mysql_statement_backend * make_statement_backend() SOCI_OVERRIDE;
+    mysql_rowid_backend * make_rowid_backend() SOCI_OVERRIDE;
+    mysql_blob_backend * make_blob_backend() SOCI_OVERRIDE;
 
     MYSQL *conn_;
 };
@@ -260,8 +260,8 @@ struct mysql_session_backend : details::session_backend
 struct mysql_backend_factory : backend_factory
 {
     mysql_backend_factory() {}
-    virtual mysql_session_backend * make_session(
-        connection_parameters const & parameters) const;
+    mysql_session_backend * make_session(
+        connection_parameters const & parameters) const SOCI_OVERRIDE;
 };
 
 extern SOCI_MYSQL_DECL mysql_backend_factory const mysql;

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -96,14 +96,14 @@ struct odbc_standard_into_type_backend : details::standard_into_type_backend,
         : odbc_standard_type_backend_base(st), buf_(0)
     {}
 
-    virtual void define_by_pos(int &position,
-        void *data, details::exchange_type type);
+    void define_by_pos(int &position,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
 
-    virtual void pre_fetch();
-    virtual void post_fetch(bool gotData, bool calledFromFetch,
-        indicator *ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, bool calledFromFetch,
+        indicator *ind) SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     char *buf_;        // generic buffer
     void *data_;
@@ -122,16 +122,16 @@ struct odbc_vector_into_type_backend : details::vector_into_type_backend,
         : odbc_standard_type_backend_base(st), indHolders_(NULL),
           data_(NULL), buf_(NULL) {}
 
-    virtual void define_by_pos(int &position,
-        void *data, details::exchange_type type);
+    void define_by_pos(int &position,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
 
-    virtual void pre_fetch();
-    virtual void post_fetch(bool gotData, indicator *ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, indicator *ind) SOCI_OVERRIDE;
 
-    virtual void resize(std::size_t sz);
-    virtual std::size_t size();
+    void resize(std::size_t sz) SOCI_OVERRIDE;
+    std::size_t size() SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     // helper function for preparing indicators
     // (as part of the define_by_pos)
@@ -154,15 +154,15 @@ struct odbc_standard_use_type_backend : details::standard_use_type_backend,
         : odbc_standard_type_backend_base(st),
           position_(-1), data_(0), buf_(0), indHolder_(0) {}
 
-    virtual void bind_by_pos(int &position,
-        void *data, details::exchange_type type, bool readOnly);
-    virtual void bind_by_name(std::string const &name,
-        void *data, details::exchange_type type, bool readOnly);
+    void bind_by_pos(int &position,
+        void *data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
+    void bind_by_name(std::string const &name,
+        void *data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
 
-    virtual void pre_use(indicator const *ind);
-    virtual void post_use(bool gotData, indicator *ind);
+    void pre_use(indicator const *ind) SOCI_OVERRIDE;
+    void post_use(bool gotData, indicator *ind) SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     // Return the pointer to the buffer containing data to be used by ODBC.
     // This can be either data_ itself or buf_, that is allocated by this
@@ -204,16 +204,16 @@ struct odbc_vector_use_type_backend : details::vector_use_type_backend,
     void bind_helper(int &position,
         void *data, details::exchange_type type);
 
-    virtual void bind_by_pos(int &position,
-        void *data, details::exchange_type type);
-    virtual void bind_by_name(std::string const &name,
-        void *data, details::exchange_type type);
+    void bind_by_pos(int &position,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
+    void bind_by_name(std::string const &name,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
 
-    virtual void pre_use(indicator const *ind);
+    void pre_use(indicator const *ind) SOCI_OVERRIDE;
 
-    virtual std::size_t size();
+    std::size_t size() SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
 
     SQLLEN *indHolders_;
@@ -231,31 +231,31 @@ struct odbc_statement_backend : details::statement_backend
 {
     odbc_statement_backend(odbc_session_backend &session);
 
-    virtual void alloc();
-    virtual void clean_up();
-    virtual void prepare(std::string const &query,
-        details::statement_type eType);
+    void alloc() SOCI_OVERRIDE;
+    void clean_up() SOCI_OVERRIDE;
+    void prepare(std::string const &query,
+        details::statement_type eType) SOCI_OVERRIDE;
 
-    virtual exec_fetch_result execute(int number);
-    virtual exec_fetch_result fetch(int number);
+    exec_fetch_result execute(int number) SOCI_OVERRIDE;
+    exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    virtual long long get_affected_rows();
-    virtual int get_number_of_rows();
-    virtual std::string get_parameter_name(int index) const;
+    long long get_affected_rows() SOCI_OVERRIDE;
+    int get_number_of_rows() SOCI_OVERRIDE;
+    std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
-    virtual std::string rewrite_for_procedure_call(std::string const &query);
+    std::string rewrite_for_procedure_call(std::string const &query) SOCI_OVERRIDE;
 
-    virtual int prepare_for_describe();
-    virtual void describe_column(int colNum, data_type &dtype,
-        std::string &columnName);
+    int prepare_for_describe() SOCI_OVERRIDE;
+    void describe_column(int colNum, data_type &dtype,
+        std::string &columnName) SOCI_OVERRIDE;
 
     // helper for defining into vector<string>
     std::size_t column_size(int position);
 
-    virtual odbc_standard_into_type_backend * make_into_type_backend();
-    virtual odbc_standard_use_type_backend * make_use_type_backend();
-    virtual odbc_vector_into_type_backend * make_vector_into_type_backend();
-    virtual odbc_vector_use_type_backend * make_vector_use_type_backend();
+    odbc_standard_into_type_backend * make_into_type_backend() SOCI_OVERRIDE;
+    odbc_standard_use_type_backend * make_use_type_backend() SOCI_OVERRIDE;
+    odbc_vector_into_type_backend * make_vector_into_type_backend() SOCI_OVERRIDE;
+    odbc_vector_use_type_backend * make_vector_use_type_backend() SOCI_OVERRIDE;
 
     odbc_session_backend &session_;
     SQLHSTMT hstmt_;
@@ -275,22 +275,22 @@ struct odbc_rowid_backend : details::rowid_backend
 {
     odbc_rowid_backend(odbc_session_backend &session);
 
-    ~odbc_rowid_backend();
+    ~odbc_rowid_backend() SOCI_OVERRIDE;
 };
 
 struct odbc_blob_backend : details::blob_backend
 {
     odbc_blob_backend(odbc_session_backend &session);
 
-    ~odbc_blob_backend();
+    ~odbc_blob_backend() SOCI_OVERRIDE;
 
-    virtual std::size_t get_len();
-    virtual std::size_t read(std::size_t offset, char *buf,
-        std::size_t toRead);
-    virtual std::size_t write(std::size_t offset, char const *buf,
-        std::size_t toWrite);
-    virtual std::size_t append(char const *buf, std::size_t toWrite);
-    virtual void trim(std::size_t newLen);
+    std::size_t get_len() SOCI_OVERRIDE;
+    std::size_t read(std::size_t offset, char *buf,
+        std::size_t toRead) SOCI_OVERRIDE;
+    std::size_t write(std::size_t offset, char const *buf,
+        std::size_t toWrite) SOCI_OVERRIDE;
+    std::size_t append(char const *buf, std::size_t toWrite) SOCI_OVERRIDE;
+    void trim(std::size_t newLen) SOCI_OVERRIDE;
 
     odbc_session_backend &session_;
 };
@@ -299,29 +299,29 @@ struct odbc_session_backend : details::session_backend
 {
     odbc_session_backend(connection_parameters const & parameters);
 
-    ~odbc_session_backend();
+    ~odbc_session_backend() SOCI_OVERRIDE;
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    void begin() SOCI_OVERRIDE;
+    void commit() SOCI_OVERRIDE;
+    void rollback() SOCI_OVERRIDE;
 
-    virtual bool get_next_sequence_value(session & s,
-        std::string const & sequence, long & value);
-    virtual bool get_last_insert_id(session & s,
-        std::string const & table, long & value);
+    bool get_next_sequence_value(session & s,
+        std::string const & sequence, long & value) SOCI_OVERRIDE;
+    bool get_last_insert_id(session & s,
+        std::string const & table, long & value) SOCI_OVERRIDE;
 
-    virtual std::string get_dummy_from_table() const;
+    std::string get_dummy_from_table() const SOCI_OVERRIDE;
 
-    virtual std::string get_backend_name() const { return "odbc"; }
+    std::string get_backend_name() const SOCI_OVERRIDE { return "odbc"; }
 
     void configure_connection();
     void reset_transaction();
 
     void clean_up();
 
-    virtual odbc_statement_backend * make_statement_backend();
-    virtual odbc_rowid_backend * make_rowid_backend();
-    virtual odbc_blob_backend * make_blob_backend();
+    odbc_statement_backend * make_statement_backend() SOCI_OVERRIDE;
+    odbc_rowid_backend * make_rowid_backend() SOCI_OVERRIDE;
+    odbc_blob_backend * make_blob_backend() SOCI_OVERRIDE;
 
     enum database_product
     {
@@ -456,8 +456,8 @@ inline bool odbc_standard_type_backend_base::use_string_for_bigint() const
 struct odbc_backend_factory : backend_factory
 {
     odbc_backend_factory() {}
-    virtual odbc_session_backend * make_session(
-        connection_parameters const & parameters) const;
+    odbc_session_backend * make_session(
+        connection_parameters const & parameters) const SOCI_OVERRIDE;
 };
 
 extern SOCI_ODBC_DECL odbc_backend_factory const odbc;

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -41,7 +41,7 @@ class SOCI_ORACLE_DECL oracle_soci_error : public soci_error
 public:
     oracle_soci_error(std::string const & msg, int errNum = 0);
 
-    virtual error_category get_error_category() const { return cat_; }
+    error_category get_error_category() const SOCI_OVERRIDE { return cat_; }
 
     int err_num_;
     error_category cat_;
@@ -55,17 +55,17 @@ struct oracle_standard_into_type_backend : details::standard_into_type_backend
         : statement_(st), defnp_(NULL), indOCIHolder_(0),
           data_(NULL), buf_(NULL) {}
 
-    virtual void define_by_pos(int &position,
-        void *data, details::exchange_type type);
+    void define_by_pos(int &position,
+        void *data, details::exchange_type type) SOCI_OVERRIDE;
 
     void read_from_lob(OCILobLocator * lobp, std::string & value);
-    
-    virtual void pre_exec(int num);
-    virtual void pre_fetch();
-    virtual void post_fetch(bool gotData, bool calledFromFetch,
-        indicator *ind);
 
-    virtual void clean_up();
+    void pre_exec(int num) SOCI_OVERRIDE;
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, bool calledFromFetch,
+        indicator *ind) SOCI_OVERRIDE;
+
+    void clean_up() SOCI_OVERRIDE;
 
     oracle_statement_backend &statement_;
 
@@ -85,25 +85,25 @@ struct oracle_vector_into_type_backend : details::vector_into_type_backend
         : statement_(st), defnp_(NULL), indOCIHolders_(NULL),
         data_(NULL), buf_(NULL), user_ranges_(true) {}
 
-    virtual void define_by_pos(int &position,
-        void *data, details::exchange_type type)
+    void define_by_pos(int &position,
+        void *data, details::exchange_type type) SOCI_OVERRIDE
     {
         user_ranges_ = false;
         define_by_pos_bulk(position, data, type, 0, &end_var_);
     }
-    
-    virtual void define_by_pos_bulk(
+
+    void define_by_pos_bulk(
         int & position, void * data, details::exchange_type type,
-        std::size_t begin, std::size_t * end);
+        std::size_t begin, std::size_t * end) SOCI_OVERRIDE;
 
-    virtual void pre_fetch();
-    virtual void post_fetch(bool gotData, indicator *ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, indicator *ind) SOCI_OVERRIDE;
 
-    virtual void resize(std::size_t sz);
-    virtual std::size_t size();
+    void resize(std::size_t sz) SOCI_OVERRIDE;
+    std::size_t size() SOCI_OVERRIDE;
     std::size_t full_size();
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     // helper function for preparing indicators and sizes_ vectors
     // (as part of the define_by_pos)
@@ -133,25 +133,25 @@ struct oracle_standard_use_type_backend : details::standard_use_type_backend
         : statement_(st), bindp_(NULL), indOCIHolder_(0),
           data_(NULL), buf_(NULL) {}
 
-    virtual void bind_by_pos(int &position,
-        void *data, details::exchange_type type, bool readOnly);
-    virtual void bind_by_name(std::string const &name,
-        void *data, details::exchange_type type, bool readOnly);
+    void bind_by_pos(int &position,
+        void *data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
+    void bind_by_name(std::string const &name,
+        void *data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
 
     // common part for bind_by_pos and bind_by_name
     void prepare_for_bind(void *&data, sb4 &size, ub2 &oracleType, bool readOnly);
 
     // common helper for pre_use for LOB-directed wrapped types
     void write_to_lob(OCILobLocator * lobp, const std::string & value);
-    
+
     // common lazy initialization of the temporary LOB object
     void lazy_temp_lob_init();
-    
-    virtual void pre_exec(int num);
-    virtual void pre_use(indicator const *ind);
-    virtual void post_use(bool gotData, indicator *ind);
 
-    virtual void clean_up();
+    void pre_exec(int num) SOCI_OVERRIDE;
+    void pre_use(indicator const *ind) SOCI_OVERRIDE;
+    void post_use(bool gotData, indicator *ind) SOCI_OVERRIDE;
+
+    void clean_up() SOCI_OVERRIDE;
 
     oracle_statement_backend &statement_;
 
@@ -170,25 +170,25 @@ struct oracle_vector_use_type_backend : details::vector_use_type_backend
         : statement_(st), bindp_(NULL), indOCIHolders_(NULL),
           data_(NULL), buf_(NULL) {}
 
-    virtual void bind_by_pos(int & position,
-        void * data, details::exchange_type type)
+    void bind_by_pos(int & position,
+        void * data, details::exchange_type type) SOCI_OVERRIDE
     {
         bind_by_pos_bulk(position, data, type, 0, &end_var_);
     }
-    
-    virtual void bind_by_pos_bulk(int & position,
+
+    void bind_by_pos_bulk(int & position,
         void * data, details::exchange_type type,
-        std::size_t begin, std::size_t * end);
-    
-    virtual void bind_by_name(const std::string & name,
-        void * data, details::exchange_type type)
+        std::size_t begin, std::size_t * end) SOCI_OVERRIDE;
+
+    void bind_by_name(const std::string & name,
+        void * data, details::exchange_type type) SOCI_OVERRIDE
     {
         bind_by_name_bulk(name, data, type, 0, &end_var_);
     }
 
-    virtual void bind_by_name_bulk(std::string const &name,
+    void bind_by_name_bulk(std::string const &name,
         void *data, details::exchange_type type,
-        std::size_t begin, std::size_t * end);
+        std::size_t begin, std::size_t * end) SOCI_OVERRIDE;
 
     // common part for bind_by_pos and bind_by_name
     void prepare_for_bind(void *&data, sb4 &size, ub2 &oracleType);
@@ -197,12 +197,12 @@ struct oracle_vector_use_type_backend : details::vector_use_type_backend
     // (as part of the bind_by_pos and bind_by_name)
     void prepare_indicators(std::size_t size);
 
-    virtual void pre_use(indicator const *ind);
+    void pre_use(indicator const *ind) SOCI_OVERRIDE;
 
-    virtual std::size_t size(); // active size (might be lower than full vector size)
+    std::size_t size() SOCI_OVERRIDE; // active size (might be lower than full vector size)
     std::size_t full_size();    // actual size of the user-provided vector
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     oracle_statement_backend &statement_;
 
@@ -226,31 +226,31 @@ struct oracle_statement_backend : details::statement_backend
 {
     oracle_statement_backend(oracle_session_backend &session);
 
-    virtual void alloc();
-    virtual void clean_up();
-    virtual void prepare(std::string const &query,
-        details::statement_type eType);
+    void alloc() SOCI_OVERRIDE;
+    void clean_up() SOCI_OVERRIDE;
+    void prepare(std::string const &query,
+        details::statement_type eType) SOCI_OVERRIDE;
 
-    virtual exec_fetch_result execute(int number);
-    virtual exec_fetch_result fetch(int number);
+    exec_fetch_result execute(int number) SOCI_OVERRIDE;
+    exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    virtual long long get_affected_rows();
-    virtual int get_number_of_rows();
-    virtual std::string get_parameter_name(int index) const;
+    long long get_affected_rows() SOCI_OVERRIDE;
+    int get_number_of_rows() SOCI_OVERRIDE;
+    std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
-    virtual std::string rewrite_for_procedure_call(std::string const &query);
+    std::string rewrite_for_procedure_call(std::string const &query) SOCI_OVERRIDE;
 
-    virtual int prepare_for_describe();
-    virtual void describe_column(int colNum, data_type &dtype,
-        std::string &columnName);
+    int prepare_for_describe() SOCI_OVERRIDE;
+    void describe_column(int colNum, data_type &dtype,
+        std::string &columnName) SOCI_OVERRIDE;
 
     // helper for defining into vector<string>
     std::size_t column_size(int position);
 
-    virtual oracle_standard_into_type_backend * make_into_type_backend();
-    virtual oracle_standard_use_type_backend * make_use_type_backend();
-    virtual oracle_vector_into_type_backend * make_vector_into_type_backend();
-    virtual oracle_vector_use_type_backend * make_vector_use_type_backend();
+    oracle_standard_into_type_backend * make_into_type_backend() SOCI_OVERRIDE;
+    oracle_standard_use_type_backend * make_use_type_backend() SOCI_OVERRIDE;
+    oracle_vector_into_type_backend * make_vector_into_type_backend() SOCI_OVERRIDE;
+    oracle_vector_use_type_backend * make_vector_use_type_backend() SOCI_OVERRIDE;
 
     oracle_session_backend &session_;
 
@@ -265,7 +265,7 @@ struct oracle_rowid_backend : details::rowid_backend
 {
     oracle_rowid_backend(oracle_session_backend &session);
 
-    ~oracle_rowid_backend();
+    ~oracle_rowid_backend() SOCI_OVERRIDE;
 
     OCIRowid *rowidp_;
 };
@@ -274,31 +274,31 @@ struct oracle_blob_backend : details::blob_backend
 {
     oracle_blob_backend(oracle_session_backend &session);
 
-    ~oracle_blob_backend();
+    ~oracle_blob_backend() SOCI_OVERRIDE;
 
-    virtual std::size_t get_len();
-    
-    virtual std::size_t read(std::size_t offset, char *buf,
-        std::size_t toRead);
-    
-    virtual std::size_t read_from_start(char * buf, std::size_t toRead,
-        std::size_t offset)
+    std::size_t get_len() SOCI_OVERRIDE;
+
+    std::size_t read(std::size_t offset, char *buf,
+        std::size_t toRead) SOCI_OVERRIDE;
+
+    std::size_t read_from_start(char * buf, std::size_t toRead,
+        std::size_t offset) SOCI_OVERRIDE
     {
         return read(offset + 1, buf, toRead);
     }
-    
-    virtual std::size_t write(std::size_t offset, char const *buf,
-        std::size_t toWrite);
-    
-    virtual std::size_t write_from_start(const char * buf, std::size_t toWrite,
-        std::size_t offset)
+
+    std::size_t write(std::size_t offset, char const *buf,
+        std::size_t toWrite) SOCI_OVERRIDE;
+
+    std::size_t write_from_start(const char * buf, std::size_t toWrite,
+        std::size_t offset) SOCI_OVERRIDE
     {
         return write(offset + 1, buf, toWrite);
     }
-    
-    virtual std::size_t append(char const *buf, std::size_t toWrite);
-    
-    virtual void trim(std::size_t newLen);
+
+    std::size_t append(char const *buf, std::size_t toWrite) SOCI_OVERRIDE;
+
+    void trim(std::size_t newLen) SOCI_OVERRIDE;
 
     oracle_session_backend &session_;
 
@@ -315,19 +315,19 @@ struct oracle_session_backend : details::session_backend
         int charset = 0,
         int ncharset = 0);
 
-    ~oracle_session_backend();
+    ~oracle_session_backend() SOCI_OVERRIDE;
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    void begin() SOCI_OVERRIDE;
+    void commit() SOCI_OVERRIDE;
+    void rollback() SOCI_OVERRIDE;
 
-    virtual std::string get_table_names_query() const
+    std::string get_table_names_query() const SOCI_OVERRIDE
     {
         return "select table_name"
             " from user_tables";
     }
 
-    virtual std::string get_column_descriptions_query() const
+    std::string get_column_descriptions_query() const SOCI_OVERRIDE
     {
         return "select column_name,"
             " data_type,"
@@ -338,19 +338,19 @@ struct oracle_session_backend : details::session_backend
             " from user_tab_columns"
             " where table_name = :t";
     }
-    
-    virtual std::string create_column_type(data_type dt,
-        int precision, int scale)
+
+    std::string create_column_type(data_type dt,
+        int precision, int scale) SOCI_OVERRIDE
     {
         //  Oracle-specific SQL syntax:
-        
+
         std::string res;
         switch (dt)
         {
         case dt_string:
             {
                 std::ostringstream oss;
-                
+
                 if (precision == 0)
                 {
                     oss << "clob";
@@ -359,11 +359,11 @@ struct oracle_session_backend : details::session_backend
                 {
                     oss << "varchar(" << precision << ")";
                 }
-                
+
                 res += oss.str();
             }
             break;
-            
+
         case dt_date:
             res += "timestamp";
             break;
@@ -379,7 +379,7 @@ struct oracle_session_backend : details::session_backend
                 {
                     oss << "number(" << precision << ", " << scale << ")";
                 }
-                
+
                 res += oss.str();
             }
             break;
@@ -391,7 +391,7 @@ struct oracle_session_backend : details::session_backend
         case dt_long_long:
             res += "number";
             break;
-            
+
         case dt_unsigned_long_long:
             res += "number";
             break;
@@ -410,38 +410,38 @@ struct oracle_session_backend : details::session_backend
 
         return res;
     }
-    virtual std::string add_column(const std::string & tableName,
+    std::string add_column(const std::string & tableName,
         const std::string & columnName, data_type dt,
-        int precision, int scale)
+        int precision, int scale) SOCI_OVERRIDE
     {
         return "alter table " + tableName + " add " +
             columnName + " " + create_column_type(dt, precision, scale);
     }
-    virtual std::string alter_column(const std::string & tableName,
+    std::string alter_column(const std::string & tableName,
         const std::string & columnName, data_type dt,
-        int precision, int scale)
+        int precision, int scale) SOCI_OVERRIDE
     {
         return "alter table " + tableName + " modify " +
             columnName + " " + create_column_type(dt, precision, scale);
     }
-    virtual std::string empty_blob()
+    std::string empty_blob() SOCI_OVERRIDE
     {
         return "empty_blob()";
     }
-    virtual std::string nvl()
+    std::string nvl() SOCI_OVERRIDE
     {
         return "nvl";
     }
 
-    virtual std::string get_dummy_from_table() const { return "dual"; }
+    std::string get_dummy_from_table() const SOCI_OVERRIDE { return "dual"; }
 
-    virtual std::string get_backend_name() const { return "oracle"; }
+    std::string get_backend_name() const SOCI_OVERRIDE { return "oracle"; }
 
     void clean_up();
 
-    virtual oracle_statement_backend * make_statement_backend();
-    virtual oracle_rowid_backend * make_rowid_backend();
-    virtual oracle_blob_backend * make_blob_backend();
+    oracle_statement_backend * make_statement_backend() SOCI_OVERRIDE;
+    oracle_rowid_backend * make_rowid_backend() SOCI_OVERRIDE;
+    oracle_blob_backend * make_blob_backend() SOCI_OVERRIDE;
 
     bool get_option_decimals_as_strings() { return decimals_as_strings_; }
 
@@ -461,8 +461,8 @@ struct oracle_session_backend : details::session_backend
 struct oracle_backend_factory : backend_factory
 {
 	  oracle_backend_factory() {}
-    virtual oracle_session_backend * make_session(
-        connection_parameters const & parameters) const;
+    oracle_session_backend * make_session(
+        connection_parameters const & parameters) const SOCI_OVERRIDE;
 };
 
 extern SOCI_ORACLE_DECL oracle_backend_factory const oracle;

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -38,7 +38,7 @@ public:
 
     std::string sqlstate() const;
 
-    virtual error_category get_error_category() const { return cat_; }
+    error_category get_error_category() const SOCI_OVERRIDE { return cat_; }
 
 private:
     char sqlstate_[ 5 ];   // not std::string to keep copy-constructor no-throw
@@ -130,14 +130,14 @@ struct postgresql_standard_into_type_backend : details::standard_into_type_backe
     postgresql_standard_into_type_backend(postgresql_statement_backend & st)
         : statement_(st) {}
 
-    virtual void define_by_pos(int & position,
-        void * data, details::exchange_type type);
+    void define_by_pos(int & position,
+        void * data, details::exchange_type type) SOCI_OVERRIDE;
 
-    virtual void pre_fetch();
-    virtual void post_fetch(bool gotData, bool calledFromFetch,
-        indicator * ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, bool calledFromFetch,
+        indicator * ind) SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     postgresql_statement_backend & statement_;
 
@@ -151,25 +151,25 @@ struct postgresql_vector_into_type_backend : details::vector_into_type_backend
     postgresql_vector_into_type_backend(postgresql_statement_backend & st)
         : statement_(st), user_ranges_(true) {}
 
-    virtual void define_by_pos(int & position,
-        void * data, details::exchange_type type)
+    void define_by_pos(int & position,
+        void * data, details::exchange_type type) SOCI_OVERRIDE
     {
         user_ranges_ = false;
         define_by_pos_bulk(position, data, type, 0, &end_var_);
     }
 
-    virtual void define_by_pos_bulk(int & position,
+    void define_by_pos_bulk(int & position,
         void * data, details::exchange_type type,
-        std::size_t begin, std::size_t * end);
+        std::size_t begin, std::size_t * end) SOCI_OVERRIDE;
 
-    virtual void pre_fetch();
-    virtual void post_fetch(bool gotData, indicator * ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, indicator * ind) SOCI_OVERRIDE;
 
-    virtual void resize(std::size_t sz);
-    virtual std::size_t size(); // active size (might be lower than full vector size)
+    void resize(std::size_t sz) SOCI_OVERRIDE;
+    std::size_t size() SOCI_OVERRIDE; // active size (might be lower than full vector size)
     std::size_t full_size();    // actual size of the user-provided vector
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     postgresql_statement_backend & statement_;
 
@@ -187,15 +187,15 @@ struct postgresql_standard_use_type_backend : details::standard_use_type_backend
     postgresql_standard_use_type_backend(postgresql_statement_backend & st)
         : statement_(st), position_(0), buf_(NULL) {}
 
-    virtual void bind_by_pos(int & position,
-        void * data, details::exchange_type type, bool readOnly);
-    virtual void bind_by_name(std::string const & name,
-        void * data, details::exchange_type type, bool readOnly);
+    void bind_by_pos(int & position,
+        void * data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
+    void bind_by_name(std::string const & name,
+        void * data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
 
-    virtual void pre_use(indicator const * ind);
-    virtual void post_use(bool gotData, indicator * ind);
+    void pre_use(indicator const * ind) SOCI_OVERRIDE;
+    void post_use(bool gotData, indicator * ind) SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     postgresql_statement_backend & statement_;
 
@@ -215,32 +215,32 @@ struct postgresql_vector_use_type_backend : details::vector_use_type_backend
     postgresql_vector_use_type_backend(postgresql_statement_backend & st)
         : statement_(st), position_(0) {}
 
-    virtual void bind_by_pos(int & position,
-        void * data, details::exchange_type type)
+    void bind_by_pos(int & position,
+        void * data, details::exchange_type type) SOCI_OVERRIDE
     {
         bind_by_pos_bulk(position, data, type, 0, &end_var_);
     }
-    
-    virtual void bind_by_pos_bulk(int & position,
+
+    void bind_by_pos_bulk(int & position,
         void * data, details::exchange_type type,
-        std::size_t begin, std::size_t * end);
-    
-    virtual void bind_by_name(std::string const & name,
-        void * data, details::exchange_type type)
+        std::size_t begin, std::size_t * end) SOCI_OVERRIDE;
+
+    void bind_by_name(std::string const & name,
+        void * data, details::exchange_type type) SOCI_OVERRIDE
     {
         bind_by_name_bulk(name, data, type, 0, &end_var_);
     }
 
-    virtual void bind_by_name_bulk(const std::string & name,
+    void bind_by_name_bulk(const std::string & name,
         void * data, details::exchange_type type,
-        std::size_t begin, std::size_t * end);
-    
-    virtual void pre_use(indicator const * ind);
+        std::size_t begin, std::size_t * end) SOCI_OVERRIDE;
 
-    virtual std::size_t size(); // active size (might be lower than full vector size)
+    void pre_use(indicator const * ind) SOCI_OVERRIDE;
+
+    std::size_t size() SOCI_OVERRIDE; // active size (might be lower than full vector size)
     std::size_t full_size();    // actual size of the user-provided vector
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     postgresql_statement_backend & statement_;
 
@@ -258,30 +258,30 @@ struct postgresql_statement_backend : details::statement_backend
 {
     postgresql_statement_backend(postgresql_session_backend & session,
         bool single_row_mode);
-    ~postgresql_statement_backend();
+    ~postgresql_statement_backend() SOCI_OVERRIDE;
 
-    virtual void alloc();
-    virtual void clean_up();
-    virtual void prepare(std::string const & query,
-        details::statement_type stType);
+    void alloc() SOCI_OVERRIDE;
+    void clean_up() SOCI_OVERRIDE;
+    void prepare(std::string const & query,
+        details::statement_type stType) SOCI_OVERRIDE;
 
-    virtual exec_fetch_result execute(int number);
-    virtual exec_fetch_result fetch(int number);
+    exec_fetch_result execute(int number) SOCI_OVERRIDE;
+    exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    virtual long long get_affected_rows();
-    virtual int get_number_of_rows();
-    virtual std::string get_parameter_name(int index) const;
+    long long get_affected_rows() SOCI_OVERRIDE;
+    int get_number_of_rows() SOCI_OVERRIDE;
+    std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
-    virtual std::string rewrite_for_procedure_call(std::string const & query);
+    std::string rewrite_for_procedure_call(std::string const & query) SOCI_OVERRIDE;
 
-    virtual int prepare_for_describe();
-    virtual void describe_column(int colNum, data_type & dtype,
-        std::string & columnName);
+    int prepare_for_describe() SOCI_OVERRIDE;
+    void describe_column(int colNum, data_type & dtype,
+        std::string & columnName) SOCI_OVERRIDE;
 
-    virtual postgresql_standard_into_type_backend * make_into_type_backend();
-    virtual postgresql_standard_use_type_backend * make_use_type_backend();
-    virtual postgresql_vector_into_type_backend * make_vector_into_type_backend();
-    virtual postgresql_vector_use_type_backend * make_vector_use_type_backend();
+    postgresql_standard_into_type_backend * make_into_type_backend() SOCI_OVERRIDE;
+    postgresql_standard_use_type_backend * make_use_type_backend() SOCI_OVERRIDE;
+    postgresql_vector_into_type_backend * make_vector_into_type_backend() SOCI_OVERRIDE;
+    postgresql_vector_use_type_backend * make_vector_use_type_backend() SOCI_OVERRIDE;
 
     postgresql_session_backend & session_;
 
@@ -321,7 +321,7 @@ struct postgresql_rowid_backend : details::rowid_backend
 {
     postgresql_rowid_backend(postgresql_session_backend & session);
 
-    ~postgresql_rowid_backend();
+    ~postgresql_rowid_backend() SOCI_OVERRIDE;
 
     unsigned long value_;
 };
@@ -330,31 +330,31 @@ struct postgresql_blob_backend : details::blob_backend
 {
     postgresql_blob_backend(postgresql_session_backend & session);
 
-    ~postgresql_blob_backend();
+    ~postgresql_blob_backend() SOCI_OVERRIDE;
 
-    virtual std::size_t get_len();
-    
-    virtual std::size_t read(std::size_t offset, char * buf,
-        std::size_t toRead);
-    
-    virtual std::size_t read_from_start(char * buf, std::size_t toRead,
-        std::size_t offset)
+    std::size_t get_len() SOCI_OVERRIDE;
+
+    std::size_t read(std::size_t offset, char * buf,
+        std::size_t toRead) SOCI_OVERRIDE;
+
+    std::size_t read_from_start(char * buf, std::size_t toRead,
+        std::size_t offset) SOCI_OVERRIDE
     {
         return read(offset, buf, toRead);
     }
-    
-    virtual std::size_t write(std::size_t offset, char const * buf,
-        std::size_t toWrite);
-    
-    virtual std::size_t write_from_start(const char * buf, std::size_t toWrite,
-        std::size_t offset)
+
+    std::size_t write(std::size_t offset, char const * buf,
+        std::size_t toWrite) SOCI_OVERRIDE;
+
+    std::size_t write_from_start(const char * buf, std::size_t toWrite,
+        std::size_t offset) SOCI_OVERRIDE
     {
         return write(offset, buf, toWrite);
     }
-    
-    virtual std::size_t append(char const * buf, std::size_t toWrite);
-    
-    virtual void trim(std::size_t newLen);
+
+    std::size_t append(char const * buf, std::size_t toWrite) SOCI_OVERRIDE;
+
+    void trim(std::size_t newLen) SOCI_OVERRIDE;
 
     postgresql_session_backend & session_;
 
@@ -367,28 +367,28 @@ struct postgresql_session_backend : details::session_backend
     postgresql_session_backend(connection_parameters const & parameters,
         bool single_row_mode);
 
-    ~postgresql_session_backend();
+    ~postgresql_session_backend() SOCI_OVERRIDE;
 
     void connect(connection_parameters const & parameters);
-    
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+
+    void begin() SOCI_OVERRIDE;
+    void commit() SOCI_OVERRIDE;
+    void rollback() SOCI_OVERRIDE;
 
     void deallocate_prepared_statement(const std::string & statementName);
 
-    virtual bool get_next_sequence_value(session & s,
-        std::string const & sequence, long & value);
+    bool get_next_sequence_value(session & s,
+        std::string const & sequence, long & value) SOCI_OVERRIDE;
 
-    virtual std::string get_dummy_from_table() const { return std::string(); }
+    std::string get_dummy_from_table() const SOCI_OVERRIDE { return std::string(); }
 
-    virtual std::string get_backend_name() const { return "postgresql"; }
+    std::string get_backend_name() const SOCI_OVERRIDE { return "postgresql"; }
 
     void clean_up();
 
-    virtual postgresql_statement_backend * make_statement_backend();
-    virtual postgresql_rowid_backend * make_rowid_backend();
-    virtual postgresql_blob_backend * make_blob_backend();
+    postgresql_statement_backend * make_statement_backend() SOCI_OVERRIDE;
+    postgresql_rowid_backend * make_rowid_backend() SOCI_OVERRIDE;
+    postgresql_blob_backend * make_blob_backend() SOCI_OVERRIDE;
 
     std::string get_next_statement_name();
 
@@ -401,8 +401,8 @@ struct postgresql_session_backend : details::session_backend
 struct postgresql_backend_factory : backend_factory
 {
     postgresql_backend_factory() {}
-    virtual postgresql_session_backend * make_session(
-        connection_parameters const & parameters) const;
+    postgresql_session_backend * make_session(
+        connection_parameters const & parameters) const SOCI_OVERRIDE;
 };
 
 extern SOCI_POSTGRESQL_DECL postgresql_backend_factory const postgresql;

--- a/include/soci/query_transformation.h
+++ b/include/soci/query_transformation.h
@@ -43,7 +43,7 @@ public:
         : callback_(callback)
     {}
 
-    result_type operator()(argument_type query) const
+    result_type operator()(argument_type query) const SOCI_OVERRIDE
     {
         return callback_(query);
     }

--- a/include/soci/ref-counted-prepare-info.h
+++ b/include/soci/ref-counted-prepare-info.h
@@ -47,7 +47,7 @@ public:
     void exchange(into_container<T, Indicator> const &ic)
     { intos_.exchange(ic); }
 
-    void final_action();
+    void final_action() SOCI_OVERRIDE;
 
 private:
     friend class statement_impl;

--- a/include/soci/ref-counted-statement.h
+++ b/include/soci/ref-counted-statement.h
@@ -41,7 +41,7 @@ public:
                 {
                     accumulate(tail_);
                 }
-                
+
                 final_action();
             }
             catch (...)
@@ -86,7 +86,7 @@ public:
     ref_counted_statement(session & s)
         : ref_counted_statement_base(s), st_(s) {}
 
-    virtual void final_action();
+    void final_action() SOCI_OVERRIDE;
 
     template <typename T>
     void exchange(T &t) { st_.exchange(t); }

--- a/include/soci/row-exchange.h
+++ b/include/soci/row-exchange.h
@@ -33,7 +33,7 @@ public:
 
 private:
     // special handling for Row
-    virtual void define(statement_impl & st, int & /* position */)
+    void define(statement_impl & st, int & /* position */) SOCI_OVERRIDE
     {
         st.set_row(&r_);
 
@@ -41,9 +41,9 @@ private:
         // as part of the statement execute
     }
 
-    virtual void pre_exec(int /* num */) {}
-    virtual void pre_fetch() {}
-    virtual void post_fetch(bool gotData, bool /* calledFromFetch */)
+    void pre_exec(int /* num */) SOCI_OVERRIDE {}
+    void pre_fetch() SOCI_OVERRIDE {}
+    void post_fetch(bool gotData, bool /* calledFromFetch */) SOCI_OVERRIDE
     {
         r_.reset_get_counter();
 
@@ -56,9 +56,9 @@ private:
         }
     }
 
-    virtual void clean_up() {}
+    void clean_up() SOCI_OVERRIDE {}
 
-    virtual std::size_t size() const { return 1; }
+    std::size_t size() const SOCI_OVERRIDE { return 1; }
 
     virtual void convert_from_base() {}
 

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -49,7 +49,7 @@ enum exchange_type
     x_statement,
     x_rowid,
     x_blob,
-    
+
     x_xmltype,
     x_longstring
 };
@@ -94,7 +94,7 @@ public:
     {
         throw soci_error("into bulk iterators are not supported with this backend");
     }
-    
+
     virtual void define_by_pos(int& position, void* data, exchange_type type) = 0;
 
     virtual void pre_exec(int /* num */) {}
@@ -226,27 +226,27 @@ public:
     virtual ~blob_backend() {}
 
     virtual std::size_t get_len() = 0;
-    
+
     virtual std::size_t read(std::size_t offset, char* buf,
         std::size_t toRead) = 0;
-    
+
     virtual std::size_t read_from_start(char * /* buf */, std::size_t /* toRead */,
         std::size_t /* offset */)
     {
         throw soci_error("read_from_start is not implemented for this backend");
     }
-    
+
     virtual std::size_t write(std::size_t offset, char const* buf,
         std::size_t toWrite) = 0;
-    
+
     virtual std::size_t write_from_start(const char * /* buf */, std::size_t /* toWrite */,
         std::size_t /* offset */)
     {
         throw soci_error("write_from_start is not implemented for this backend");
     }
-    
+
     virtual std::size_t append(char const* buf, std::size_t toWrite) = 0;
-    
+
     virtual void trim(std::size_t newLen) = 0;
 
 private:
@@ -292,7 +292,7 @@ public:
             " from information_schema.tables"
             " where table_schema = 'public'";
     }
-    
+
     // Returns a query with a single parameter (table name) for the list
     // of columns and their properties.
     virtual std::string get_column_descriptions_query() const
@@ -306,7 +306,7 @@ public:
             " from information_schema.columns"
             " where table_schema = 'public' and table_name = :t";
     }
-    
+
     virtual std::string create_table(const std::string & tableName)
     {
         return "create table " + tableName + " (";
@@ -323,14 +323,14 @@ public:
         int precision, int scale)
     {
         // PostgreSQL was selected as a baseline for the syntax:
-        
+
         std::string res;
         switch (dt)
         {
         case dt_string:
             {
                 std::ostringstream oss;
-                
+
                 if (precision == 0)
                 {
                     oss << "text";
@@ -339,11 +339,11 @@ public:
                 {
                     oss << "varchar(" << precision << ")";
                 }
-                
+
                 res += oss.str();
             }
             break;
-            
+
         case dt_date:
             res += "timestamp";
             break;
@@ -359,7 +359,7 @@ public:
                 {
                     oss << "numeric(" << precision << ", " << scale << ")";
                 }
-                
+
                 res += oss.str();
             }
             break;
@@ -371,7 +371,7 @@ public:
         case dt_long_long:
             res += "bigint";
             break;
-            
+
         case dt_unsigned_long_long:
             res += "bigint";
             break;

--- a/include/soci/soci-platform.h
+++ b/include/soci/soci-platform.h
@@ -95,6 +95,12 @@ namespace std {
 // mode, we just need to check for the minimal compiler version supporting them
 // (see https://msdn.microsoft.com/en-us/library/hh567368.aspx).
 
+#if defined(SOCI_HAVE_CXX_C11) || (defined(_MSC_VER) && _MSC_VER >= 1800)
+# define SOCI_OVERRIDE override
+#else
+# define SOCI_OVERRIDE
+#endif
+
 namespace soci
 {
 

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -75,14 +75,14 @@ struct sqlite3_standard_into_type_backend : details::standard_into_type_backend
     {
     }
 
-    virtual void define_by_pos(int &position,
-                             void *data, details::exchange_type type);
+    void define_by_pos(int &position,
+                             void *data, details::exchange_type type) SOCI_OVERRIDE;
 
-    virtual void pre_fetch();
-    virtual void post_fetch(bool gotData, bool calledFromFetch,
-                           indicator *ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, bool calledFromFetch,
+                           indicator *ind) SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     sqlite3_statement_backend &statement_;
 
@@ -98,15 +98,15 @@ struct sqlite3_vector_into_type_backend : details::vector_into_type_backend
     {
     }
 
-    void define_by_pos(int& position, void* data, details::exchange_type type);
+    void define_by_pos(int& position, void* data, details::exchange_type type) SOCI_OVERRIDE;
 
-    void pre_fetch();
-    void post_fetch(bool gotData, indicator* ind);
+    void pre_fetch() SOCI_OVERRIDE;
+    void post_fetch(bool gotData, indicator* ind) SOCI_OVERRIDE;
 
-    void resize(std::size_t sz);
-    std::size_t size();
+    void resize(std::size_t sz) SOCI_OVERRIDE;
+    std::size_t size() SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     sqlite3_statement_backend& statement_;
 
@@ -119,15 +119,15 @@ struct sqlite3_standard_use_type_backend : details::standard_use_type_backend
 {
     sqlite3_standard_use_type_backend(sqlite3_statement_backend &st);
 
-    virtual void bind_by_pos(int &position,
-        void *data, details::exchange_type type, bool readOnly);
-    virtual void bind_by_name(std::string const &name,
-        void *data, details::exchange_type type, bool readOnly);
+    void bind_by_pos(int &position,
+        void *data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
+    void bind_by_name(std::string const &name,
+        void *data, details::exchange_type type, bool readOnly) SOCI_OVERRIDE;
 
-    virtual void pre_use(indicator const *ind);
-    virtual void post_use(bool gotData, indicator *ind);
+    void pre_use(indicator const *ind) SOCI_OVERRIDE;
+    void post_use(bool gotData, indicator *ind) SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     sqlite3_statement_backend &statement_;
 
@@ -144,16 +144,16 @@ struct sqlite3_vector_use_type_backend : details::vector_use_type_backend
     {
     }
 
-    virtual void bind_by_pos(int &position,
-                           void *data, details::exchange_type type);
-    virtual void bind_by_name(std::string const &name,
-                            void *data, details::exchange_type type);
+    void bind_by_pos(int &position,
+                           void *data, details::exchange_type type) SOCI_OVERRIDE;
+    void bind_by_name(std::string const &name,
+                            void *data, details::exchange_type type) SOCI_OVERRIDE;
 
-    virtual void pre_use(indicator const *ind);
+    void pre_use(indicator const *ind) SOCI_OVERRIDE;
 
-    virtual std::size_t size();
+    std::size_t size() SOCI_OVERRIDE;
 
-    virtual void clean_up();
+    void clean_up() SOCI_OVERRIDE;
 
     sqlite3_statement_backend &statement_;
 
@@ -203,30 +203,30 @@ struct sqlite3_statement_backend : details::statement_backend
 {
     sqlite3_statement_backend(sqlite3_session_backend &session);
 
-    virtual void alloc();
-    virtual void clean_up();
-    virtual void prepare(std::string const &query,
-        details::statement_type eType);
+    void alloc() SOCI_OVERRIDE;
+    void clean_up() SOCI_OVERRIDE;
+    void prepare(std::string const &query,
+        details::statement_type eType) SOCI_OVERRIDE;
     void reset_if_needed();
     void reset();
 
-    virtual exec_fetch_result execute(int number);
-    virtual exec_fetch_result fetch(int number);
+    exec_fetch_result execute(int number) SOCI_OVERRIDE;
+    exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    virtual long long get_affected_rows();
-    virtual int get_number_of_rows();
-    virtual std::string get_parameter_name(int index) const;
+    long long get_affected_rows() SOCI_OVERRIDE;
+    int get_number_of_rows() SOCI_OVERRIDE;
+    std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
-    virtual std::string rewrite_for_procedure_call(std::string const &query);
+    std::string rewrite_for_procedure_call(std::string const &query) SOCI_OVERRIDE;
 
-    virtual int prepare_for_describe();
-    virtual void describe_column(int colNum, data_type &dtype,
-                                std::string &columnName);
+    int prepare_for_describe() SOCI_OVERRIDE;
+    void describe_column(int colNum, data_type &dtype,
+                                std::string &columnName) SOCI_OVERRIDE;
 
-    virtual sqlite3_standard_into_type_backend * make_into_type_backend();
-    virtual sqlite3_standard_use_type_backend * make_use_type_backend();
-    virtual sqlite3_vector_into_type_backend * make_vector_into_type_backend();
-    virtual sqlite3_vector_use_type_backend * make_vector_use_type_backend();
+    sqlite3_standard_into_type_backend * make_into_type_backend() SOCI_OVERRIDE;
+    sqlite3_standard_use_type_backend * make_use_type_backend() SOCI_OVERRIDE;
+    sqlite3_vector_into_type_backend * make_vector_into_type_backend() SOCI_OVERRIDE;
+    sqlite3_vector_use_type_backend * make_vector_use_type_backend() SOCI_OVERRIDE;
 
     sqlite3_session_backend &session_;
     sqlite_api::sqlite3_stmt *stmt_;
@@ -250,7 +250,7 @@ struct sqlite3_rowid_backend : details::rowid_backend
 {
     sqlite3_rowid_backend(sqlite3_session_backend &session);
 
-    ~sqlite3_rowid_backend();
+    ~sqlite3_rowid_backend() SOCI_OVERRIDE;
 
     unsigned long value_;
 };
@@ -259,15 +259,15 @@ struct sqlite3_blob_backend : details::blob_backend
 {
     sqlite3_blob_backend(sqlite3_session_backend &session);
 
-    ~sqlite3_blob_backend();
+    ~sqlite3_blob_backend() SOCI_OVERRIDE;
 
-    virtual std::size_t get_len();
-    virtual std::size_t read(std::size_t offset, char *buf,
-                             std::size_t toRead);
-    virtual std::size_t write(std::size_t offset, char const *buf,
-                              std::size_t toWrite);
-    virtual std::size_t append(char const *buf, std::size_t toWrite);
-    virtual void trim(std::size_t newLen);
+    std::size_t get_len() SOCI_OVERRIDE;
+    std::size_t read(std::size_t offset, char *buf,
+                             std::size_t toRead) SOCI_OVERRIDE;
+    std::size_t write(std::size_t offset, char const *buf,
+                              std::size_t toWrite) SOCI_OVERRIDE;
+    std::size_t append(char const *buf, std::size_t toWrite) SOCI_OVERRIDE;
+    void trim(std::size_t newLen) SOCI_OVERRIDE;
 
     sqlite3_session_backend &session_;
 
@@ -283,35 +283,35 @@ struct sqlite3_session_backend : details::session_backend
 {
     sqlite3_session_backend(connection_parameters const & parameters);
 
-    ~sqlite3_session_backend();
+    ~sqlite3_session_backend() SOCI_OVERRIDE;
 
-    virtual void begin();
-    virtual void commit();
-    virtual void rollback();
+    void begin() SOCI_OVERRIDE;
+    void commit() SOCI_OVERRIDE;
+    void rollback() SOCI_OVERRIDE;
 
-    virtual bool get_last_insert_id(session&, std::string const&, long&);
+    bool get_last_insert_id(session&, std::string const&, long&) SOCI_OVERRIDE;
 
-    virtual std::string empty_blob()
+    std::string empty_blob() SOCI_OVERRIDE
     {
         return "x\'\'";
     }
-    
-    virtual std::string get_dummy_from_table() const { return std::string(); }
 
-    virtual std::string get_backend_name() const { return "sqlite3"; }
+    std::string get_dummy_from_table() const SOCI_OVERRIDE { return std::string(); }
+
+    std::string get_backend_name() const SOCI_OVERRIDE { return "sqlite3"; }
 
     void clean_up();
 
-    virtual sqlite3_statement_backend * make_statement_backend();
-    virtual sqlite3_rowid_backend * make_rowid_backend();
-    virtual sqlite3_blob_backend * make_blob_backend();
-    virtual std::string get_table_names_query() const
+    sqlite3_statement_backend * make_statement_backend() SOCI_OVERRIDE;
+    sqlite3_rowid_backend * make_rowid_backend() SOCI_OVERRIDE;
+    sqlite3_blob_backend * make_blob_backend() SOCI_OVERRIDE;
+    std::string get_table_names_query() const SOCI_OVERRIDE
     {
         return "select name as \"TABLE_NAME\""
                 " from sqlite_master where type = 'table'";
     }
-    virtual std::string create_column_type(data_type dt,
-                                           int , int )
+    std::string create_column_type(data_type dt,
+                                           int , int ) SOCI_OVERRIDE
     {
         switch (dt)
         {
@@ -338,8 +338,8 @@ struct sqlite3_session_backend : details::session_backend
 struct sqlite3_backend_factory : backend_factory
 {
     sqlite3_backend_factory() {}
-    virtual sqlite3_session_backend * make_session(
-        connection_parameters const & parameters) const;
+    sqlite3_session_backend * make_session(
+        connection_parameters const & parameters) const SOCI_OVERRIDE;
 };
 
 extern SOCI_SQLITE3_DECL sqlite3_backend_factory const sqlite3;

--- a/include/soci/type-conversion.h
+++ b/include/soci/type-conversion.h
@@ -62,7 +62,7 @@ public:
 
 
 private:
-    void convert_from_base()
+    void convert_from_base() SOCI_OVERRIDE
     {
         type_conversion<T>::from_base(
             base_value_holder<T>::val_, ind_, value_);
@@ -130,7 +130,7 @@ public:
         //convert_to_base();
     }
 
-    void convert_from_base()
+    void convert_from_base() SOCI_OVERRIDE
     {
         // NOTE:
         // readOnly_ flag indicates that use_type object has been generated
@@ -145,7 +145,7 @@ public:
         }
     }
 
-    void convert_to_base()
+    void convert_to_base() SOCI_OVERRIDE
     {
         type_conversion<T>::to_base(value_,
             base_value_holder<T>::val_, ind_);
@@ -214,18 +214,18 @@ public:
         user_ranges_ = end != NULL;
     }
 
-    virtual std::size_t size() const
+    std::size_t size() const SOCI_OVERRIDE
     {
         // the user might have resized his vector in the meantime
         // -> synchronize the base-value mirror to have the same size
 
         std::size_t const userSize = value_.size();
         base_vector_holder<T>::vec_.resize(userSize);
-        
+
         return into_type<base_type>::size();
     }
 
-    virtual void resize(std::size_t sz)
+    void resize(std::size_t sz) SOCI_OVERRIDE
     {
         into_type<base_type>::resize(sz);
 
@@ -235,7 +235,7 @@ public:
     }
 
 private:
-    void convert_from_base()
+    void convert_from_base() SOCI_OVERRIDE
     {
         if (user_ranges_)
         {
@@ -351,7 +351,7 @@ private:
         std::size_t const sz = base_vector_holder<T>::vec_.size();
         value_.resize(sz);
         ind_.resize(sz);
-        
+
         if (user_ranges_)
         {
             for (std::size_t i = begin_; i != *end_; ++i)
@@ -370,12 +370,12 @@ private:
         }
     }
 
-    void convert_to_base()
+    void convert_to_base() SOCI_OVERRIDE
     {
         std::size_t const sz = value_.size();
         base_vector_holder<T>::vec_.resize(sz);
         ind_.resize(sz);
-        
+
         if (user_ranges_)
         {
             for (std::size_t i = begin_; i != *end_; ++i)

--- a/include/soci/type-holder.h
+++ b/include/soci/type-holder.h
@@ -7,6 +7,8 @@
 
 #ifndef SOCI_TYPE_HOLDER_H_INCLUDED
 #define SOCI_TYPE_HOLDER_H_INCLUDED
+
+#include "soci/soci-platform.h"
 // std
 #include <typeinfo>
 
@@ -52,7 +54,7 @@ class type_holder : public holder
 {
 public:
     type_holder(T * t) : t_(t) {}
-    ~type_holder() { delete t_; }
+    ~type_holder() SOCI_OVERRIDE { delete t_; }
 
     template<typename TypeValue>
     TypeValue value() const { return *t_; }

--- a/include/soci/use-type.h
+++ b/include/soci/use-type.h
@@ -73,10 +73,10 @@ public:
         //convert_to_base();
     }
 
-    virtual ~standard_use_type();
-    virtual void bind(statement_impl & st, int & position);
-    virtual std::string get_name() const { return name_; }
-    virtual void dump_value(std::ostream& os) const;
+    ~standard_use_type() SOCI_OVERRIDE;
+    void bind(statement_impl & st, int & position) SOCI_OVERRIDE;
+    std::string get_name() const SOCI_OVERRIDE { return name_; }
+    void dump_value(std::ostream& os) const SOCI_OVERRIDE;
     virtual void * get_data() { return data_; }
 
     // conversion hook (from arbitrary user type to base type)
@@ -84,13 +84,13 @@ public:
     virtual void convert_from_base() {}
 
 protected:
-    virtual void pre_use();
+    void pre_use() SOCI_OVERRIDE;
 
 private:
-    virtual void pre_exec(int num);
-    virtual void post_use(bool gotData);
-    virtual void clean_up();
-    virtual std::size_t size() const { return 1; }
+    void pre_exec(int num) SOCI_OVERRIDE;
+    void post_use(bool gotData) SOCI_OVERRIDE;
+    void clean_up() SOCI_OVERRIDE;
+    std::size_t size() const SOCI_OVERRIDE { return 1; }
 
     void* data_;
     exchange_type type_;
@@ -152,17 +152,17 @@ public:
         , backEnd_(NULL)
     {}
 
-    ~vector_use_type();
+    ~vector_use_type() SOCI_OVERRIDE;
 
 private:
-    virtual void bind(statement_impl& st, int & position);
-    virtual std::string get_name() const { return name_; }
-    virtual void dump_value(std::ostream& os) const;
-    virtual void pre_exec(int num);
-    virtual void pre_use();
-    virtual void post_use(bool) { /* nothing to do */ }
-    virtual void clean_up();
-    virtual std::size_t size() const;
+    void bind(statement_impl& st, int & position) SOCI_OVERRIDE;
+    std::string get_name() const SOCI_OVERRIDE { return name_; }
+    void dump_value(std::ostream& os) const SOCI_OVERRIDE;
+    void pre_exec(int num) SOCI_OVERRIDE;
+    void pre_use() SOCI_OVERRIDE;
+    void post_use(bool) SOCI_OVERRIDE { /* nothing to do */ }
+    void clean_up() SOCI_OVERRIDE;
+    std::size_t size() const SOCI_OVERRIDE;
 
     void* data_;
     exchange_type type_;

--- a/include/soci/values-exchange.h
+++ b/include/soci/values-exchange.h
@@ -46,7 +46,7 @@ public:
         : v_(v)
     {}
 
-    virtual void bind(details::statement_impl & st, int & /*position*/)
+    void bind(details::statement_impl & st, int & /*position*/) SOCI_OVERRIDE
     {
         v_.uppercase_column_names(st.session_.get_uppercase_column_names());
 
@@ -54,7 +54,7 @@ public:
         st.bind(v_);
     }
 
-    virtual std::string get_name() const
+    std::string get_name() const SOCI_OVERRIDE
     {
         std::ostringstream oss;
 
@@ -74,23 +74,23 @@ public:
         return oss.str();
     }
 
-    virtual void dump_value(std::ostream& os) const
+    void dump_value(std::ostream& os) const SOCI_OVERRIDE
     {
         // TODO: Dump all columns.
         os << "<value>";
     }
 
-    virtual void pre_exec(int /* num */) {}
+    void pre_exec(int /* num */) SOCI_OVERRIDE {}
 
-    virtual void post_use(bool /*gotData*/)
+    void post_use(bool /*gotData*/) SOCI_OVERRIDE
     {
         v_.reset_get_counter();
         convert_from_base();
     }
 
-    virtual void pre_use() {convert_to_base();}
-    virtual void clean_up() {v_.clean_up();}
-    virtual std::size_t size() const { return 1; }
+    void pre_use() SOCI_OVERRIDE {convert_to_base();}
+    void clean_up() SOCI_OVERRIDE {v_.clean_up();}
+    std::size_t size() const SOCI_OVERRIDE { return 1; }
 
     // these are used only to re-dispatch to derived class
     // (the derived class might be generated automatically by
@@ -124,7 +124,7 @@ public:
         : into_type<row>(v.get_row(), ind), v_(v)
     {}
 
-    void clean_up()
+    void clean_up() SOCI_OVERRIDE
     {
         v_.clean_up();
     }

--- a/tests/db2/test-db2.cpp
+++ b/tests/db2/test-db2.cpp
@@ -68,35 +68,35 @@ public:
     test_context(backend_factory const & pi_back_end, std::string const & pi_connect_string)
         : test_context_base(pi_back_end, pi_connect_string) {}
 
-    table_creator_base* table_creator_1(soci::session & pr_s) const
+    table_creator_base* table_creator_1(soci::session & pr_s) const SOCI_OVERRIDE
     {
         pr_s << "SET CURRENT SCHEMA = 'DB2INST1'";
         return new table_creator_one(pr_s);
     }
 
-    table_creator_base* table_creator_2(soci::session & pr_s) const
+    table_creator_base* table_creator_2(soci::session & pr_s) const SOCI_OVERRIDE
     {
         pr_s << "SET CURRENT SCHEMA = 'DB2INST1'";
         return new table_creator_two(pr_s);
     }
 
-    table_creator_base* table_creator_3(soci::session & pr_s) const
+    table_creator_base* table_creator_3(soci::session & pr_s) const SOCI_OVERRIDE
     {
         pr_s << "SET CURRENT SCHEMA = 'DB2INST1'";
         return new table_creator_three(pr_s);
     }
 
-    table_creator_base* table_creator_4(soci::session& s) const
+    table_creator_base* table_creator_4(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_get_affected_rows(s);
     }
 
-    std::string to_date_time(std::string const & pi_datdt_string) const
+    std::string to_date_time(std::string const & pi_datdt_string) const SOCI_OVERRIDE
     {
         return "to_date('" + pi_datdt_string + "', 'YYYY-MM-DD HH24:MI:SS')";
     }
 
-    virtual std::string sql_length(std::string const& s) const
+    std::string sql_length(std::string const& s) const SOCI_OVERRIDE
     {
         return "length(" + s + ")";
     }

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -618,8 +618,8 @@ TEST_CASE("Firebird blobs", "[firebird][blob]")
 
     {
         //create large blob
-        const int blobSize = 65536; //max segment size is 65535(unsigned short) 
-        std::vector<char> data(blobSize); 
+        const int blobSize = 65536; //max segment size is 65535(unsigned short)
+        std::vector<char> data(blobSize);
         blob b(sql);
         b.write(0, data.data(), blobSize);
         sql << "insert into test7(id, img) values(3,?)", use(b);
@@ -1304,47 +1304,47 @@ class test_context : public tests::test_context_base
                 : test_context_base(backEnd, connectString)
         {}
 
-        tests::table_creator_base* table_creator_1(soci::session& s) const
+        tests::table_creator_base* table_creator_1(soci::session& s) const SOCI_OVERRIDE
         {
             return new TableCreator1(s);
         }
 
-        tests::table_creator_base* table_creator_2(soci::session& s) const
+        tests::table_creator_base* table_creator_2(soci::session& s) const SOCI_OVERRIDE
         {
             return new TableCreator2(s);
         }
 
-        tests::table_creator_base* table_creator_3(soci::session& s) const
+        tests::table_creator_base* table_creator_3(soci::session& s) const SOCI_OVERRIDE
         {
             return new TableCreator3(s);
         }
 
-        tests::table_creator_base* table_creator_4(soci::session& s) const
+        tests::table_creator_base* table_creator_4(soci::session& s) const SOCI_OVERRIDE
         {
             return new TableCreator4(s);
         }
 
-        tests::table_creator_base* table_creator_clob(soci::session& s) const
+        tests::table_creator_base* table_creator_clob(soci::session& s) const SOCI_OVERRIDE
         {
             return new TableCreatorCLOB(s);
         }
 
-        tests::table_creator_base* table_creator_xml(soci::session& s) const
+        tests::table_creator_base* table_creator_xml(soci::session& s) const SOCI_OVERRIDE
         {
             return new TableCreatorXML(s);
         }
 
-        std::string to_date_time(std::string const &datdt_string) const
+        std::string to_date_time(std::string const &datdt_string) const SOCI_OVERRIDE
         {
             return "'" + datdt_string + "'";
         }
 
-        virtual void on_after_ddl(soci::session& sql) const
+        void on_after_ddl(soci::session& sql) const SOCI_OVERRIDE
         {
             sql.commit();
         }
 
-        virtual std::string sql_length(std::string const& s) const
+        std::string sql_length(std::string const& s) const SOCI_OVERRIDE
         {
             return "char_length(" + s + ")";
         }

--- a/tests/mysql/test-mysql.h
+++ b/tests/mysql/test-mysql.h
@@ -60,39 +60,39 @@ public:
                 std::string const &connectString)
         : test_context_base(backEnd, connectString) {}
 
-    table_creator_base* table_creator_1(soci::session& s) const
+    table_creator_base* table_creator_1(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base* table_creator_2(soci::session& s) const
+    table_creator_base* table_creator_2(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base* table_creator_3(soci::session& s) const
+    table_creator_base* table_creator_3(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base* table_creator_4(soci::session& s) const
+    table_creator_base* table_creator_4(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_get_affected_rows(s);
     }
 
-    std::string to_date_time(std::string const &datdt_string) const
+    std::string to_date_time(std::string const &datdt_string) const SOCI_OVERRIDE
     {
         return "\'" + datdt_string + "\'";
     }
 
-    virtual bool has_fp_bug() const
+    bool has_fp_bug() const SOCI_OVERRIDE
     {
         // MySQL fails in the common test3() with "1.8000000000000000 !=
         // 1.7999999999999998", so don't use exact doubles comparisons for it.
         return true;
     }
 
-    virtual bool has_transactions_support(soci::session& sql) const
+    bool has_transactions_support(soci::session& sql) const SOCI_OVERRIDE
     {
         sql << "drop table if exists soci_test";
         sql << "create table soci_test (id int) engine=InnoDB";
@@ -103,7 +103,7 @@ public:
         return retv;
     }
 
-    virtual bool has_silent_truncate_bug(soci::session& sql) const
+    bool has_silent_truncate_bug(soci::session& sql) const SOCI_OVERRIDE
     {
         std::string sql_mode;
         sql << "select @@session.sql_mode", into(sql_mode);
@@ -113,7 +113,7 @@ public:
         return sql_mode.find("STRICT_") == std::string::npos;
     }
 
-    virtual bool enable_std_char_padding(session& sql) const
+    bool enable_std_char_padding(session& sql) const SOCI_OVERRIDE
     {
         // turn on standard right padding on mysql. This options is supported as of version 5.1.20
         try
@@ -128,7 +128,7 @@ public:
         }
     }
 
-    virtual std::string sql_length(std::string const& s) const
+    std::string sql_length(std::string const& s) const SOCI_OVERRIDE
     {
         return "char_length(" + s + ")";
     }

--- a/tests/odbc/test-odbc-mssql.cpp
+++ b/tests/odbc/test-odbc-mssql.cpp
@@ -145,47 +145,47 @@ public:
                 std::string const &connectString)
         : test_context_base(backEnd, connectString) {}
 
-    table_creator_base* table_creator_1(soci::session& s) const
+    table_creator_base* table_creator_1(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base* table_creator_2(soci::session& s) const
+    table_creator_base* table_creator_2(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base* table_creator_3(soci::session& s) const
+    table_creator_base* table_creator_3(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base * table_creator_4(soci::session& s) const
+    table_creator_base * table_creator_4(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_get_affected_rows(s);
     }
 
-    tests::table_creator_base* table_creator_clob(soci::session& s) const
+    tests::table_creator_base* table_creator_clob(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_clob(s);
     }
 
-    tests::table_creator_base* table_creator_xml(soci::session& s) const
+    tests::table_creator_base* table_creator_xml(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_xml(s);
     }
 
-    bool has_real_xml_support() const
+    bool has_real_xml_support() const SOCI_OVERRIDE
     {
         return true;
     }
 
-    std::string to_date_time(std::string const &datdt_string) const
+    std::string to_date_time(std::string const &datdt_string) const SOCI_OVERRIDE
     {
         return "convert(datetime, \'" + datdt_string + "\', 120)";
     }
 
-    virtual bool has_multiple_select_bug() const
+    bool has_multiple_select_bug() const SOCI_OVERRIDE
     {
         // MS SQL does support MARS (multiple active result sets) since 2005
         // version, but this support needs to be explicitly enabled and is not
@@ -194,7 +194,7 @@ public:
         return true;
     }
 
-    virtual std::string sql_length(std::string const& s) const
+    std::string sql_length(std::string const& s) const SOCI_OVERRIDE
     {
         return "len(" + s + ")";
     }

--- a/tests/odbc/test-odbc-postgresql.cpp
+++ b/tests/odbc/test-odbc-postgresql.cpp
@@ -161,47 +161,47 @@ public:
         std::cout << "Using ODBC driver version " << m_verDriver << "\n";
     }
 
-    table_creator_base * table_creator_1(soci::session& s) const
+    table_creator_base * table_creator_1(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base * table_creator_2(soci::session& s) const
+    table_creator_base * table_creator_2(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base * table_creator_3(soci::session& s) const
+    table_creator_base * table_creator_3(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base * table_creator_4(soci::session& s) const
+    table_creator_base * table_creator_4(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_get_affected_rows(s);
     }
 
-    table_creator_base* table_creator_xml(soci::session& s) const
+    table_creator_base* table_creator_xml(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_xml(s);
     }
 
-    table_creator_base* table_creator_clob(soci::session& s) const
+    table_creator_base* table_creator_clob(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_clob(s);
     }
 
-    bool has_real_xml_support() const
+    bool has_real_xml_support() const SOCI_OVERRIDE
     {
         return true;
     }
 
-    std::string to_date_time(std::string const &datdt_string) const
+    std::string to_date_time(std::string const &datdt_string) const SOCI_OVERRIDE
     {
         return "timestamptz(\'" + datdt_string + "\')";
     }
 
-    virtual bool has_fp_bug() const
+    bool has_fp_bug() const SOCI_OVERRIDE
     {
         // The bug with using insufficiently many digits for double values was
         // only fixed in 9.03.0400 version of the ODBC driver (see commit
@@ -212,7 +212,7 @@ public:
         return !m_verDriver.is_initialized() || m_verDriver < odbc_version(9, 3, 400);
     }
 
-    virtual std::string sql_length(std::string const& s) const
+    std::string sql_length(std::string const& s) const SOCI_OVERRIDE
     {
         return "char_length(" + s + ")";
     }

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -120,7 +120,7 @@ TEST_CASE("Oracle blob", "[oracle][blob]")
 {
     {
         session sql(backEnd, connectString);
-    
+
         blob_table_creator tableCreator(sql);
 
         char buf[] = "abcdefghijklmnopqrstuvwxyz";
@@ -167,7 +167,7 @@ TEST_CASE("Oracle blob", "[oracle][blob]")
     // additional sibling test for read_from_start and write_from_start
     {
         session sql(backEnd, connectString);
-    
+
         blob_table_creator tableCreator(sql);
 
         char buf[] = "abcdefghijklmnopqrstuvwxyz";
@@ -1120,12 +1120,12 @@ TEST_CASE("Oracle DDL with metadata", "[oracle][ddl]")
     std::string ddl_t1 = "DDL_T1";
     std::string ddl_t2 = "DDL_T2";
     std::string ddl_t3 = "DDL_T3";
-    
+
     // single-expression variant:
     sql.create_table(ddl_t1).column("I", soci::dt_integer).column("J", soci::dt_integer);
 
     // check whether this table was created:
-    
+
     bool ddl_t1_found = false;
     bool ddl_t2_found = false;
     bool ddl_t3_found = false;
@@ -1144,7 +1144,7 @@ TEST_CASE("Oracle DDL with metadata", "[oracle][ddl]")
     CHECK(ddl_t3_found == false);
 
     // check whether ddl_t1 has the right structure:
-    
+
     bool i_found = false;
     bool j_found = false;
     bool other_found = false;
@@ -1176,7 +1176,7 @@ TEST_CASE("Oracle DDL with metadata", "[oracle][ddl]")
     CHECK(other_found == false);
 
     // two more tables:
-    
+
     // separately defined columns:
     // (note: statement is executed when ddl object goes out of scope)
     {
@@ -1203,7 +1203,7 @@ TEST_CASE("Oracle DDL with metadata", "[oracle][ddl]")
     }
 
     // check if all tables were created:
-    
+
     ddl_t1_found = false;
     ddl_t2_found = false;
     ddl_t3_found = false;
@@ -1221,7 +1221,7 @@ TEST_CASE("Oracle DDL with metadata", "[oracle][ddl]")
     CHECK(ddl_t3_found);
 
     // check if ddl_t1 has the right structure (it was altered):
-    
+
     i_found = false;
     j_found = false;
     bool k_found = false;
@@ -1260,9 +1260,9 @@ TEST_CASE("Oracle DDL with metadata", "[oracle][ddl]")
     CHECK(k_found);
     CHECK(big_found);
     CHECK(other_found == false);
-    
+
     // check if ddl_t2 has the right structure:
-    
+
     i_found = false;
     j_found = false;
     k_found = false;
@@ -1311,9 +1311,9 @@ TEST_CASE("Oracle DDL with metadata", "[oracle][ddl]")
     sql.drop_table(ddl_t1);
     sql.drop_table(ddl_t3); // note: this must be dropped before ddl_t2
     sql.drop_table(ddl_t2);
-    
+
     // check if all tables were dropped:
-    
+
     ddl_t1_found = false;
     ddl_t2_found = false;
     ddl_t3_found = false;
@@ -1491,59 +1491,59 @@ public:
                 std::string const &connectString)
         : test_context_base(backEnd, connectString) {}
 
-    table_creator_base* table_creator_1(soci::session& s) const
+    table_creator_base* table_creator_1(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base* table_creator_2(soci::session& s) const
+    table_creator_base* table_creator_2(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base* table_creator_3(soci::session& s) const
+    table_creator_base* table_creator_3(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base* table_creator_4(soci::session& s) const
+    table_creator_base* table_creator_4(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_four(s);
     }
 
-    table_creator_base* table_creator_clob(soci::session& s) const
+    table_creator_base* table_creator_clob(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_clob(s);
     }
 
-    table_creator_base* table_creator_xml(soci::session& s) const
+    table_creator_base* table_creator_xml(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_xml(s);
     }
 
-    std::string to_xml(std::string const& x) const
+    std::string to_xml(std::string const& x) const SOCI_OVERRIDE
     {
         return "xmltype(" + x + ")";
     }
 
-    std::string from_xml(std::string const& x) const
+    std::string from_xml(std::string const& x) const SOCI_OVERRIDE
     {
         // Notice that using just x.getCLOBVal() doesn't work, only
         // table.x.getCLOBVal() or (x).getCLOBVal(), as used here, does.
         return "(" + x + ").getCLOBVal()";
     }
 
-    bool has_real_xml_support() const
+    bool has_real_xml_support() const SOCI_OVERRIDE
     {
         return true;
     }
 
-    std::string to_date_time(std::string const &datdt_string) const
+    std::string to_date_time(std::string const &datdt_string) const SOCI_OVERRIDE
     {
         return "to_date('" + datdt_string + "', 'YYYY-MM-DD HH24:MI:SS')";
     }
 
-    virtual std::string sql_length(std::string const& s) const
+    std::string sql_length(std::string const& s) const SOCI_OVERRIDE
     {
         // Oracle treats empty strings as NULLs, but we want to return the
         // length of 0 for them for consistency with the other backends, so use

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -737,12 +737,12 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
     std::string ddl_t1 = "ddl_t1";
     std::string ddl_t2 = "ddl_t2";
     std::string ddl_t3 = "ddl_t3";
-    
+
     // single-expression variant:
     sql.create_table(ddl_t1).column("i", soci::dt_integer).column("j", soci::dt_integer);
 
     // check whether this table was created:
-    
+
     bool ddl_t1_found = false;
     bool ddl_t2_found = false;
     bool ddl_t3_found = false;
@@ -761,7 +761,7 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
     CHECK(ddl_t3_found == false);
 
     // check whether ddl_t1 has the right structure:
-    
+
     bool i_found = false;
     bool j_found = false;
     bool other_found = false;
@@ -793,7 +793,7 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
     CHECK(other_found == false);
 
     // two more tables:
-    
+
     // separately defined columns:
     // (note: statement is executed when ddl object goes out of scope)
     {
@@ -820,7 +820,7 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
     }
 
     // check if all tables were created:
-    
+
     ddl_t1_found = false;
     ddl_t2_found = false;
     ddl_t3_found = false;
@@ -838,7 +838,7 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
     CHECK(ddl_t3_found);
 
     // check if ddl_t1 has the right structure (it was altered):
-    
+
     i_found = false;
     j_found = false;
     bool k_found = false;
@@ -877,9 +877,9 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
     CHECK(k_found);
     CHECK(big_found);
     CHECK(other_found == false);
-    
+
     // check if ddl_t2 has the right structure:
-    
+
     i_found = false;
     j_found = false;
     k_found = false;
@@ -928,9 +928,9 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
     sql.drop_table(ddl_t1);
     sql.drop_table(ddl_t3); // note: this must be dropped before ddl_t2
     sql.drop_table(ddl_t2);
-    
+
     // check if all tables were dropped:
-    
+
     ddl_t1_found = false;
     ddl_t2_found = false;
     ddl_t3_found = false;
@@ -946,7 +946,7 @@ TEST_CASE("PostgreSQL DDL with metadata", "[postgresql][ddl]")
     CHECK(ddl_t1_found == false);
     CHECK(ddl_t2_found == false);
     CHECK(ddl_t3_found == false);
-    
+
     int i = -1;
     sql << "select lo_unlink(" + sql.empty_blob() + ")", into(i);
     CHECK(i == 1);
@@ -1111,52 +1111,52 @@ public:
         : test_context_base(backEnd, connectString)
     {}
 
-    table_creator_base* table_creator_1(soci::session& s) const
+    table_creator_base* table_creator_1(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base* table_creator_2(soci::session& s) const
+    table_creator_base* table_creator_2(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base* table_creator_3(soci::session& s) const
+    table_creator_base* table_creator_3(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base* table_creator_4(soci::session& s) const
+    table_creator_base* table_creator_4(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_get_affected_rows(s);
     }
 
-    table_creator_base* table_creator_xml(soci::session& s) const
+    table_creator_base* table_creator_xml(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_xml(s);
     }
 
-    table_creator_base* table_creator_clob(soci::session& s) const
+    table_creator_base* table_creator_clob(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_clob(s);
     }
 
-    bool has_real_xml_support() const
+    bool has_real_xml_support() const SOCI_OVERRIDE
     {
         return true;
     }
 
-    std::string to_date_time(std::string const &datdt_string) const
+    std::string to_date_time(std::string const &datdt_string) const SOCI_OVERRIDE
     {
         return "timestamptz(\'" + datdt_string + "\')";
     }
 
-    virtual bool has_fp_bug() const
+    bool has_fp_bug() const SOCI_OVERRIDE
     {
         return false;
     }
 
-    virtual std::string sql_length(std::string const& s) const
+    std::string sql_length(std::string const& s) const SOCI_OVERRIDE
     {
         return "char_length(" + s + ")";
     }

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -331,32 +331,32 @@ public:
                 std::string const &connectString)
         : test_context_base(backEnd, connectString) {}
 
-    table_creator_base* table_creator_1(soci::session& s) const
+    table_creator_base* table_creator_1(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_one(s);
     }
 
-    table_creator_base* table_creator_2(soci::session& s) const
+    table_creator_base* table_creator_2(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_two(s);
     }
 
-    table_creator_base* table_creator_3(soci::session& s) const
+    table_creator_base* table_creator_3(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_three(s);
     }
 
-    table_creator_base* table_creator_4(soci::session& s) const
+    table_creator_base* table_creator_4(soci::session& s) const SOCI_OVERRIDE
     {
         return new table_creator_for_get_affected_rows(s);
     }
 
-    std::string to_date_time(std::string const &datdt_string) const
+    std::string to_date_time(std::string const &datdt_string) const SOCI_OVERRIDE
     {
         return "datetime(\'" + datdt_string + "\')";
     }
 
-    virtual bool has_fp_bug() const
+    bool has_fp_bug() const SOCI_OVERRIDE
     {
         /*
             SQLite seems to be buggy when using text conversion, e.g.:
@@ -374,13 +374,13 @@ public:
         return true;
     }
 
-    virtual bool enable_std_char_padding(soci::session&) const
+    bool enable_std_char_padding(soci::session&) const SOCI_OVERRIDE
     {
         // SQLite does not support right padded char type.
         return false;
     }
 
-    virtual std::string sql_length(std::string const& s) const
+    std::string sql_length(std::string const& s) const SOCI_OVERRIDE
     {
         return "length(" + s + ")";
     }


### PR DESCRIPTION
MSVC++ 1900+ always compile with C++11 mode enabled, so it should be safe to selectively enable 'override'specifier for internal use.

It does not enable all C++11 features for SOCI and we still compile  with C++11 compilation mode SOCI_CXX_C11=OFF by default.

---

# Refactoring Procedure with clang-tidy

* Install clang-tidy as new as you can easily get

```
$ clang-tidy-4.0 --version
LLVM (http://llvm.org/):
  LLVM version 4.0.0

  Optimized build.
  Default target: x86_64-pc-linux-gnu
  Host CPU: haswell
```

* Generate compile command database (`compile_commands.json`) with CMake (sweet, isn't it? :-))

```
$ cd soci
$ mkdir build
$ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DSOCI_CXX_C11=ON .. 

# All backends configured!
```

* Run `clang-tidy` with `modernize-use-override` check on all translations units and actually refactor all the code (`-fix`)

```
$ /usr/lib/llvm-4.0/share/clang/run-clang-tidy.py -clang-tidy-binary \
       -header-filter='.*' -checks='-*,modernize-use-modernize' -fix
```

Here we use [run-clang-tidy.py](https://github.com/llvm-mirror/clang-tools-extra/blob/master/clang-tidy/tool/run-clang-tidy.py)
utility script and run  inside the directory with `compile_commands.json` database.
The script is recommended way to run `clang-tidy`, it runs concurrent executions, etc,

* Finally, use your favourite tool to run case-sensitive whole-word search for `override` and replace with `SOCI_OVERRIDE`.

Voilà!