### PR TITLE
Better handling of cancelling ODBC connection parameters dialog

### DIFF
--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -46,7 +46,7 @@ odbc_session_backend::odbc_session_backend(
     }
 
     SQLCHAR outConnString[1024];
-    SQLSMALLINT strLength;
+    SQLSMALLINT strLength = 0;
 
     // Prompt the user for any missing information (typically UID/PWD) in the
     // connection string by default but allow overriding this using "prompt"


### PR DESCRIPTION
I've recently noticed that cancelling the dialog shown by ODBC when the username and/or password is not specified resulted in a weird `bad_alloc` being thrown. Turns out we were using an unitialized variable, which can't be a good thing -- clarity of the error message notwithstanding.