### PR TITLE
Avoid memory corruption at ODBC backend in vector_into

### DIFF
--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -351,6 +351,7 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
 void odbc_vector_into_type_backend::resize(std::size_t sz)
 {
     indHolderVec_.resize(sz);
+    indHolders_ = &indHolderVec_[0];
     switch (type_)
     {
     // simple cases


### PR DESCRIPTION
BUG: potentially a new memory block gots allocated inside **indHolderVec_**
but still the old (and now freed) memory is bound by **indHolders_** member.
In multithreaded apps this additionally may overwrite other threads
memory.