### PR TITLE
Work around gcc 8 -Wformat-truncation warnings in release builds

### DIFF
--- a/src/backends/mysql/standard-use-type.cpp
+++ b/src/backends/mysql/standard-use-type.cpp
@@ -116,7 +116,7 @@ void mysql_standard_use_type_backend::pre_use(indicator const *ind)
             break;
         case x_stdtm:
             {
-                std::size_t const bufSize = 22;
+                std::size_t const bufSize = 80;
                 buf_ = new char[bufSize];
 
                 std::tm const& t = exchange_type_cast<x_stdtm>(data_);

--- a/src/backends/mysql/vector-use-type.cpp
+++ b/src/backends/mysql/vector-use-type.cpp
@@ -153,7 +153,7 @@ void mysql_vector_use_type_backend::pre_use(indicator const *ind)
                         = static_cast<std::vector<std::tm> *>(data_);
                     std::vector<std::tm> &v = *pv;
 
-                    std::size_t const bufSize = 22;
+                    std::size_t const bufSize = 80;
                     buf = new char[bufSize];
 
                     snprintf(buf, bufSize, "\'%d-%02d-%02d %02d:%02d:%02d\'",

--- a/src/backends/postgresql/standard-use-type.cpp
+++ b/src/backends/postgresql/standard-use-type.cpp
@@ -108,7 +108,7 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
             break;
         case x_stdtm:
             {
-                std::size_t const bufSize = 20;
+                std::size_t const bufSize = 80;
                 buf_ = new char[bufSize];
 
                 std::tm const& t = exchange_type_cast<x_stdtm>(data_);

--- a/src/backends/postgresql/vector-use-type.cpp
+++ b/src/backends/postgresql/vector-use-type.cpp
@@ -164,7 +164,7 @@ void postgresql_vector_use_type_backend::pre_use(indicator const * ind)
                         = static_cast<std::vector<std::tm> *>(data_);
                     std::vector<std::tm> & v = *pv;
 
-                    std::size_t const bufSize = 20;
+                    std::size_t const bufSize = 80;
                     buf = new char[bufSize];
 
                     snprintf(buf, bufSize, "%d-%02d-%02d %02d:%02d:%02d",

--- a/src/core/soci-simple.cpp
+++ b/src/core/soci-simple.cpp
@@ -339,8 +339,10 @@ struct statement_wrapper
     std::map<std::string, std::vector<double> > use_doubles_v;
     std::map<std::string, std::vector<std::tm> > use_dates_v;
 
-    // format is: "YYYY MM DD hh mm ss"
-    char date_formatted[20];
+    // format is: "YYYY MM DD hh mm ss", but we make the buffer bigger to
+    // avoid gcc -Wformat-truncation warnings as it considers that the output
+    // could be up to 72 bytes if the integers had maximal values
+    char date_formatted[80];
 
     bool is_ok;
     std::string error_message;

--- a/src/core/use-type.cpp
+++ b/src/core/use-type.cpp
@@ -81,7 +81,7 @@ void standard_use_type::dump_value(std::ostream& os) const
             {
                 std::tm const& t = exchange_type_cast<x_stdtm>(data_);
 
-                char buf[32];
+                char buf[80];
                 snprintf(buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d:%02d",
                               t.tm_year + 1900, t.tm_mon + 1, t.tm_mday,
                               t.tm_hour, t.tm_min, t.tm_sec);


### PR DESCRIPTION
gcc 8 considers that sprintf("%d", n) may output up to 11 bytes and even
though we know that the range of "n" is limited to 2 digits and so it
actually can't be so long, just increase the sizes of the buffers used
with snprintf() to avoid gcc warnings it's much simpler than doing
anything more complicated.

Closes #640.