### PR TITLE
Allow Oracle Travis CI build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,20 @@ services:
 env:
   global:
     - secure: "I7/28jg7R24y64426d5XsfILrd/VW0BdwFbNpEgBfW1qNk9GpkNGTvp/ET6hKwBVrW5jmN9QdEviGcPpQRIAlMj6g9GvZeAUxM+VZTcXD2u30REUPPxNTJMRVHPfL9DA7EMFCST8SjBCgMdTHFwqLV4vSQEF4NTXbntley/IPfM="
-  matrix:
-    - SOCI_TRAVIS_BACKEND=db2
-    - SOCI_TRAVIS_BACKEND=empty
-    - SOCI_TRAVIS_BACKEND=firebird
-    - SOCI_TRAVIS_BACKEND=mysql
-    - SOCI_TRAVIS_BACKEND=odbc
-    - SOCI_TRAVIS_BACKEND=postgresql
-    - SOCI_TRAVIS_BACKEND=sqlite3
-    - SOCI_TRAVIS_BACKEND=valgrind
-    - SOCI_TRAVIS_BACKEND=oracle WITH_BOOST=OFF
+
+matrix:
+    include:
+        - env: SOCI_TRAVIS_BACKEND=db2
+        - env: SOCI_TRAVIS_BACKEND=empty
+        - env: SOCI_TRAVIS_BACKEND=firebird
+        - env: SOCI_TRAVIS_BACKEND=mysql
+        - env: SOCI_TRAVIS_BACKEND=odbc
+        - env: SOCI_TRAVIS_BACKEND=postgresql
+        - env: SOCI_TRAVIS_BACKEND=sqlite3
+        - env: SOCI_TRAVIS_BACKEND=valgrind
+        - env: SOCI_TRAVIS_BACKEND=oracle WITH_BOOST=OFF
+    allow_failures:
+        - env: SOCI_TRAVIS_BACKEND=oracle WITH_BOOST=OFF
 
 addons:
   coverity_scan:


### PR DESCRIPTION
It does fail all the time currently due to not being able to download
the Oracle package any longer.

---

Just in case you don't have time to look into this in more details (I'm totally out of my depth with this stuff...), I think we should merge this, at least "temporarily" (of course, it risks becoming permanent...).