### PR TITLE
Drop support for PostgreSQL 7.x

### DIFF
--- a/docs/backends/postgresql.md
+++ b/docs/backends/postgresql.md
@@ -107,16 +107,6 @@ int id = 7;
 sql << "select name from person where id = :id", use(id, "id")
 ```
 
-Apart from the portable "colon-name" syntax above, which is achieved by rewriting the query string, the backend also supports the PostgreSQL native numbered syntax:
-
-```cpp
-int i = 7;
-int j = 8;
-sql << "insert into t(x, y) values($1, $2)", use(i), use(j);
-```
-
-The use of native syntax is not recommended, but can be nevertheless imposed by switching off the query rewriting. This can be achieved by defining the macro `SOCI_POSTGRESQL_NOBINDBYNAME` and it is actually necessary for PostgreSQL 7.3, in which case binding of use elements is not supported at all. See the [Configuration options](#options) section for details.
-
 ### Bulk Operations
 
 The PostgreSQL backend has full support for SOCI's [bulk operations](../binding.md#bulk-operations) interface.
@@ -165,7 +155,4 @@ format of UUID on output. See the test `test_uuid_column_type_support` for usage
 
 To support older PostgreSQL versions, the following configuration macros are recognized:
 
-* `SOCI_POSTGRESQL_NOBINDBYNAME` - switches off the query rewriting.
-* `SOCI_POSTGRESQL_NOPARAMS` - disables support for parameterized queries (binding of use elements), automatically imposes also the `SOCI_POSTGRESQL_NOBINDBYNAME` macro. It is necessary for PostgreSQL 7.3.
-* `SOCI_POSTGRESQL_NOPREPARE` - disables support for separate query preparation, which in this backend is significant only in terms of optimization. It is necessary for PostgreSQL 7.3 and 7.4.
-* `SOCI_POSTGRESQL_NOSINGLEROWMODE` - disable single mode retrieving query results row-by-row. It is necessary for PostgreSQL prior to version 9.
+* `SOCI_POSTGRESQL_NOSINLGEROWMODE` - disable single mode retrieving query results row-by-row. It is necessary for PostgreSQL prior to version 9.

--- a/docs/binding.md
+++ b/docs/binding.md
@@ -83,11 +83,6 @@ string const& name = getNameFromSomewhere();
 sql << "insert into person(name) values(:n)", use(name);
 ```
 
-### Portability note
-
-Older versions of the PostgreSQL client API do not allow to use input parameters at all.
-In order to compile SOCI with those old client libraries, define the `SOCI_POSTGRESQL_NOPARAMS` preprocessor name passing `-DSOCI_POSTGRESQL_NOPARAMS=ON` variable to CMake.
-
 ## Binding by position
 
 If there is more output or input "holes" in the single statement, it is possible to use many `into` and `use` expressions, separated by commas, where each expression will be responsible for the consecutive "hole" in the statement:
