### PR TITLE
Fix portable DDL query CREATE TABLE for SQLite3

### DIFF
--- a/include/soci/mysql/soci-mysql.h
+++ b/include/soci/mysql/soci-mysql.h
@@ -253,6 +253,72 @@ struct mysql_session_backend : details::session_backend
     mysql_rowid_backend * make_rowid_backend() SOCI_OVERRIDE;
     mysql_blob_backend * make_blob_backend() SOCI_OVERRIDE;
 
+    std::string create_column_type(data_type dt,
+        int precision, int scale) SOCI_OVERRIDE
+    {
+        std::string res;
+        switch (dt)
+        {
+        case dt_string:
+            {
+                std::ostringstream oss;
+
+                if (precision == 0)
+                {
+                    oss << "text";
+                }
+                else
+                {
+                    oss << "varchar(" << precision << ")";
+                }
+
+                res += oss.str();
+            }
+            break;
+
+        case dt_date:
+            res += "datetime";
+            break;
+
+        case dt_double:
+            {
+                std::ostringstream oss;
+                if (precision == 0)
+                {
+                    oss << "double precision";
+                }
+                else
+                {
+                    oss << "numeric(" << precision << ", " << scale << ")";
+                }
+
+                res += oss.str();
+            }
+            break;
+
+        case dt_integer:
+            res += "integer";
+            break;
+
+        case dt_long_long:
+            res += "bigint";
+            break;
+
+        case dt_unsigned_long_long:
+            res += "bigint unsigned";
+            break;
+
+        case dt_blob:
+            res += "longblob";
+            break;
+
+        default:
+            throw soci_error("this data_type is not supported in create_column");
+        }
+
+        return res;
+    }
+
     MYSQL *conn_;
 };
 

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -353,7 +353,7 @@ public:
                 std::ostringstream oss;
                 if (precision == 0)
                 {
-                    oss << "numeric";
+                    oss << "double precision";
                 }
                 else
                 {
@@ -372,8 +372,10 @@ public:
             res += "bigint";
             break;
 
+        // PostgeSQL haven't got native unsigned types. Treat NUMERIC type with
+        // a precision of 64 bits and a scale of 0 bits as dt_unsigned_long_long
         case dt_unsigned_long_long:
-            res += "bigint";
+            res += "numeric(64,0)";
             break;
 
         case dt_blob:

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -324,8 +324,9 @@ struct sqlite3_session_backend : details::session_backend
             case dt_integer:
                 return "integer";
             case dt_long_long:
-            case dt_unsigned_long_long:
                 return "bigint";
+            case dt_unsigned_long_long:
+                return "unsigned big int";
             case dt_blob:
                 return "blob";
             case dt_xml:

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -324,9 +324,8 @@ struct sqlite3_session_backend : details::session_backend
             case dt_integer:
                 return "integer";
             case dt_long_long:
-                return "bigint";
             case dt_unsigned_long_long:
-                return "unsigned big int";
+                return "bigint";
             case dt_blob:
                 return "blob";
             case dt_xml:

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -315,18 +315,22 @@ struct sqlite3_session_backend : details::session_backend
     {
         switch (dt)
         {
-            case dt_xml:
             case dt_string:
                 return "text";
             case dt_double:
                 return "real";
             case dt_date:
+                return "datetime";
             case dt_integer:
-            case dt_long_long:
-            case dt_unsigned_long_long:
                 return "integer";
+            case dt_long_long:
+                return "bigint";
+            case dt_unsigned_long_long:
+                return "unsigned big int";
             case dt_blob:
                 return "blob";
+            case dt_xml:
+                throw soci_error("XML data type is not supported");
             default:
                 throw soci_error("this data_type is not supported in create_column");
         }

--- a/include/soci/type-conversion-traits.h
+++ b/include/soci/type-conversion-traits.h
@@ -36,29 +36,6 @@ struct type_conversion
     }
 };
 
-// Most majority of database engines ignore unsigned integer related types.
-// This hack allows to trait these types as signed integers in the database.
-template<>
-struct type_conversion<unsigned long long>
-{
-    typedef long long base_type;
-
-    static void from_base(base_type const & in, indicator ind, unsigned long long & out)
-    {
-        if (ind == i_null)
-        {
-            throw soci_error("Null value not allowed for this type");
-        }
-        out = static_cast<unsigned long long>(in);
-    }
-
-    static void to_base(unsigned long long const & in, base_type & out, indicator & ind)
-    {
-        out = static_cast<long long>(in);
-        ind = i_ok;
-    }
-};
-
 } // namespace soci
 
 #endif // SOCI_TYPE_CONVERSION_TRAITS_H_INCLUDED

--- a/include/soci/type-conversion-traits.h
+++ b/include/soci/type-conversion-traits.h
@@ -36,6 +36,29 @@ struct type_conversion
     }
 };
 
