### PR TITLE
Avoid g++-8 -Wcatch-value warnings in the tests

### DIFF
--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -528,18 +528,18 @@ TEST_CASE_METHOD(common_tests, "Exception on not connected", "[core][exception]"
     soci::session sql; // no connection
 
     // ensure connection is checked, no crash occurs
-    CHECK_THROWS_AS(sql.begin(), soci_error);
-    CHECK_THROWS_AS(sql.commit(), soci_error);
-    CHECK_THROWS_AS(sql.rollback(), soci_error);
-    CHECK_THROWS_AS(sql.get_backend_name(), soci_error);
-    CHECK_THROWS_AS(sql.make_statement_backend(), soci_error);
-    CHECK_THROWS_AS(sql.make_rowid_backend(), soci_error);
-    CHECK_THROWS_AS(sql.make_blob_backend(), soci_error);
+    CHECK_THROWS_AS(sql.begin(), soci_error&);
+    CHECK_THROWS_AS(sql.commit(), soci_error&);
+    CHECK_THROWS_AS(sql.rollback(), soci_error&);
+    CHECK_THROWS_AS(sql.get_backend_name(), soci_error&);
+    CHECK_THROWS_AS(sql.make_statement_backend(), soci_error&);
+    CHECK_THROWS_AS(sql.make_rowid_backend(), soci_error&);
+    CHECK_THROWS_AS(sql.make_blob_backend(), soci_error&);
 
     std::string s;
     long l;
-    CHECK_THROWS_AS(sql.get_next_sequence_value(s, l), soci_error);
-    CHECK_THROWS_AS(sql.get_last_insert_id(s, l), soci_error);
+    CHECK_THROWS_AS(sql.get_next_sequence_value(s, l), soci_error&);
+    CHECK_THROWS_AS(sql.get_last_insert_id(s, l), soci_error&);
 }
 
 TEST_CASE_METHOD(common_tests, "Basic functionality", "[core][basics]")
@@ -548,7 +548,7 @@ TEST_CASE_METHOD(common_tests, "Basic functionality", "[core][basics]")
 
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
 
-    CHECK_THROWS_AS(sql << "drop table soci_test_nosuchtable", soci_error);
+    CHECK_THROWS_AS(sql << "drop table soci_test_nosuchtable", soci_error&);
 
     sql << "insert into soci_test (id) values (" << 123 << ")";
     int id;
@@ -2845,7 +2845,7 @@ TEST_CASE_METHOD(common_tests, "Rowset expected exception", "[core][exception][r
     std::string troublemaker;
     CHECK_THROWS_AS(
         rowset<std::string>((sql.prepare << "select str from soci_test", into(troublemaker))),
-        soci_error
+        soci_error&
         );
 }
 
@@ -2878,7 +2878,7 @@ TEST_CASE_METHOD(common_tests, "NULL expected exception", "[core][exception][nul
 
     rowset<int> rs = (sql.prepare << "select val from soci_test order by val asc");
 
-    CHECK_THROWS_AS( std::for_each(rs.begin(), rs.end(), THelper()), soci_error );
+    CHECK_THROWS_AS( std::for_each(rs.begin(), rs.end(), THelper()), soci_error& );
 }
 
 // This is like the first dynamic binding test but with rowset and iterators use
@@ -4402,7 +4402,7 @@ TEST_CASE_METHOD(common_tests, "XML", "[core][xml]")
             (sql << "insert into soci_test(id, x) values (2, "
                         + tc_.to_xml(":1") + ")",
                     use(xml)
-            ), soci_error
+            ), soci_error&
         );
     }
 }

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -803,10 +803,10 @@ TEST_CASE("Firebird dynamic binding", "[firebird][dynamic]")
     // verify default values
     CHECK(tests::are_doubles_exactly_equal(r.get<double>("NTEST", 2), 2));
 
-    CHECK_THROWS_AS(r.get<double>("NTEST"), soci_error);
+    CHECK_THROWS_AS(r.get<double>("NTEST"), soci_error&);
 
     // verify exception thrown on invalid get<>
-    CHECK_THROWS_AS(r.get<std::string>(0), std::bad_cast);
+    CHECK_THROWS_AS(r.get<std::string>(0), std::bad_cast&);
 
     sql << "drop table test9";
 }

--- a/tests/odbc/test-odbc-mssql.cpp
+++ b/tests/odbc/test-odbc-mssql.cpp
@@ -69,7 +69,7 @@ TEST_CASE("MS SQL long string", "[odbc][mssql][long]")
     // column.
     CHECK_THROWS_AS(
         (sql << "insert into soci_test(fixed_text) values(:str)", use(str_in)),
-        soci_error
+        soci_error&
     );
 }
 

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -626,7 +626,7 @@ TEST_CASE("PostgreSQL JSON", "[postgresql][json]")
 
         CHECK_THROWS_AS((
             sql << "insert into soci_json_test (data) values(:data)",use(invalid_input)),
-            soci_error
+            soci_error&
         );
     }
     else


### PR DESCRIPTION
Catch soci_error (and std::bad_cast in one place) by reference rather
than by value to avoid slicing -- even if it doesn't matter in the test
code, it still provokes the new g++-8 warning about it.

See #640.