@@ -127,17 +122,6 @@ sql << "update person"
         " where id = 7",
         use(addr, "addr");
 ```
-
-### Portability notes
-
-The PostgreSQL backend allows to use the "native" PostgreSQL way of naming parameters in the query, which is by numbers like `$1`, `$2`, `$3`, etc.
-In fact, the backend *rewrites* the given query to the native form - and this is also one of the very few places where SOCI intrudes into the SQL query.
-For portability reasons, it is recommended to use named parameters, as shown in the examples above.
-
-The query rewriting can be switched off by compiling the backend with the `SOCI_POSTGRESQL_NOBINDBYNAME` name defined (pass `-DSOCI_POSTGRESQL_NOBINDBYNAME=ON` variable to CMake).
-Note that in this case it is also necessary to define `SOCI_POSTGRESQL_NOPREPARE` (controlled by CMake variable `-DSOCI_POSTGRESQL_NOPREPARE=ON`), because statement preparation relies on successful query rewriting.
-
-In practice, both macros will be needed for PostgreSQL server older than 8.0.
 
 ## Bulk operations
 

--- a/docs/statements.md
+++ b/docs/statements.md
@@ -47,9 +47,6 @@ The `true` parameter given to the `execute` method indicates that the actual dat
 
 The above syntax is supported for all backends, even if some database server does not actually provide this functionality - in which case the library will internally execute the query in a single phase, without really separating the statement preparation from execution.
 
-For PostgreSQL servers older than 8.0 it is necessary to define the `SOCI_POSTGRESQL_NOPREPARE` macro while compiling the library to fall back to this one-phase behaviour.
-Simply, pass `-DSOCI_POSTGRESQL_NOPREPARE=ON` variable to CMake.
-
 ## Rowset and iterator
 
 The `rowset` class provides an alternative means of executing queries and accessing results using STL-like iterator interface.

--- a/src/backends/postgresql/CMakeLists.txt
+++ b/src/backends/postgresql/CMakeLists.txt
@@ -15,30 +15,6 @@ option(SOCI_POSTGRESQL_NOSINGLEROWMODE
   "Do not use single row mode. PostgreSQL <9 portability."
   OFF)
 
-option(SOCI_POSTGRESQL_NOPARAMS
-  "Do not use input parameters. PostgreSQL 7.x portability."
-  OFF)
-
-option(SOCI_POSTGRESQL_NOBINDBYNAME
-  "Disable query rewriting to native form. PostgreSQL 7.0 portability."
-  OFF)
-
-cmake_dependent_option(SOCI_POSTGRESQL_NOPREPARE
-  "Disable prepared statements. Set ON if SOCI_POSTGRESQL_NOBINDBYNAME is ON. PostgreSQL 7.0 portability." ON
-  SOCI_POSTGRESQL_NOBINDBYNAME OFF)
-
-if(SOCI_POSTGRESQL_NOPARAMS)
-  add_definitions(-DSOCI_POSTGRESQL_NOPARAMS=1)
-endif()
-
-if(SOCI_POSTGRESQL_NOBINDBYNAME)
-  add_definitions(-DSOCI_POSTGRESQL_NOBINDBYNAME=1)
-endif()
-
-if(SOCI_POSTGRESQL_NOPREPARE)
-  add_definitions(-DSOCI_POSTGRESQL_NOPREPARE=1)
-endif()
-
 if (POSTGRESQL_VERSION VERSION_LESS "9.0.0")
   set(SOCI_POSTGRESQL_NOSINGLEROWMODE ON CACHE BOOL "Use single row mode for PostgreSQL 9+" FORCE)
 endif()
@@ -53,7 +29,4 @@ soci_backend(PostgreSQL
   AUTHORS "Maciej Sobczak, Stephen Hutton"
   MAINTAINERS "Mateusz Loskot")
 
-boost_report_value(SOCI_POSTGRESQL_NOPARAMS)
-boost_report_value(SOCI_POSTGRESQL_NOBINDBYNAME)
-boost_report_value(SOCI_POSTGRESQL_NOPREPARE)
-boost_report_value(SOCI_POSTGRESQL_NOSINGLEROWMODE)
+boost_report_value(SOCI_POSTGRESQL_NOSINLGEROWMODE)

--- a/src/backends/postgresql/blob.cpp
+++ b/src/backends/postgresql/blob.cpp
@@ -14,12 +14,6 @@
 #include <ctime>
 #include <sstream>
 
-#ifdef SOCI_POSTGRESQL_NOPARAMS
-#ifndef SOCI_POSTGRESQL_NOBINDBYNAME
-#define SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOPARAMS
-
 #ifdef _MSC_VER
 #pragma warning(disable:4355)
 #endif

--- a/src/backends/postgresql/factory.cpp
+++ b/src/backends/postgresql/factory.cpp
@@ -11,12 +11,6 @@
 #include "soci/backend-loader.h"
 #include <libpq/libpq-fs.h> // libpq
 
-#ifdef SOCI_POSTGRESQL_NOPARAMS
-#ifndef SOCI_POSTGRESQL_NOBINDBYNAME
-#define SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOPARAMS
-
 #ifdef _MSC_VER
 #pragma warning(disable:4355)
 #endif
@@ -80,7 +74,7 @@ std::string chop_connect_string(std::string const & connectString,
     bool & single_row_mode)
 {
     std::string pruned_conn_string;
-    
+
     single_row_mode = false;
 
     std::string key, value;
@@ -119,7 +113,7 @@ postgresql_session_backend * postgresql_backend_factory::make_session(
 
     connection_parameters pruned_parameters(parameters);
     pruned_parameters.set_connect_string(pruned_conn_string);
-    
+
     return new postgresql_session_backend(pruned_parameters, single_row_mode);
 }
 

--- a/src/backends/postgresql/row-id.cpp
+++ b/src/backends/postgresql/row-id.cpp
@@ -14,12 +14,6 @@
 #include <ctime>
 #include <sstream>
 
-#ifdef SOCI_POSTGRESQL_NOPARAMS
-#ifndef SOCI_POSTGRESQL_NOBINDBYNAME
-#define SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOPARAMS
-
 #ifdef _MSC_VER
 #pragma warning(disable:4355)
 #endif

--- a/src/backends/postgresql/session.cpp
+++ b/src/backends/postgresql/session.cpp
@@ -17,12 +17,6 @@
 #include <ctime>
 #include <sstream>
 
-#ifdef SOCI_POSTGRESQL_NOPARAMS
-#ifndef SOCI_POSTGRESQL_NOBINDBYNAME
-#define SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOPARAMS
-
 using namespace soci;
 using namespace soci::details;
 

--- a/src/backends/postgresql/standard-into-type.cpp
+++ b/src/backends/postgresql/standard-into-type.cpp
@@ -23,12 +23,6 @@
 #include <ctime>
 #include <sstream>
 
-#ifdef SOCI_POSTGRESQL_NOPARAMS
-#ifndef SOCI_POSTGRESQL_NOBINDBYNAME
-#define SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOPARAMS
-
 using namespace soci;
 using namespace soci::details;
 using namespace soci::details::postgresql;

--- a/src/backends/postgresql/standard-use-type.cpp
+++ b/src/backends/postgresql/standard-use-type.cpp
@@ -21,12 +21,6 @@
 #include <limits>
 #include <sstream>
 
-#ifdef SOCI_POSTGRESQL_NOPARAMS
-#ifndef SOCI_POSTGRESQL_NOBINDBYNAME
-#define SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOPARAMS
-
 using namespace soci;
 using namespace soci::details;
 
@@ -157,7 +151,7 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
         case x_longstring:
             copy_from_string(exchange_type_cast<x_longstring>(data_).value);
             break;
-            
+
         default:
             throw soci_error("Use element used with non-supported type.");
         }

--- a/src/backends/postgresql/vector-into-type.cpp
+++ b/src/backends/postgresql/vector-into-type.cpp
@@ -19,12 +19,6 @@
 #include <ctime>
 #include <sstream>
 
-#ifdef SOCI_POSTGRESQL_NOPARAMS
-#ifndef SOCI_POSTGRESQL_NOBINDBYNAME
-#define SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOPARAMS
-
 using namespace soci;
 using namespace soci::details;
 using namespace soci::details::postgresql;
@@ -253,7 +247,7 @@ std::size_t postgresql_vector_into_type_backend::size()
         // ... and in that case return the actual size
         return actual_size;
     }
-    
+
     if (end_ != NULL && *end_ != 0)
     {
         return *end_ - begin_;

--- a/src/backends/postgresql/vector-use-type.cpp
+++ b/src/backends/postgresql/vector-use-type.cpp
@@ -19,13 +19,6 @@
 #include <limits>
 #include <sstream>
 
-#ifdef SOCI_POSTGRESQL_NOPARAMS
-#ifndef SOCI_POSTGRESQL_NOBINDBYNAME
-#define SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOBINDBYNAME
-#endif // SOCI_POSTGRESQL_NOPARAMS
-
-
 using namespace soci;
 using namespace soci::details;
 using namespace soci::details::postgresql;
@@ -69,7 +62,7 @@ void postgresql_vector_use_type_backend::pre_use(indicator const * ind)
     {
         vend = end_var_;
     }
-    
+
     for (size_t i = begin_; i != vend; ++i)
     {
         char * buf;
@@ -231,7 +224,7 @@ std::size_t postgresql_vector_use_type_backend::size()
         // ... and in that case return the actual size
         return actual_size;
     }
-    
+
     if (end_ != NULL && *end_ != 0)
     {
         return *end_ - begin_;

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -1293,9 +1293,6 @@ TEST_CASE_METHOD(common_tests, "Indicators vector", "[core][indicator][vector]")
 
 }
 
-// Note: this functionality is not available with older PostgreSQL
-#ifndef SOCI_POSTGRESQL_NOPARAMS
-
 // "use" tests, type conversions, etc.
 TEST_CASE_METHOD(common_tests, "Use type conversion", "[core][use]")
 {
@@ -1519,8 +1516,6 @@ TEST_CASE_METHOD(common_tests, "Use type conversion", "[core][use]")
     }
 }
 
-#endif // SOCI_POSTGRESQL_NOPARAMS
-
 // test for multiple use (and into) elements
 TEST_CASE_METHOD(common_tests, "Multiple use and into", "[core][use][into]")
 {
@@ -1532,17 +1527,8 @@ TEST_CASE_METHOD(common_tests, "Multiple use and into", "[core][use][into]")
         int i2 = 6;
         int i3 = 7;
 
-#ifndef SOCI_POSTGRESQL_NOPARAMS
-
         sql << "insert into soci_test(i1, i2, i3) values(:i1, :i2, :i3)",
             use(i1), use(i2), use(i3);
-
-#else
-        // Older PostgreSQL does not support use elements.
-
-        sql << "insert into soci_test(i1, i2, i3) values(5, 6, 7)";
-
-#endif // SOCI_POSTGRESQL_NOPARAMS
 
         i1 = 0;
         i2 = 0;
@@ -1561,8 +1547,6 @@ TEST_CASE_METHOD(common_tests, "Multiple use and into", "[core][use][into]")
         i2 = 0;
         i3 = 0;
 
-#ifndef SOCI_POSTGRESQL_NOPARAMS
-
         statement st = (sql.prepare
             << "insert into soci_test(i1, i2, i3) values(:i1, :i2, :i3)",
             use(i1), use(i2), use(i3));
@@ -1579,15 +1563,6 @@ TEST_CASE_METHOD(common_tests, "Multiple use and into", "[core][use][into]")
         i2 = 8;
         i3 = 9;
         st.execute(true);
-
-#else
-        // Older PostgreSQL does not support use elements.
-
-        sql << "insert into soci_test(i1, i2, i3) values(1, 2, 3)";
-        sql << "insert into soci_test(i1, i2, i3) values(4, 5, 6)";
-        sql << "insert into soci_test(i1, i2, i3) values(7, 8, 9)";
-
-#endif // SOCI_POSTGRESQL_NOPARAMS
 
         std::vector<int> v1(5);
         std::vector<int> v2(5);
@@ -1610,9 +1585,6 @@ TEST_CASE_METHOD(common_tests, "Multiple use and into", "[core][use][into]")
         CHECK(v3[2] == 9);
     }
 }
-
-// Not supported with older PostgreSQL
-#ifndef SOCI_POSTGRESQL_NOPARAMS
 
 // use vector elements
 TEST_CASE_METHOD(common_tests, "Use vector", "[core][use][vector]")
@@ -1915,7 +1887,6 @@ TEST_CASE_METHOD(common_tests, "Named parameters with similar names", "[core][us
         // }
     }
 }
-#endif // SOCI_POSTGRESQL_NOPARAMS
 
 // transaction test
 TEST_CASE_METHOD(common_tests, "Transactions", "[core][transaction]")
@@ -1988,8 +1959,6 @@ TEST_CASE_METHOD(common_tests, "Transactions", "[core][transaction]")
         }
     }
 }
-
-#ifndef SOCI_POSTGRESQL_NOPARAMS
 
 std::tm  generate_tm()
 {
@@ -2073,8 +2042,6 @@ TEST_CASE_METHOD(common_tests, "Use with indicators", "[core][use][indicator]")
     CHECK(vals[2] == 12);
     CHECK(vals[4] == 10);
 }
-
-#endif // SOCI_POSTGRESQL_NOPARAMS
 
 // Dynamic binding to Row objects
 TEST_CASE_METHOD(common_tests, "Dynamic row binding", "[core][dynamic]")
@@ -2200,7 +2167,6 @@ TEST_CASE_METHOD(common_tests, "Dynamic row binding 2", "[core][dynamic]")
     sql << "insert into soci_test(id, val) values(2, 20)";
     sql << "insert into soci_test(id, val) values(3, 30)";
 
-#ifndef SOCI_POSTGRESQL_NOPARAMS
     {
         int id = 2;
         row r;
@@ -2234,16 +2200,6 @@ TEST_CASE_METHOD(common_tests, "Dynamic row binding 2", "[core][dynamic]")
         CHECK(r.get_properties(0).get_data_type() == dt_integer);
         CHECK(r.get<int>(0) == 10);
     }
-#else
-    {
-        row r;
-        sql << "select val from soci_test where id = 2", into(r);
-
-        CHECK(r.size() == 1);
-        CHECK(r.get_properties(0).get_data_type() == dt_integer);
-        CHECK(r.get<int>(0) == 20);
-    }
-#endif // SOCI_POSTGRESQL_NOPARAMS
 }
 
 // More Dynamic binding to row objects
@@ -2499,8 +2455,6 @@ TEST_CASE_METHOD(common_tests, "Numeric round trip", "[core][float]")
     ASSERT_EQUAL_EXACT(d1, d2);
 }
 
-#ifndef SOCI_POSTGRESQL_NOPARAMS
-
 // test for bulk fetch with single use
 TEST_CASE_METHOD(common_tests, "Bulk fetch with single use", "[core][bulk]")
 {
@@ -2524,8 +2478,6 @@ TEST_CASE_METHOD(common_tests, "Bulk fetch with single use", "[core][bulk]")
     CHECK(names[1] == "john");
     CHECK(names[2] == "julian");
 }
-
-#endif // SOCI_POSTGRESQL_NOPARAMS
 
 // test for basic logging support
 TEST_CASE_METHOD(common_tests, "Basic logging support", "[core][logging]")


### PR DESCRIPTION
Remove uses of CMake opions and related #define-s
  SOCI_POSTGRESQL_NOPREPARE
  SOCI_POSTGRESQL_NOPARAMS
  SOCI_POSTGRESQL_NOBINDBYNAME.

Closes #122