### PR TITLE
Support DB2 driver not compliant to ODBC spec

### DIFF
--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -484,7 +484,10 @@ inline SQLLEN odbc_standard_type_backend_base::get_spec_compliant_sqllen_from_va
 {
     if (requires_not_spec_compliant_indicators())
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
         return *reinterpret_cast<const int*>(&val);
+#pragma GCC diagnostic pop
     }
     return val;
 }
@@ -502,7 +505,10 @@ inline void odbc_vector_use_type_backend::set_spec_compliant_sqllen_into_vector_
 {
     if (requires_not_spec_compliant_indicators())
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
         reinterpret_cast<int*>(&indHolderVec_[0])[idx] = *reinterpret_cast<const int*>(&val);
+#pragma GCC diagnostic pop
     }
     else
     {

--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -206,6 +206,10 @@ bool odbc_session_backend::get_next_sequence_value(
 
     switch ( get_database_product() )
     {
+        case prod_db2:
+            query = "select next value for " + sequence + " from SYSIBM.SYSDUMMY1";
+            break;
+
         case prod_firebird:
             query = "select next value for " + sequence + " from rdb$database";
             break;
@@ -247,6 +251,10 @@ bool odbc_session_backend::get_last_insert_id(
 
     switch ( get_database_product() )
     {
+        case prod_db2:
+            query = "SELECT IDENTITY_VAL_LOCAL() AS LASTID FROM SYSIBM.SYSDUMMY1";
+            break;
+          
         case prod_mssql:
             query = "select ident_current('" + table + "')";
             break;
@@ -287,6 +295,10 @@ std::string odbc_session_backend::get_dummy_from_table() const
 
     switch ( get_database_product() )
     {
+        case prod_db2:
+            table = "SYSIBM.SYSDUMMY1";
+            break;
+
         case prod_firebird:
             table = "rdb$database";
             break;
@@ -387,6 +399,8 @@ odbc_session_backend::get_database_product() const
         product_ = prod_postgresql;
     else if (strcmp(product_name, "SQLite") == 0)
         product_ = prod_sqlite;
+    else if (strstr(product_name, "DB2") == product_name) // "DB2/LINUXX8664"
+        product_ = prod_db2;
     else
         product_ = prod_unknown;
 

--- a/src/backends/odbc/standard-into-type.cpp
+++ b/src/backends/odbc/standard-into-type.cpp
@@ -128,7 +128,7 @@ void odbc_standard_into_type_backend::post_fetch(
     if (gotData)
     {
         // first, deal with indicators
-        if (SQL_NULL_DATA == get_spec_compliant_sqllen_from_value(valueLen_))
+        if (SQL_NULL_DATA == get_sqllen_from_value(valueLen_))
         {
             if (ind == NULL)
             {

--- a/src/backends/odbc/standard-into-type.cpp
+++ b/src/backends/odbc/standard-into-type.cpp
@@ -128,7 +128,7 @@ void odbc_standard_into_type_backend::post_fetch(
     if (gotData)
     {
         // first, deal with indicators
-        if (SQL_NULL_DATA == valueLen_)
+        if (SQL_NULL_DATA == get_spec_compliant_sqllen_from_value(valueLen_))
         {
             if (ind == NULL)
             {

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -145,7 +145,7 @@ void odbc_vector_into_type_backend::define_by_pos(
             odbcType_ = SQL_C_CHAR;
             std::vector<std::string> *v
                 = static_cast<std::vector<std::string> *>(data);
-            colSize_ = get_spec_compliant_sqllen_from_value(statement_.column_size(position)) + 1;
+            colSize_ = get_sqllen_from_value(statement_.column_size(position)) + 1;
             std::size_t bufSize = colSize_ * v->size();
             buf_ = new char[bufSize];
 
@@ -225,7 +225,7 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             std::size_t const vsize = v.size();
             for (std::size_t i = 0; i != vsize; ++i, pos += colSize_)
             {
-                SQLLEN const len = get_spec_compliant_sqllen_from_vector_at(i);
+                SQLLEN const len = get_sqllen_from_vector_at(i);
 
                 if (len == -1)
                 {
@@ -315,7 +315,7 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             std::size_t const indSize = statement_.get_number_of_rows();
             for (std::size_t i = 0; i != indSize; ++i)
             {
-                SQLLEN const val = get_spec_compliant_sqllen_from_vector_at(i);
+                SQLLEN const val = get_sqllen_from_vector_at(i);
                 if (val > 0)
                 {
                     ind[i] = i_ok;
@@ -335,7 +335,7 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             std::size_t const indSize = statement_.get_number_of_rows();
             for (std::size_t i = 0; i != indSize; ++i)
             {
-                if (get_spec_compliant_sqllen_from_vector_at(i) == SQL_NULL_DATA)
+                if (get_sqllen_from_vector_at(i) == SQL_NULL_DATA)
                 {
                     // fetched null and no indicator - programming error!
                     throw soci_error(
@@ -352,7 +352,7 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
 
 void odbc_vector_into_type_backend::resize(std::size_t sz)
 {
-    // stays 64bit but gets but casted, see: get_spec_compliant_sqllen_from_vector_at(...)
+    // stays 64bit but gets but casted, see: get_sqllen_from_vector_at(...)
     indHolderVec_.resize(sz);
     switch (type_)
     {

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -166,7 +166,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
             for (std::size_t i = 0; i != vecSize; ++i)
             {
                 std::size_t sz = v[i].length();
-                set_spec_compliant_sqllen_into_vector_at(i, static_cast<long>(sz));
+                set_sqllen_from_vector_at(i, static_cast<long>(sz));
                 maxSize = sz > maxSize ? sz : maxSize;
             }
 
@@ -390,14 +390,14 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
         {
             if (*ind == i_null)
             {
-                set_spec_compliant_sqllen_into_vector_at(i, SQL_NULL_DATA);
+                set_sqllen_from_vector_at(i, SQL_NULL_DATA);
             }
             else
             {
                 // for strings we have already set the values
                 if (type_ != x_stdstring)
                 {
-                    set_spec_compliant_sqllen_into_vector_at(i, non_null_indicator);
+                    set_sqllen_from_vector_at(i, non_null_indicator);
                 }
             }
         }
@@ -411,7 +411,7 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
             // for strings we have already set the values
             if (type_ != x_stdstring)
             {
-                set_spec_compliant_sqllen_into_vector_at(i, non_null_indicator);
+                set_sqllen_from_vector_at(i, non_null_indicator);
             }
         }
     }

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -166,7 +166,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
             for (std::size_t i = 0; i != vecSize; ++i)
             {
                 std::size_t sz = v[i].length();
-                indHolderVec_[i] = static_cast<long>(sz);
+                set_spec_compliant_sqllen_into_vector_at(i, static_cast<long>(sz));
                 maxSize = sz > maxSize ? sz : maxSize;
             }
 
@@ -390,14 +390,14 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
         {
             if (*ind == i_null)
             {
-                indHolderVec_[i] = SQL_NULL_DATA; // null
+                set_spec_compliant_sqllen_into_vector_at(i, SQL_NULL_DATA);
             }
             else
             {
-            // for strings we have already set the values
-            if (type_ != x_stdstring)
+                // for strings we have already set the values
+                if (type_ != x_stdstring)
                 {
-                    indHolderVec_[i] = non_null_indicator;
+                    set_spec_compliant_sqllen_into_vector_at(i, non_null_indicator);
                 }
             }
         }
@@ -411,7 +411,7 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
             // for strings we have already set the values
             if (type_ != x_stdstring)
             {
-                indHolderVec_[i] = non_null_indicator;
+                set_spec_compliant_sqllen_into_vector_at(i, non_null_indicator);
             }
         }
     }

--- a/tests/odbc/CMakeLists.txt
+++ b/tests/odbc/CMakeLists.txt
@@ -49,10 +49,14 @@ soci_backend_test(
 
 # TODO: DB2 backend is tested by Travis CI on dedicated VM, separate from ODBC,
 # in order to test DB2 with ODBC, it would be best to install DB2 driver only.
-if (NOT $ENV{TRAVIS})
-soci_backend_test(
-  NAME db2
-  BACKEND ODBC
-  SOURCE test-odbc-db2.cpp
-  CONNSTR "test-db2.dsn")
+# if (NOT $ENV{TRAVIS})
+option(WITH_ODBC_TEST_DB2 "Build ODBC DB2 test" OFF)
+if (WITH_ODBC_TEST_DB2)
+  soci_backend_test(
+    NAME db2
+    BACKEND ODBC
+    SOURCE test-odbc-db2.cpp
+    CONNSTR "test-db2.dsn")
+else()
+  message(STATUS "ODBC DB2 test disabled.")
 endif()


### PR DESCRIPTION
IBM DB2 driver is not compliant to ODBC spec for indicators in 64bit
SQLLEN is still defined 32bit (int) but spec requires 64bit (long).

ref: https://bugs.php.net/bug.php?id=54007

> A workaround that we successfully used in production for several years includes casting certain 64-bit ODBC values down to 32-bits when comparing for SQL_NULL_DATA. It essentially changes PHP to conform to an outdated ODBC spec that IBM requires. It doesn't break other "real" 64-bit ODBC drivers as long as you aren't pulling back individual values > 4GB.

2 new cmake options introduced (default is `OFF`, replaces the `if (NOT $ENV{TRAVIS})` hack
```
  -DWITH_ODBC_TEST_DB2=ON
  -DSOCI_ODBC_TEST_DB2_CONNSTR="test-db2.dsn"
```

tested on macOS build:
```
ctest -R soci_odbc
Test project /Users/heikorabe/Builds/soci_4.0
    Start  9: soci_odbc_test_mssql
1/8 Test  #9: soci_odbc_test_mssql ...............   Passed   15.32 sec
    Start 10: soci_odbc_test_mssql_static
2/8 Test #10: soci_odbc_test_mssql_static ........   Passed   15.62 sec
    Start 11: soci_odbc_test_mysql
3/8 Test #11: soci_odbc_test_mysql ...............   Passed   10.85 sec
    Start 12: soci_odbc_test_mysql_static
4/8 Test #12: soci_odbc_test_mysql_static ........   Passed   13.51 sec
    Start 13: soci_odbc_test_postgresql
5/8 Test #13: soci_odbc_test_postgresql ..........   Passed    8.38 sec
    Start 14: soci_odbc_test_postgresql_static
6/8 Test #14: soci_odbc_test_postgresql_static ...   Passed    8.88 sec
    Start 15: soci_odbc_test_db2
7/8 Test #15: soci_odbc_test_db2 .................   Passed   63.35 sec
    Start 16: soci_odbc_test_db2_static
8/8 Test #16: soci_odbc_test_db2_static ..........   Passed   67.20 sec

100% tests passed, 0 tests failed out of 8

Total Test time (real) = 203.12 sec
```
closes #660 