### PR TITLE
fix build on macosx sierra

### DIFF
--- a/tests/mysql/test-mysql.h
+++ b/tests/mysql/test-mysql.h
@@ -113,7 +113,7 @@ public:
         return sql_mode.find("STRICT_") == std::string::npos;
     }
 
-    bool enable_std_char_padding(session& sql) const SOCI_OVERRIDE
+    bool enable_std_char_padding(soci::session& sql) const SOCI_OVERRIDE
     {
         // turn on standard right padding on mysql. This options is supported as of version 5.1.20
         try

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -196,7 +196,7 @@ struct blob_table_creator : public table_creator_base
 TEST_CASE("PostgreSQL blob", "[postgresql][blob]")
 {
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
 
         blob_table_creator tableCreator(sql);
 
@@ -235,7 +235,7 @@ TEST_CASE("PostgreSQL blob", "[postgresql][blob]")
 
     // additional sibling test for read_from_start and write_from_start
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
 
         blob_table_creator tableCreator(sql);
 


### PR DESCRIPTION
use fully qualified `soci::` namespace prefix for occurrences of `soci::session` to avoid ambiguity with `proc.h` on darwin

fix for #605 