### PR TITLE
additional fix for the Oracle test

### DIFF
--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -522,13 +522,13 @@ TEST_CASE("Oracle bulk insert", "[oracle][insert][bulk]")
     //verify an exception is thrown if into vector is zero length
     {
         std::vector<int> ids;
-        CHECK_THROWS_AS((sql << "select id from soci_test", into(ids)), soci_error);
+        CHECK_THROWS_AS((sql << "select id from soci_test", into(ids)), soci_error&);
     }
 
     // verify an exception is thrown if use vector is zero length
     {
         std::vector<int> ids;
-        CHECK_THROWS_AS((sql << "insert into soci_test(id) values(:id)", use(ids)), soci_error);
+        CHECK_THROWS_AS((sql << "insert into soci_test(id) values(:id)", use(ids)), soci_error&);
     }
 
     // test "no data" condition


### PR DESCRIPTION
Added the missing fix for Oracle db. The same idea as the original fix for gcc 8.1 compiler.