### PR TITLE
Include the parameter number in the errors from post_fetch()

### DIFF
--- a/src/core/statement.cpp
+++ b/src/core/statement.cpp
@@ -592,7 +592,21 @@ void statement_impl::post_fetch(bool gotData, bool calledFromFetch)
     std::size_t const isize = intos_.size();
     for (std::size_t i = 0; i != isize; ++i)
     {
-        intos_[i]->post_fetch(gotData, calledFromFetch);
+        try
+        {
+            intos_[i]->post_fetch(gotData, calledFromFetch);
+        }
+        catch (soci_error& e)
+        {
+            // Provide the parameter number in the error message as the
+            // exceptions thrown by the backend only say what went wrong, but
+            // not where.
+            std::ostringstream oss;
+            oss << "for the parameter number " << i + 1;
+            e.add_context(oss.str());
+
+            throw;
+        }
     }
 }
 

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -708,6 +708,8 @@ TEST_CASE_METHOD(common_tests, "Use and into", "[core][into]")
         {
             CHECK(e.get_error_message() ==
                 "Null value fetched and no indicator defined.");
+            CHECK_THAT(e.what(),
+                Catch::Contains("for the parameter number 1"));
         }
 
         sql << "select id from soci_test where id = 1000", into(i, ind);


### PR DESCRIPTION
This makes errors such as e.g. "Null value fetched and no indicator
defined." much more useful, as the error message now says which
parameter exactly was null.