### PR TITLE
sqlite params default init fix

### DIFF
--- a/src/backends/sqlite3/standard-use-type.cpp
+++ b/src/backends/sqlite3/standard-use-type.cpp
@@ -79,7 +79,9 @@ void sqlite3_standard_use_type_backend::pre_use(indicator const * ind)
 
     if (statement_.useData_[0].size() < static_cast<std::size_t>(position_))
     {
-        statement_.useData_[0].resize(position_);
+        sqlite3_column empty;
+        empty.isNull_ = true;
+        statement_.useData_[0].resize(position_, empty);
     }
 
     sqlite3_column &col = statement_.useData_[0][pos];


### PR DESCRIPTION
Parameters to sqlite can be provided in a sparse list (when not all parameters are specified) .`isNull_` field in [sqlite3_column](https://github.com/SOCI/soci/blob/d081e1248d74bbc7c42b4c695cff684ee6376b5d/include/soci/sqlite3/soci-sqlite3.h#L178) does not have a default initializer. During the [resize](https://en.cppreference.com/w/cpp/container/vector/resize) of a parameters vector `isNull_` field for omitted parameters points to unitialized memory, it is interpreted as `true` most of the time, but not always. In release builds this causes intermittent crashes or errors like [this one](https://sourceforge.net/p/soci/mailman/message/24537235/).

