### PR TITLE
Really fix long strings with ODBC

### DIFF
--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -33,10 +33,6 @@
 #include <sqlext.h> // ODBC
 #include <string.h> // strcpy()
 
-#ifndef SQL_SS_LENGTH_UNLIMITED
-#define SQL_SS_LENGTH_UNLIMITED 0
-#endif
-
 namespace soci
 {
 

--- a/src/backends/odbc/standard-use-type.cpp
+++ b/src/backends/odbc/standard-use-type.cpp
@@ -139,9 +139,9 @@ void odbc_standard_use_type_backend::copy_from_string(
         SQLSMALLINT& cType
     )
 {
-    sqlType = SQL_VARCHAR;
-    cType = SQL_C_CHAR;
     size = s.size();
+    sqlType = size > ODBC_MAX_COL_SIZE ? SQL_LONGVARCHAR : SQL_VARCHAR;
+    cType = SQL_C_CHAR;
     buf_ = new char[size+1];
     memcpy(buf_, s.c_str(), size);
     buf_[size++] = '\0';
@@ -210,11 +210,7 @@ void odbc_standard_use_type_backend::pre_use(indicator const *ind)
     SQLLEN bufLen(0);
 
     void* const sqlData = prepare_for_bind(size, sqlType, cType);
-    if (size > ODBC_MAX_COL_SIZE)
-    {
-        bufLen = size;
-        size   = SQL_SS_LENGTH_UNLIMITED;
-    }
+
     SQLRETURN rc = SQLBindParameter(statement_.hstmt_,
                                     static_cast<SQLUSMALLINT>(position_),
                                     SQL_PARAM_INPUT,

--- a/tests/odbc/test-odbc-mssql.cpp
+++ b/tests/odbc/test-odbc-mssql.cpp
@@ -47,7 +47,9 @@ TEST_CASE("MS SQL long string", "[odbc][mssql][long]")
     }
 
     std::string const str_in = os.str();
-    sql << "insert into soci_test(long_text) values(:str)", use(str_in);
+    CHECK_NOTHROW((
+        sql << "insert into soci_test(long_text) values(:str)", use(str_in)
+    ));
 
     std::string str_out;
     sql << "select long_text from soci_test", into(str_out);


### PR DESCRIPTION
This also works with the old ODBC drivers.

See #383.