### PR TITLE
[DB2] Add additional install paths to search for DB2 client

### DIFF
--- a/cmake/modules/FindDB2.cmake
+++ b/cmake/modules/FindDB2.cmake
@@ -19,12 +19,14 @@ if(UNIX)
     /opt/ibm/db2/V10.1
     /opt/ibm/db2/V9.7
     /opt/ibm/db2/V9.5
-    /opt/ibm/db2/V9.1)
+    /opt/ibm/db2/V9.1
+    /opt/ibm/clidriver
+    /opt/clidriver)
 
   if(CMAKE_SIZEOF_VOID_P EQUAL 4)
     set(DB2_LIBDIRS "lib32" "lib")
   else()
-    set(DB2_LIBDIRS "lib64")
+    set(DB2_LIBDIRS "lib64" "lib")
   endif()
 
   set(DB2_FIND_INCLUDE_PATHS)


### PR DESCRIPTION
Tested with DB2 client driver unpacked from fairly latest `ibm_data_server_driver_for_odbc_cli_linuxx64_v11.1.tar.gz` available (after zillions of clicks!) from 
[Download initial Version 11.1 clients and drivers](https://www-01.ibm.com/support/docview.wss?uid=swg2138521) page.

The archive unpacks clidriver folder which is often copied over to /opt or /opt/ibm.
For example https://globalengineer.wordpress.com/2017/02/28/configuration-of-db2-cliodbc-driver/

That 64-bit package contains lib, not lib64.