+// Most majority of database engines ignore unsigned integer related types.
+// This hack allows to trait these types as signed integers in the database.
+template<>
+struct type_conversion<unsigned long long>
+{
+    typedef long long base_type;
+
+    static void from_base(base_type const & in, indicator ind, unsigned long long & out)
+    {
+        if (ind == i_null)
+        {
+            throw soci_error("Null value not allowed for this type");
+        }
+        out = static_cast<unsigned long long>(in);
+    }
+
+    static void to_base(unsigned long long const & in, base_type & out, indicator & ind)
+    {
+        out = static_cast<long long>(in);
+        ind = i_ok;
+    }
+};
+
 } // namespace soci
 
 #endif // SOCI_TYPE_CONVERSION_TRAITS_H_INCLUDED

--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -746,9 +746,23 @@ void postgresql_statement_backend::describe_column(int colNum, data_type & type,
 
     case 700:  // float4
     case 701:  // float8
-    case 1700: // numeric
         type = dt_double;
         break;
+
+    case 1700: // numeric
+    {
+        int mod = PQfmod(result_, pos);
+        int pgprec = (mod >> 16);
+        int pgscal = ((mod - 4)& 0xFFFF);
+
+        // PostgeSQL haven't got native unsigned types. Treat NUMERIC type with
+        // a precision of 64 bits and a scale of 0 bits as dt_unsigned_long_long
+        if (pgprec == 64 && pgscal == 0)
+            type = dt_unsigned_long_long;
+        else
+            type = dt_double;
+        break;
+    }
 
     case 16:   // bool
     case 21:   // int2

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -491,10 +491,10 @@ void sqlite3_statement_backend::describe_column(int colNum, data_type & type,
 
     std::string dt = declType;
 
-    // remove extra characters for example "(20)" in "varchar(20)"
-    std::string::iterator siter = std::find_if(dt.begin(), dt.end(), std::not1(std::ptr_fun(isalnum)));
-    if (siter != dt.end())
-        dt.resize(siter - dt.begin());
+    // remove possible size between parenthesis. For example "(20)" in "varing character(20)"
+    size_t size_new = dt.find_first_of("(");
+    if (size_new != std::string::npos)
+        dt.resize(size_new);
 
     // do all comparisons in lower case
     std::transform(dt.begin(), dt.end(), dt.begin(), tolower);

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -439,7 +439,6 @@ static sqlite3_data_type_map get_data_type_map()
     // dt_long_long
     m["bigint"]             = dt_long_long;
     m["int8"]               = dt_long_long;
-    m["unsigned big int"]   = dt_long_long;
 
     // dt_string
     m["char"]               = dt_string;
@@ -451,6 +450,10 @@ static sqlite3_data_type_map get_data_type_map()
     m["text"]               = dt_string;
     m["varchar"]            = dt_string;
     m["varying character"]  = dt_string;
+
+    // dt_unsigned_long_long
+    m["unsigned big int"]   = dt_unsigned_long_long;
+
 
     return m;
 }

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -439,6 +439,7 @@ static sqlite3_data_type_map get_data_type_map()
     // dt_long_long
     m["bigint"]             = dt_long_long;
     m["int8"]               = dt_long_long;
+    m["unsigned big int"]   = dt_long_long;
 
     // dt_string
     m["char"]               = dt_string;
@@ -450,10 +451,6 @@ static sqlite3_data_type_map get_data_type_map()
     m["text"]               = dt_string;
     m["varchar"]            = dt_string;
     m["varying character"]  = dt_string;
-
-    // dt_unsigned_long_long
-    m["unsigned big int"]   = dt_unsigned_long_long;
-
 
     return m;
 }

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4603,7 +4603,7 @@ TEST_CASE_METHOD(common_tests, "DDL data types", "[core][ddl][data_types]")
         t.tm_min = 13;
         t.tm_sec = 14;
 
-        SociDataTypes write = {3.14159265, -10, -20, 30, "Helo SOCI!", t};
+        SociDataTypes write = {3.14159265, -2147483648, -9223372036854775807LL, 18446744073709551615ULL, "Helo SOCI!", t};
         sql << "insert into soci_test(double_type, integer_type, long_long_type, "
                "unsigned_long_long_type, string_type, date_type) values(:double_type, "
                ":integer_type, :long_long_type, :unsigned_long_long_type, :string_type, "


### PR DESCRIPTION
New attempt to patch the error described in pull request #639. This patch solves more related errors.

When the portable DDL query CREATE TABLE is used in conjunction with ORM, the use of the following data types cause an exception of type std::bad_cast in type_conversion::from_base method:
- dt_date
- dt_long_long
- dt_unsigned_long_long

The data type dt_xml isn't supported by the SQLite3 backend. The method now throws an exception when this type is used.

The method statement_backend::describe_column previously failed when a column type name had spaces, for example "unsigned big int". It has been fixed.

Added test "DDL data types" to the file common-tests.h to check the above errors.