### PR TITLE
Add base_type for each exchange_traits overload

### DIFF
--- a/include/soci/exchange-traits.h
+++ b/include/soci/exchange-traits.h
@@ -31,14 +31,11 @@ struct exchange_traits
     // this is used for tag-dispatch between implementations for basic types
     // and user-defined types
     typedef user_type_tag type_family;
+    typedef typename type_conversion<T>::base_type base_type;
 
     enum // anonymous
     {
-        x_type =
-            exchange_traits
-            <
-                typename type_conversion<T>::base_type
-            >::x_type
+        x_type = exchange_traits<base_type>::x_type
     };
 };
 
@@ -46,6 +43,7 @@ template <>
 struct exchange_traits<short>
 {
     typedef basic_type_tag type_family;
+    typedef short base_type;
     enum { x_type = x_short };
 };
 
@@ -58,6 +56,7 @@ template <>
 struct exchange_traits<int>
 {
     typedef basic_type_tag type_family;
+    typedef int base_type;
     enum { x_type = x_integer };
 };
 
@@ -70,6 +69,7 @@ template <>
 struct exchange_traits<char>
 {
     typedef basic_type_tag type_family;
+    typedef char base_type;
     enum { x_type = x_char };
 };
 
@@ -77,6 +77,7 @@ template <>
 struct exchange_traits<long long>
 {
     typedef basic_type_tag type_family;
+    typedef long long base_type;
     enum { x_type = x_long_long };
 };
 
@@ -84,19 +85,22 @@ template <>
 struct exchange_traits<unsigned long long>
 {
     typedef basic_type_tag type_family;
+    typedef unsigned long long base_type;
     enum { x_type = x_unsigned_long_long };
 };
 
 // long must be mapped either to x_integer or x_long_long:
 template<int long_size> struct long_traits_helper;
-template<> struct long_traits_helper<4> { enum { x_type = x_integer }; };
-template<> struct long_traits_helper<8> { enum { x_type = x_long_long }; };
+template<> struct long_traits_helper<4> { typedef int base_type; };
+template<> struct long_traits_helper<8> { typedef long long base_type; };
 
 template <>
 struct exchange_traits<long int>
 {
     typedef basic_type_tag type_family;
-    enum { x_type = long_traits_helper<sizeof(long int)>::x_type };
+    typedef long_traits_helper<sizeof(long int)>::base_type base_type;
+
+    enum { x_type = exchange_traits<base_type>::x_type };
 };
 
 template <>
@@ -108,6 +112,7 @@ template <>
 struct exchange_traits<double>
 {
     typedef basic_type_tag type_family;
+    typedef double base_type;
     enum { x_type = x_double };
 };
 
@@ -115,6 +120,7 @@ template <>
 struct exchange_traits<std::string>
 {
     typedef basic_type_tag type_family;
+    typedef std::string base_type;
     enum { x_type = x_stdstring };
 };
 
@@ -122,6 +128,7 @@ template <>
 struct exchange_traits<std::tm>
 {
     typedef basic_type_tag type_family;
+    typedef std::tm base_type;
     enum { x_type = x_stdtm };
 };
 
@@ -129,6 +136,7 @@ template <typename T>
 struct exchange_traits<std::vector<T> >
 {
     typedef typename exchange_traits<T>::type_family type_family;
+    typedef std::vector<T> base_type;
     enum { x_type = exchange_traits<T>::x_type };
 };
 

--- a/include/soci/row.h
+++ b/include/soci/row.h
@@ -8,10 +8,12 @@
 #ifndef SOCI_ROW_H_INCLUDED
 #define SOCI_ROW_H_INCLUDED
 
+#include "soci/exchange-traits.h"
 #include "soci/type-holder.h"
 #include "soci/soci-backend.h"
 #include "soci/type-conversion.h"
 // std
+#include <cassert>
 #include <cstddef>
 #include <map>
 #include <string>
@@ -64,7 +66,10 @@ public:
     template <typename T>
     T get(std::size_t pos) const
     {
-        typedef typename type_conversion<T>::base_type base_type;
+        assert(holders_.size() >= pos + 1);
+
+        //typedef typename type_conversion<T>::base_type base_type;
+        typedef typename details::exchange_traits<T>::base_type base_type;
         base_type const& baseVal = holders_.at(pos)->get<base_type>();
 
         T ret;


### PR DESCRIPTION
 * base_type is now used in row::get

-----
Cherry-pick from https://github.com/SOCI/soci/pull/215