### PR TITLE
Deadlock caused by infinite loop in try_lease resolved

### DIFF
--- a/src/core/connection-pool.cpp
+++ b/src/core/connection-pool.cpp
@@ -127,6 +127,12 @@ bool connection_pool::try_lease(std::size_t & pos, int timeout)
         {
             break;
         }
+        // pthread_cond_timedwait can return EINVAL or EPERM
+        if (cc == EINVAL || cc == EPERM)
+        {
+            // Without this break the while loop can result in an infinate loop
+            break;
+        }
     }
 
     if (cc == 0)


### PR DESCRIPTION
If the mutex is locked until the timeout of pthread_cond_timedwait is triggered EINVAL will be returned.
EINVAL was not checked which resulted in infinite loop.