### PR TITLE
Fix #640, at least when compiling with -O1 and above

### DIFF
--- a/src/core/soci-simple.cpp
+++ b/src/core/soci-simple.cpp
@@ -705,7 +705,7 @@ static inline bool isTmValid(std::tm const & d)
 // helper for formatting date values
 char const * format_date(statement_wrapper & wrapper, std::tm const & d)
 {
-    if (isTmValid(d) {
+    if (isTmValid(d)) {
         std::sprintf(wrapper.date_formatted, "%d %d %d %d %d %d",
             d.tm_year + 1900, d.tm_mon + 1, d.tm_mday,
             d.tm_hour, d.tm_min, d.tm_sec);
@@ -745,7 +745,7 @@ bool string_to_date(char const * val, std::tm & /* out */ dt,
     dt.tm_min = minute;
     dt.tm_sec = second;
 
-return true;
+    return true;
 }
 
 } // namespace unnamed
@@ -1821,7 +1821,7 @@ SOCI_DECL char const * soci_get_use_date(statement_handle st, char const * name)
 
     // format is: "YYYY MM DD hh mm ss"
     std::tm const & d = wrapper->use_dates[name];
-    if (isTmValid(d) {
+    if (isTmValid(d)) {
         std::sprintf(wrapper->date_formatted, "%d %d %d %d %d %d",
             d.tm_year + 1900, d.tm_mon + 1, d.tm_mday,
             d.tm_hour, d.tm_min, d.tm_sec);

--- a/src/core/soci-simple.cpp
+++ b/src/core/soci-simple.cpp
@@ -17,6 +17,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <limits>
 
 using namespace soci;
 
@@ -339,8 +340,8 @@ struct statement_wrapper
     std::map<std::string, std::vector<double> > use_doubles_v;
     std::map<std::string, std::vector<std::tm> > use_dates_v;
 
-    // format is: "YYYY MM DD hh mm ss"
-    char date_formatted[20];
+    // format is: "YYYY MM DD hh mm ss", year can span the entire range of decltype(std::tm::tm_year) (i.e. int)
+    char date_formatted[28];
 
     bool is_ok;
     std::string error_message;
@@ -682,8 +683,9 @@ void resize_in_map(std::map<std::string, std::vector<T> > & m, int new_size)
 #define isInRange(what, min, max) (what >= min && what <= max)
 static inline bool isTmValid(std::tm const & d)
 {
+    const int max_year = std::numeric_limits<int>::max() - 1900; // int == decltype(std::tm::dt_year)
     if (
-        !isInRange(d.tm_year, -2899, 8099) // To ensure 4 digits (positive) [max 9999] or minus + 3 digits [min -999]
+        (d.tm_year > max_year) // to avoid undefined behaviour
      || !isInRange(d.tm_mon, 0, 11)
      || !isInRange(d.tm_mday, 1, 31)
      || !isInRange(d.tm_hour, 0, 23)


### PR DESCRIPTION
Avoid warnings/errors on std::tm formatting in simple interface when compiling with gcc and -Wformat-overflow=2.
Works for -O1 and above, because -O0 does not do range propagation, thus the warning is not suppressed (not even when inlining the function by hand).