### PR TITLE
Longlong

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,16 @@ option(SOCI_ASAN "Enable address sanitizer on GCC v4.8+/Clang v 3.1+" OFF)
 set(CMAKE_MODULE_PATH ${SOCI_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 set(CMAKE_MODULE_PATH ${SOCI_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
 
+set(SOCI_CXX_C11	ON CACHE BOOL "activé pour la réception v3" FORCE)
+set(SOCI_SHARED 	ON CACHE BOOL "activé pour la réception v3" FORCE)
+set(SOCI_STATIC 	OFF CACHE BOOL "DÉSactivé pour la réception v3" FORCE)
+
+foreach(OPT DB2 FIREBIRD ODBC ORACLE MYSQL SQLITE3)
+	set(WITH_${OPT}	OFF CACHE BOOL "désactivé pour la réception v3" FORCE)
+endforeach(OPT)
+
+set(WITH_POSTGRESQL	ON CACHE BOOL "activé pour la réception v3" FORCE)
+
 include(SociUtilities)
 include(SociConfig)
 

--- a/include/private/firebird/common.h
+++ b/include/private/firebird/common.h
@@ -118,7 +118,7 @@ void to_isc(void * val, XSQLVAR * var, short x_scale = 0)
     T1 value = *reinterpret_cast<T1*>(val);
     short scale = var->sqlscale + x_scale;
     short type = var->sqltype & ~1;
-    long long divisor = 1, multiplier = 1;
+    int64_t divisor = 1, multiplier = 1;
 
     cond_to_isc<std::numeric_limits<T1>::is_integer>::checkInteger(scale,type);
 
@@ -143,8 +143,8 @@ void to_isc(void * val, XSQLVAR * var, short x_scale = 0)
         break;
     case SQL_INT64:
         {
-            long long tmp = static_cast<long long>(round_for_isc(value*multiplier)/divisor);
-            std::memcpy(var->sqldata, &tmp, sizeof(long long));
+            int64_t tmp = static_cast<int64_t>(round_for_isc(value*multiplier)/divisor);
+            std::memcpy(var->sqldata, &tmp, sizeof(int64_t));
         }
         break;
     case SQL_FLOAT:
@@ -238,7 +238,7 @@ T1 from_isc(XSQLVAR * var)
     case SQL_LONG:
         return static_cast<T1>(*reinterpret_cast<int*>(var->sqldata)/tens);
     case SQL_INT64:
-        return static_cast<T1>(*reinterpret_cast<long long*>(var->sqldata)/tens);
+        return static_cast<T1>(*reinterpret_cast<int64_t*>(var->sqldata)/tens);
     case SQL_FLOAT:
         return static_cast<T1>(*reinterpret_cast<float*>(var->sqldata));
     case SQL_DOUBLE:

--- a/include/private/firebird/error-firebird.h
+++ b/include/private/firebird/error-firebird.h
@@ -22,7 +22,7 @@ namespace firebird
 
 void SOCI_FIREBIRD_DECL get_iscerror_details(ISC_STATUS * status_vector, std::string &msg);
 
-bool SOCI_FIREBIRD_DECL check_iscerror(ISC_STATUS const * status_vector, long errNum);
+bool SOCI_FIREBIRD_DECL check_iscerror(ISC_STATUS const * status_vector, int64_t errNum);
 
 void SOCI_FIREBIRD_DECL throw_iscerror(ISC_STATUS * status_vector);
 

--- a/include/private/soci-exchange-cast.h
+++ b/include/private/soci-exchange-cast.h
@@ -49,13 +49,13 @@ struct exchange_type_traits<x_integer>
 template <>
 struct exchange_type_traits<x_long_long>
 {
-  typedef long long value_type;
+  typedef int64_t value_type;
 };
 
 template <>
 struct exchange_type_traits<x_unsigned_long_long>
 {
-  typedef unsigned long long value_type;
+  typedef uint64_t value_type;
 };
 
 template <>

--- a/include/soci/column-info.h
+++ b/include/soci/column-info.h
@@ -44,10 +44,10 @@ struct type_conversion<column_info>
                 v.get<int>(field_name, 0));
         case dt_long_long:
             return static_cast<std::size_t>(
-                v.get<long long>(field_name, 0ll));
+                v.get<int64_t>(field_name, 0ll));
         case dt_unsigned_long_long:
             return static_cast<std::size_t>(
-                v.get<unsigned long long>(field_name, 0ull));
+                v.get<uint64_t>(field_name, 0ull));
             break;
         default:
             return 0u;

--- a/include/soci/db2/soci-db2.h
+++ b/include/soci/db2/soci-db2.h
@@ -199,7 +199,7 @@ struct SOCI_DB2_DECL db2_statement_backend : details::statement_backend
     exec_fetch_result execute(int number) SOCI_OVERRIDE;
     exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    long long get_affected_rows() SOCI_OVERRIDE;
+    int64_t get_affected_rows() SOCI_OVERRIDE;
     int get_number_of_rows() SOCI_OVERRIDE;
     std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 

--- a/include/soci/empty/soci-empty.h
+++ b/include/soci/empty/soci-empty.h
@@ -114,7 +114,7 @@ struct SOCI_EMPTY_DECL empty_statement_backend : details::statement_backend
     exec_fetch_result execute(int number) SOCI_OVERRIDE;
     exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    long long get_affected_rows() SOCI_OVERRIDE;
+    int64_t get_affected_rows() SOCI_OVERRIDE;
     int get_number_of_rows() SOCI_OVERRIDE;
     std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 

--- a/include/soci/exchange-traits.h
+++ b/include/soci/exchange-traits.h
@@ -74,36 +74,36 @@ struct exchange_traits<char>
 };
 
 template <>
-struct exchange_traits<long long>
+struct exchange_traits<int64_t>
 {
     typedef basic_type_tag type_family;
     enum { x_type = x_long_long };
 };
 
 template <>
-struct exchange_traits<unsigned long long>
+struct exchange_traits<uint64_t>
 {
     typedef basic_type_tag type_family;
     enum { x_type = x_unsigned_long_long };
 };
 
-// long must be mapped either to x_integer or x_long_long:
+// int64_t must be mapped either to x_integer or x_long_long:
 template<int long_size> struct long_traits_helper;
 template<> struct long_traits_helper<4> { enum { x_type = x_integer }; };
 template<> struct long_traits_helper<8> { enum { x_type = x_long_long }; };
-
+/*
 template <>
-struct exchange_traits<long int>
+struct exchange_traits<int64_t>
 {
     typedef basic_type_tag type_family;
-    enum { x_type = long_traits_helper<sizeof(long int)>::x_type };
+    enum { x_type = long_traits_helper<sizeof(int64_t)>::x_type };
 };
 
 template <>
-struct exchange_traits<unsigned long> : exchange_traits<long>
+struct exchange_traits<uint64_t> : exchange_traits<int64_t>
 {
 };
-
+*/
 template <>
 struct exchange_traits<double>
 {

--- a/include/soci/firebird/soci-firebird.h
+++ b/include/soci/firebird/soci-firebird.h
@@ -198,7 +198,7 @@ struct firebird_statement_backend : details::statement_backend
     exec_fetch_result execute(int number) SOCI_OVERRIDE;
     exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    long long get_affected_rows() SOCI_OVERRIDE;
+    int64_t get_affected_rows() SOCI_OVERRIDE;
     int get_number_of_rows() SOCI_OVERRIDE;
     std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
@@ -231,7 +231,7 @@ protected:
     int rowsFetched_;
     bool endOfRowSet_;
 
-    long long rowsAffectedBulk_; // number of rows affected by the last bulk operation
+    int64_t rowsAffectedBulk_; // number of rows affected by the last bulk operation
 
     virtual void exchangeData(bool gotData, int row);
     virtual void prepareSQLDA(XSQLDA ** sqldap, short size = 10);
@@ -291,7 +291,7 @@ struct firebird_blob_backend : details::blob_backend
 protected:
 
     virtual void open();
-    virtual long getBLOBInfo();
+    virtual int64_t getBLOBInfo();
     virtual void load();
     virtual void writeBuffer(std::size_t offset, char const * buf,
         std::size_t toWrite);
@@ -301,7 +301,7 @@ protected:
     std::vector<char> data_;
 
     bool loaded_;
-    long max_seg_size_;
+    int64_t max_seg_size_;
 };
 
 struct firebird_session_backend : details::session_backend
@@ -315,7 +315,7 @@ struct firebird_session_backend : details::session_backend
     void rollback() SOCI_OVERRIDE;
 
     bool get_next_sequence_value(session & s,
-        std::string const & sequence, long & value) SOCI_OVERRIDE;
+        std::string const & sequence, int64_t & value) SOCI_OVERRIDE;
 
     std::string get_dummy_from_table() const SOCI_OVERRIDE { return "rdb$database"; }
 

--- a/include/soci/mysql/soci-mysql.h
+++ b/include/soci/mysql/soci-mysql.h
@@ -151,7 +151,7 @@ struct mysql_statement_backend : details::statement_backend
     exec_fetch_result execute(int number) SOCI_OVERRIDE;
     exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    long long get_affected_rows() SOCI_OVERRIDE;
+    int64_t get_affected_rows() SOCI_OVERRIDE;
     int get_number_of_rows() SOCI_OVERRIDE;
     std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
@@ -177,7 +177,7 @@ struct mysql_statement_backend : details::statement_backend
     std::vector<std::string> queryChunks_;
     std::vector<std::string> names_; // list of names for named binds
 
-    long long rowsAffectedBulk_; // number of rows affected by the last bulk operation
+    int64_t rowsAffectedBulk_; // number of rows affected by the last bulk operation
 
     int numberOfRows_;  // number of rows retrieved from the server
     int currentRow_;    // "current" row number to consume in postFetch
@@ -239,7 +239,7 @@ struct mysql_session_backend : details::session_backend
     void commit() SOCI_OVERRIDE;
     void rollback() SOCI_OVERRIDE;
 
-    bool get_last_insert_id(session&, std::string const&, long&) SOCI_OVERRIDE;
+    bool get_last_insert_id(session&, std::string const&, int64_t&) SOCI_OVERRIDE;
 
     // Note that MySQL supports both "SELECT 2+2" and "SELECT 2+2 FROM DUAL"
     // syntaxes, but there doesn't seem to be any reason to use the longer one.

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -81,7 +81,7 @@ protected:
     };
 
     // IBM DB2 driver is not compliant to ODBC spec for indicators in 64bit
-    // SQLLEN is still defined 32bit (int) but spec requires 64bit (long)
+    // SQLLEN is still defined 32bit (int) but spec requires 64bit (int64_t)
     inline bool requires_noncompliant_32bit_sqllen() const;
     inline SQLLEN get_sqllen_from_value(const SQLLEN val) const;
     inline void set_sqllen_from_value(SQLLEN &target, const SQLLEN val) const;
@@ -141,7 +141,7 @@ struct odbc_vector_into_type_backend : details::vector_into_type_backend,
     void prepare_indicators(std::size_t size);
 
     // IBM DB2 driver is not compliant to ODBC spec for indicators in 64bit
-    // SQLLEN is still defined 32bit (int) but spec requires 64bit (long)
+    // SQLLEN is still defined 32bit (int) but spec requires 64bit (int64_t)
     inline SQLLEN get_sqllen_from_vector_at(std::size_t idx) const;
 
     SQLLEN *indHolders_;
@@ -222,7 +222,7 @@ struct odbc_vector_use_type_backend : details::vector_use_type_backend,
     void clean_up() SOCI_OVERRIDE;
 
     // IBM DB2 driver is not compliant to ODBC spec for indicators in 64bit
-    // SQLLEN is still defined 32bit (int) but spec requires 64bit (long)
+    // SQLLEN is still defined 32bit (int) but spec requires 64bit (int64_t)
     inline void set_sqllen_from_vector_at(const std::size_t idx, const SQLLEN val);
 
     SQLLEN *indHolders_;
@@ -248,7 +248,7 @@ struct odbc_statement_backend : details::statement_backend
     exec_fetch_result execute(int number) SOCI_OVERRIDE;
     exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    long long get_affected_rows() SOCI_OVERRIDE;
+    int64_t get_affected_rows() SOCI_OVERRIDE;
     int get_number_of_rows() SOCI_OVERRIDE;
     std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
@@ -273,7 +273,7 @@ struct odbc_statement_backend : details::statement_backend
     bool boundByName_;
     bool boundByPos_;
 
-    long long rowsAffected_; // number of rows affected by the last operation
+    int64_t rowsAffected_; // number of rows affected by the last operation
 
     std::string query_;
     std::vector<std::string> names_; // list of names for named binds
@@ -315,9 +315,9 @@ struct odbc_session_backend : details::session_backend
     void rollback() SOCI_OVERRIDE;
 
     bool get_next_sequence_value(session & s,
-        std::string const & sequence, long & value) SOCI_OVERRIDE;
+        std::string const & sequence, int64_t & value) SOCI_OVERRIDE;
     bool get_last_insert_id(session & s,
-        std::string const & table, long & value) SOCI_OVERRIDE;
+        std::string const & table, int64_t & value) SOCI_OVERRIDE;
 
     std::string get_dummy_from_table() const SOCI_OVERRIDE;
 
@@ -409,7 +409,7 @@ private:
             break;
 
           case SQL_SUCCESS_WITH_INFO:
-            socierror = "[SOCI]: Error message too long.";
+            socierror = "[SOCI]: Error message too int64_t.";
             break;
 
           case SQL_NO_DATA:

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -234,7 +234,7 @@ struct oracle_statement_backend : details::statement_backend
     exec_fetch_result execute(int number) SOCI_OVERRIDE;
     exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    long long get_affected_rows() SOCI_OVERRIDE;
+    int64_t get_affected_rows() SOCI_OVERRIDE;
     int get_number_of_rows() SOCI_OVERRIDE;
     std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -268,7 +268,7 @@ struct postgresql_statement_backend : details::statement_backend
     exec_fetch_result execute(int number) SOCI_OVERRIDE;
     exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    long long get_affected_rows() SOCI_OVERRIDE;
+    int64_t get_affected_rows() SOCI_OVERRIDE;
     int get_number_of_rows() SOCI_OVERRIDE;
     std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
@@ -293,7 +293,7 @@ struct postgresql_statement_backend : details::statement_backend
     std::string statementName_;
     std::vector<std::string> names_; // list of names for named binds
 
-    long long rowsAffectedBulk_; // number of rows affected by the last bulk operation
+    int64_t rowsAffectedBulk_; // number of rows affected by the last bulk operation
 
     int numberOfRows_;  // number of rows retrieved from the server
     int currentRow_;    // "current" row number to consume in postFetch
@@ -323,7 +323,7 @@ struct postgresql_rowid_backend : details::rowid_backend
 
     ~postgresql_rowid_backend() SOCI_OVERRIDE;
 
-    unsigned long value_;
+    uint64_t value_;
 };
 
 struct postgresql_blob_backend : details::blob_backend
@@ -358,7 +358,7 @@ struct postgresql_blob_backend : details::blob_backend
 
     postgresql_session_backend & session_;
 
-    unsigned long oid_; // oid of the large object
+    uint64_t oid_; // oid of the large object
     int fd_;            // descriptor of the large object
 };
 
@@ -378,7 +378,7 @@ struct postgresql_session_backend : details::session_backend
     void deallocate_prepared_statement(const std::string & statementName);
 
     bool get_next_sequence_value(session & s,
-        std::string const & sequence, long & value) SOCI_OVERRIDE;
+        std::string const & sequence, int64_t & value) SOCI_OVERRIDE;
 
     std::string get_dummy_from_table() const SOCI_OVERRIDE { return std::string(); }
 

--- a/include/soci/query_transformation.h
+++ b/include/soci/query_transformation.h
@@ -21,7 +21,7 @@ namespace details
 // any string-to-string transformation to SQL statement just
 // before it is executed.
 // Transformation procedure is specified by user,
-// be it a function or an arbitrary type as long as it
+// be it a function or an arbitrary type as int64_t as it
 // defines operator() with the appropriate signature:
 // unary function takes any type converible-to std::string
 // and returns std::string.

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -118,12 +118,12 @@ public:
     // the current backend doesn't support sequences. If you use sequences for
     // automatically generating primary key values, you should use
     // get_last_insert_id() after the insertion in this case.
-    bool get_next_sequence_value(std::string const & sequence, long & value);
+    bool get_next_sequence_value(std::string const & sequence, int64_t & value);
 
     // If true is returned, value is filled with the last auto-generated value
     // for this table (although some backends ignore the table argument and
     // return the last value auto-generated in this session).
-    bool get_last_insert_id(std::string const & table, long & value);
+    bool get_last_insert_id(std::string const & table, int64_t & value);
 
     // Returns once_temp_type for the internally composed query
     // for the list of tables in the current schema.

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -189,7 +189,7 @@ public:
     virtual exec_fetch_result execute(int number) = 0;
     virtual exec_fetch_result fetch(int number) = 0;
 
-    virtual long long get_affected_rows() = 0;
+    virtual int64_t get_affected_rows() = 0;
     virtual int get_number_of_rows() = 0;
 
     virtual std::string get_parameter_name(int index) const = 0;
@@ -271,11 +271,11 @@ public:
     // versions of them in the derived classes. However every backend should
     // define at least one of them to allow the code using auto-generated values
     // to work.
-    virtual bool get_next_sequence_value(session&, std::string const&, long&)
+    virtual bool get_next_sequence_value(session&, std::string const&, int64_t&)
     {
         return false;
     }
-    virtual bool get_last_insert_id(session&, std::string const&, long&)
+    virtual bool get_last_insert_id(session&, std::string const&, int64_t&)
     {
         return false;
     }

--- a/include/soci/soci-platform.h
+++ b/include/soci/soci-platform.h
@@ -25,8 +25,12 @@
 
 #if defined(_MSC_VER)
 #define LL_FMT_FLAGS "I64"
+#elif __WORDSIZE == 64
+#define LL_FMT_FLAGS "l"
+#define LLU_FMT_FLAGS "lu"
 #else
 #define LL_FMT_FLAGS "ll"
+#define LLU_FMT_FLAGS "llu"
 #endif
 
 // Portability hacks for Microsoft Visual C++ compiler
@@ -51,12 +55,12 @@
 # error "Visual C++ versions prior 1300 don't support _strtoi64 and _strtoui64"
 #elif _MSC_VER >= 1300 && _MSC_VER < 1800
 namespace std {
-    inline long long strtoll(char const* str, char** str_end, int base)
+    inline int64_t strtoll(char const* str, char** str_end, int base)
     {
         return _strtoi64(str, str_end, base);
     }
 
-    inline unsigned long long strtoull(char const* str, char** str_end, int base)
+    inline uint64_t strtoull(char const* str, char** str_end, int base)
     {
         return _strtoui64(str, str_end, base);
     }

--- a/include/soci/soci-simple.h
+++ b/include/soci/soci-simple.h
@@ -70,7 +70,7 @@ SOCI_DECL int soci_into_date_v     (statement_handle st);
 SOCI_DECL int          soci_get_into_state    (statement_handle st, int position);
 SOCI_DECL char const * soci_get_into_string   (statement_handle st, int position);
 SOCI_DECL int          soci_get_into_int      (statement_handle st, int position);
-SOCI_DECL long long    soci_get_into_long_long(statement_handle st, int position);
+SOCI_DECL int64_t         soci_get_into_long_long(statement_handle st, int position);
 SOCI_DECL double       soci_get_into_double   (statement_handle st, int position);
 SOCI_DECL char const * soci_get_into_date     (statement_handle st, int position);
 SOCI_DECL blob_handle  soci_get_into_blob     (statement_handle st, int position);
@@ -83,7 +83,7 @@ SOCI_DECL void soci_into_resize_v  (statement_handle st, int new_size);
 SOCI_DECL int          soci_get_into_state_v    (statement_handle st, int position, int index);
 SOCI_DECL char const * soci_get_into_string_v   (statement_handle st, int position, int index);
 SOCI_DECL int          soci_get_into_int_v      (statement_handle st, int position, int index);
-SOCI_DECL long long    soci_get_into_long_long_v(statement_handle st, int position, int index);
+SOCI_DECL int64_t         soci_get_into_long_long_v(statement_handle st, int position, int index);
 SOCI_DECL double       soci_get_into_double_v   (statement_handle st, int position, int index);
 SOCI_DECL char const * soci_get_into_date_v     (statement_handle st, int position, int index);
 
@@ -108,7 +108,7 @@ SOCI_DECL void soci_use_date_v     (statement_handle st, char const * name);
 SOCI_DECL void soci_set_use_state    (statement_handle st, char const * name, int state);
 SOCI_DECL void soci_set_use_string   (statement_handle st, char const * name, char const * val);
 SOCI_DECL void soci_set_use_int      (statement_handle st, char const * name, int val);
-SOCI_DECL void soci_set_use_long_long(statement_handle st, char const * name, long long val);
+SOCI_DECL void soci_set_use_long_long(statement_handle st, char const * name, int64_t val);
 SOCI_DECL void soci_set_use_double   (statement_handle st, char const * name, double val);
 SOCI_DECL void soci_set_use_date     (statement_handle st, char const * name, char const * val);
 SOCI_DECL void soci_set_use_blob     (statement_handle st, char const * name, blob_handle blob);
@@ -125,7 +125,7 @@ SOCI_DECL void soci_set_use_string_v(statement_handle st,
 SOCI_DECL void soci_set_use_int_v(statement_handle st,
     char const * name, int index, int val);
 SOCI_DECL void soci_set_use_long_long_v(statement_handle st,
-    char const * name, int index, long long val);
+    char const * name, int index, int64_t val);
 SOCI_DECL void soci_set_use_double_v(statement_handle st,
     char const * name, int index, double val);
 SOCI_DECL void soci_set_use_date_v(statement_handle st,
@@ -136,7 +136,7 @@ SOCI_DECL void soci_set_use_date_v(statement_handle st,
 SOCI_DECL int          soci_get_use_state    (statement_handle st, char const * name);
 SOCI_DECL char const * soci_get_use_string   (statement_handle st, char const * name);
 SOCI_DECL int          soci_get_use_int      (statement_handle st, char const * name);
-SOCI_DECL long long    soci_get_use_long_long(statement_handle st, char const * name);
+SOCI_DECL int64_t         soci_get_use_long_long(statement_handle st, char const * name);
 SOCI_DECL double       soci_get_use_double   (statement_handle st, char const * name);
 SOCI_DECL char const * soci_get_use_date     (statement_handle st, char const * name);
 SOCI_DECL blob_handle  soci_get_use_blob     (statement_handle st, char const * name);
@@ -145,7 +145,7 @@ SOCI_DECL blob_handle  soci_get_use_blob     (statement_handle st, char const * 
 // statement preparation and execution
 SOCI_DECL void      soci_prepare(statement_handle st, char const * query);
 SOCI_DECL int       soci_execute(statement_handle st, int withDataExchange);
-SOCI_DECL long long soci_get_affected_rows(statement_handle st);
+SOCI_DECL int64_t      soci_get_affected_rows(statement_handle st);
 SOCI_DECL int       soci_fetch(statement_handle st);
 SOCI_DECL int       soci_got_data(statement_handle st);
 

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -213,7 +213,7 @@ struct sqlite3_statement_backend : details::statement_backend
     exec_fetch_result execute(int number) SOCI_OVERRIDE;
     exec_fetch_result fetch(int number) SOCI_OVERRIDE;
 
-    long long get_affected_rows() SOCI_OVERRIDE;
+    int64_t get_affected_rows() SOCI_OVERRIDE;
     int get_number_of_rows() SOCI_OVERRIDE;
     std::string get_parameter_name(int index) const SOCI_OVERRIDE;
 
@@ -238,7 +238,7 @@ struct sqlite3_statement_backend : details::statement_backend
     sqlite3_column_info_list columns_;
 
 
-    long long rowsAffectedBulk_; // number of rows affected by the last bulk operation
+    int64_t rowsAffectedBulk_; // number of rows affected by the last bulk operation
 
 private:
     exec_fetch_result load_rowset(int totalRows);
@@ -252,7 +252,7 @@ struct sqlite3_rowid_backend : details::rowid_backend
 
     ~sqlite3_rowid_backend() SOCI_OVERRIDE;
 
-    unsigned long value_;
+    uint64_t value_;
 };
 
 struct sqlite3_blob_backend : details::blob_backend
@@ -289,7 +289,7 @@ struct sqlite3_session_backend : details::session_backend
     void commit() SOCI_OVERRIDE;
     void rollback() SOCI_OVERRIDE;
 
-    bool get_last_insert_id(session&, std::string const&, long&) SOCI_OVERRIDE;
+    bool get_last_insert_id(session&, std::string const&, int64_t&) SOCI_OVERRIDE;
 
     std::string empty_blob() SOCI_OVERRIDE
     {

--- a/include/soci/statement.h
+++ b/include/soci/statement.h
@@ -63,7 +63,7 @@ public:
     void define_and_bind();
     void undefine_and_bind();
     bool execute(bool withDataExchange = false);
-    long long get_affected_rows();
+    int64_t get_affected_rows();
     bool fetch();
     void describe();
     void set_row(row * r);
@@ -217,7 +217,7 @@ public:
         return gotData_;
     }
 
-    long long get_affected_rows()
+    int64_t get_affected_rows()
     {
         return impl_->get_affected_rows();
     }

--- a/include/soci/unsigned-types.h
+++ b/include/soci/unsigned-types.h
@@ -19,7 +19,7 @@ namespace soci
 template <>
 struct type_conversion<unsigned char>
 {
-    typedef long long base_type;
+    typedef int64_t base_type;
 
     static void from_base(base_type const & in, indicator ind,
         unsigned char & out)
@@ -50,7 +50,7 @@ struct type_conversion<unsigned char>
 template <>
 struct type_conversion<unsigned short>
 {
-    typedef long long base_type;
+    typedef int64_t base_type;
 
     static void from_base(base_type const & in, indicator ind,
         unsigned short & out)
@@ -60,8 +60,8 @@ struct type_conversion<unsigned short>
             throw soci_error("Null value not allowed for this type.");
         }
 
-        const long long max = (std::numeric_limits<unsigned short>::max)();
-        const long long min = (std::numeric_limits<unsigned short>::min)();
+        const int64_t max = (std::numeric_limits<unsigned short>::max)();
+        const int64_t min = (std::numeric_limits<unsigned short>::min)();
         if (in < min || in > max)
         {
             throw soci_error("Value outside of allowed range.");
@@ -81,7 +81,7 @@ struct type_conversion<unsigned short>
 template <>
 struct type_conversion<unsigned int>
 {
-    typedef long long base_type;
+    typedef int64_t base_type;
 
     static void from_base(base_type const & in, indicator ind,
         unsigned int & out)
@@ -91,8 +91,8 @@ struct type_conversion<unsigned int>
             throw soci_error("Null value not allowed for this type.");
         }
 
-        const long long max = (std::numeric_limits<unsigned int>::max)();
-        const long long min = (std::numeric_limits<unsigned int>::min)();
+        const int64_t max = (std::numeric_limits<unsigned int>::max)();
+        const int64_t min = (std::numeric_limits<unsigned int>::min)();
         if (in < min || in > max)
         {
             throw soci_error("Value outside of allowed range.");

--- a/include/soci/values.h
+++ b/include/soci/values.h
@@ -69,7 +69,7 @@ public:
         {
             std::ostringstream msg;
             msg << "Column at position "
-                << static_cast<unsigned long>(pos)
+                << static_cast<uint64_t>(pos)
                 << " contains NULL value and no default was provided";
             throw soci_error(msg.str());
         }
@@ -130,7 +130,7 @@ public:
         {
             std::ostringstream msg;
             msg << "Column at position "
-                << static_cast<unsigned long>(currentPos_)
+                << static_cast<uint64_t>(currentPos_)
                 << " contains NULL value and no default was provided";
             throw soci_error(msg.str());
         }
@@ -300,7 +300,7 @@ private:
         {
             std::ostringstream msg;
             msg << "Value at position "
-                << static_cast<unsigned long>(pos)
+                << static_cast<uint64_t>(pos)
                 << " was set using a different type"
                    " than the one passed to get()";
             throw soci_error(msg.str());

--- a/src/backends/db2/standard-into-type.cpp
+++ b/src/backends/db2/standard-into-type.cpp
@@ -55,11 +55,11 @@ void db2_standard_into_type_backend::define_by_pos(
         break;
     case x_long_long:
         cType = SQL_C_SBIGINT;
-        size = sizeof(long long);
+        size = sizeof(int64_t);
         break;
     case x_unsigned_long_long:
         cType = SQL_C_UBIGINT;
-        size = sizeof(unsigned long long);
+        size = sizeof(uint64_t);
         break;
     case x_double:
         cType = SQL_C_DOUBLE;
@@ -73,7 +73,7 @@ void db2_standard_into_type_backend::define_by_pos(
         break;
     case x_rowid:
         cType = SQL_C_UBIGINT;
-        size = sizeof(unsigned long long);
+        size = sizeof(uint64_t);
         break;
     default:
         throw soci_error("Into element used with non-supported type.");

--- a/src/backends/db2/standard-use-type.cpp
+++ b/src/backends/db2/standard-use-type.cpp
@@ -37,12 +37,12 @@ void *db2_standard_use_type_backend::prepare_for_bind(
     case x_long_long:
         sqlType = SQL_BIGINT;
         cType = SQL_C_SBIGINT;
-        size = sizeof(long long);
+        size = sizeof(int64_t);
         break;
     case x_unsigned_long_long:
         sqlType = SQL_BIGINT;
         cType = SQL_C_UBIGINT;
-        size = sizeof(unsigned long long);
+        size = sizeof(uint64_t);
         break;
     case x_double:
         sqlType = SQL_DOUBLE;

--- a/src/backends/db2/statement.cpp
+++ b/src/backends/db2/statement.cpp
@@ -184,7 +184,7 @@ db2_statement_backend::fetch(int  number )
     return ef_success;
 }
 
-long long db2_statement_backend::get_affected_rows()
+int64_t db2_statement_backend::get_affected_rows()
 {
     SQLLEN rows;
 

--- a/src/backends/db2/vector-into-type.cpp
+++ b/src/backends/db2/vector-into-type.cpp
@@ -63,10 +63,10 @@ void db2_vector_into_type_backend::define_by_pos(
     case x_long_long:
         {
             cType = SQL_C_SBIGINT;
-            size = sizeof(long long);
-            std::vector<long long> *vp
-                = static_cast<std::vector<long long> *>(data);
-            std::vector<long long> &v(*vp);
+            size = sizeof(int64_t);
+            std::vector<int64_t> *vp
+                = static_cast<std::vector<int64_t> *>(data);
+            std::vector<int64_t> &v(*vp);
             prepare_indicators(v.size());
             data = &v[0];
         }
@@ -74,10 +74,10 @@ void db2_vector_into_type_backend::define_by_pos(
     case x_unsigned_long_long:
         {
             cType = SQL_C_UBIGINT;
-            size = sizeof(unsigned long long);
-            std::vector<unsigned long long> *vp
-                = static_cast<std::vector<unsigned long long> *>(data);
-            std::vector<unsigned long long> &v(*vp);
+            size = sizeof(uint64_t);
+            std::vector<uint64_t> *vp
+                = static_cast<std::vector<uint64_t> *>(data);
+            std::vector<uint64_t> &v(*vp);
             prepare_indicators(v.size());
             data = &v[0];
         }
@@ -305,15 +305,15 @@ void db2_vector_into_type_backend::resize(std::size_t sz)
         break;
     case x_long_long:
         {
-            std::vector<long long> *v
-                = static_cast<std::vector<long long> *>(data);
+            std::vector<int64_t> *v
+                = static_cast<std::vector<int64_t> *>(data);
             v->resize(sz);
         }
         break;
     case x_unsigned_long_long:
         {
-            std::vector<unsigned long long> *v
-                = static_cast<std::vector<unsigned long long> *>(data);
+            std::vector<uint64_t> *v
+                = static_cast<std::vector<uint64_t> *>(data);
             v->resize(sz);
         }
         break;
@@ -373,15 +373,15 @@ std::size_t db2_vector_into_type_backend::size()
         break;
     case x_long_long:
         {
-            std::vector<long long> *v
-                = static_cast<std::vector<long long> *>(data);
+            std::vector<int64_t> *v
+                = static_cast<std::vector<int64_t> *>(data);
             sz = v->size();
         }
         break;
    case x_unsigned_long_long:
         {
-            std::vector<unsigned long long> *v
-                = static_cast<std::vector<unsigned long long> *>(data);
+            std::vector<uint64_t> *v
+                = static_cast<std::vector<uint64_t> *>(data);
             sz = v->size();
         }
         break;

--- a/src/backends/db2/vector-use-type.cpp
+++ b/src/backends/db2/vector-use-type.cpp
@@ -68,10 +68,10 @@ void db2_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &siz
         {
             sqlType = SQL_BIGINT;
             cType = SQL_C_SBIGINT;
-            size = sizeof(long long);
-            std::vector<long long> *vp
-                 = static_cast<std::vector<long long> *>(data);
-            std::vector<long long> &v(*vp);
+            size = sizeof(int64_t);
+            std::vector<int64_t> *vp
+                 = static_cast<std::vector<int64_t> *>(data);
+            std::vector<int64_t> &v(*vp);
             prepare_indicators(v.size());
             data = &v[0];
         }
@@ -80,10 +80,10 @@ void db2_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &siz
         {
             sqlType = SQL_BIGINT;
             cType = SQL_C_UBIGINT;
-            size = sizeof(unsigned long long);
-            std::vector<unsigned long long> *vp
-                 = static_cast<std::vector<unsigned long long> *>(data);
-            std::vector<unsigned long long> &v(*vp);
+            size = sizeof(uint64_t);
+            std::vector<uint64_t> *vp
+                 = static_cast<std::vector<uint64_t> *>(data);
+            std::vector<uint64_t> &v(*vp);
             prepare_indicators(v.size());
             data = &v[0];
         }
@@ -140,7 +140,7 @@ void db2_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &siz
             for (std::size_t i = 0; i != vecSize; ++i)
             {
                 std::size_t sz = v[i].length();
-                indVec[i] = static_cast<long>(sz);
+                indVec[i] = static_cast<int64_t>(sz);
                 maxSize = sz > maxSize ? sz : maxSize;
             }
 
@@ -348,15 +348,15 @@ std::size_t db2_vector_use_type_backend::size()
         break;
     case x_long_long:
         {
-            std::vector<long long> *vp
-                = static_cast<std::vector<long long> *>(data);
+            std::vector<int64_t> *vp
+                = static_cast<std::vector<int64_t> *>(data);
             sz = vp->size();
         }
         break;
     case x_unsigned_long_long:
         {
-            std::vector<unsigned long long> *vp
-                = static_cast<std::vector<unsigned long long> *>(data);
+            std::vector<uint64_t> *vp
+                = static_cast<std::vector<uint64_t> *>(data);
             sz = vp->size();
         }
         break;

--- a/src/backends/empty/statement.cpp
+++ b/src/backends/empty/statement.cpp
@@ -51,7 +51,7 @@ empty_statement_backend::fetch(int /* number */)
     return ef_success;
 }
 
-long long empty_statement_backend::get_affected_rows()
+int64_t empty_statement_backend::get_affected_rows()
 {
     // ...
     return -1;

--- a/src/backends/firebird/blob.cpp
+++ b/src/backends/firebird/blob.cpp
@@ -147,7 +147,7 @@ void firebird_blob_backend::open()
     }
 
     // get basic blob info
-    long blob_size = getBLOBInfo();
+    int64_t blob_size = getBLOBInfo();
 
     data_.resize(blob_size);
 }
@@ -273,12 +273,12 @@ void firebird_blob_backend::save()
 
 // retrives number of segments and total length of BLOB
 // returns total length of BLOB
-long firebird_blob_backend::getBLOBInfo()
+int64_t firebird_blob_backend::getBLOBInfo()
 {
     char blob_items[] = {isc_info_blob_max_segment, isc_info_blob_total_length};
     char res_buffer[20], *p, item;
     short length;
-    long total_length = 0;
+    int64_t total_length = 0;
 
     ISC_STATUS stat[20];
 

--- a/src/backends/firebird/common.cpp
+++ b/src/backends/firebird/common.cpp
@@ -98,7 +98,7 @@ void setTextParam(char const * s, std::size_t size, char * buf_,
         if (size > static_cast<std::size_t>(var->sqllen))
         {
             std::ostringstream msg;
-            msg << "Value \"" << s << "\" is too long ("
+            msg << "Value \"" << s << "\" is too int64_t ("
                 << size << " bytes) to be stored in column of size "
                 << var->sqllen << " bytes";
             throw soci_error(msg.str());
@@ -130,7 +130,7 @@ void setTextParam(char const * s, std::size_t size, char * buf_,
     }
     else if (sqltype == SQL_INT64)
     {
-        parse_decimal<long long, unsigned long long>(buf_, var, s);
+        parse_decimal<int64_t, uint64_t>(buf_, var, s);
     }
     else if (sqltype == SQL_TIMESTAMP
             || sqltype == SQL_TYPE_DATE)
@@ -206,7 +206,7 @@ std::string getTextParam(XSQLVAR const *var)
     }
     else if ((var->sqltype & ~1) == SQL_INT64)
     {
-        return format_decimal<long long>(var->sqldata, var->sqlscale);
+        return format_decimal<int64_t>(var->sqldata, var->sqlscale);
     }
     else
         throw soci_error("Unexpected string type");

--- a/src/backends/firebird/error-firebird.cpp
+++ b/src/backends/firebird/error-firebird.cpp
@@ -58,7 +58,7 @@ void get_iscerror_details(ISC_STATUS * status_vector, std::string &msg)
     }
 }
 
-bool check_iscerror(ISC_STATUS const * status_vector, long errNum)
+bool check_iscerror(ISC_STATUS const * status_vector, int64_t errNum)
 {
     std::size_t i=0;
     while (status_vector[i] != 0)

--- a/src/backends/firebird/session.cpp
+++ b/src/backends/firebird/session.cpp
@@ -344,7 +344,7 @@ void firebird_session_backend::cleanUp()
 }
 
 bool firebird_session_backend::get_next_sequence_value(
-    session & s, std::string const & sequence, long & value)
+    session & s, std::string const & sequence, int64_t & value)
 {
     // We could use isq_execute2() directly but this is even simpler.
     s << "select next value for " + sequence + " from rdb$database",

--- a/src/backends/firebird/standard-into-type.cpp
+++ b/src/backends/firebird/standard-into-type.cpp
@@ -82,7 +82,7 @@ void firebird_standard_into_type_backend::exchangeData()
             exchange_type_cast<x_integer>(data_) = from_isc<int>(var);
             break;
         case x_long_long:
-            exchange_type_cast<x_long_long>(data_) = from_isc<long long>(var);
+            exchange_type_cast<x_long_long>(data_) = from_isc<int64_t>(var);
             break;
         case x_double:
             exchange_type_cast<x_double>(data_) = from_isc<double>(var);

--- a/src/backends/firebird/standard-use-type.cpp
+++ b/src/backends/firebird/standard-use-type.cpp
@@ -114,7 +114,7 @@ void firebird_standard_use_type_backend::exchangeData()
             to_isc<int>(data_, var);
             break;
         case x_long_long:
-            to_isc<long long>(data_, var);
+            to_isc<int64_t>(data_, var);
             break;
         case x_double:
             to_isc<double>(data_, var);

--- a/src/backends/firebird/statement.cpp
+++ b/src/backends/firebird/statement.cpp
@@ -409,7 +409,7 @@ firebird_statement_backend::execute(int number)
 
     if (useType_ == eVector)
     {
-        long long rowsAffectedBulkTemp = 0;
+        int64_t rowsAffectedBulkTemp = 0;
 
         // Here we have to explicitly loop to achieve the
         // effect of inserting or updating with vector use elements.
@@ -562,7 +562,7 @@ void firebird_statement_backend::exchangeData(bool gotData, int row)
     }
 }
 
-long long firebird_statement_backend::get_affected_rows()
+int64_t firebird_statement_backend::get_affected_rows()
 {
     if (rowsAffectedBulk_ >= 0)
     {
@@ -597,7 +597,7 @@ long long firebird_statement_backend::get_affected_rows()
 
     // Examine the 4 sub-blocks each of which has a header indicating the block
     // type, its value length in bytes and the value itself.
-    long long row_count = 0;
+    int64_t row_count = 0;
 
     for ( char* p = sql_rec_buf; !row_count && p < sql_rec_buf + length; )
     {

--- a/src/backends/firebird/vector-into-type.cpp
+++ b/src/backends/firebird/vector-into-type.cpp
@@ -76,7 +76,7 @@ void firebird_vector_into_type_backend::exchangeData(std::size_t row)
         break;
     case x_long_long:
         {
-            long long tmp = from_isc<long long>(var);
+            int64_t tmp = from_isc<int64_t>(var);
             setIntoVector(data_, row, tmp);
         }
         break;
@@ -142,7 +142,7 @@ void firebird_vector_into_type_backend::resize(std::size_t sz)
         resizeVector<int> (data_, sz);
         break;
     case x_long_long:
-        resizeVector<long long> (data_, sz);
+        resizeVector<int64_t> (data_, sz);
         break;
     case x_double:
         resizeVector<double> (data_, sz);
@@ -175,7 +175,7 @@ std::size_t firebird_vector_into_type_backend::size()
         sz = getVectorSize<int> (data_);
         break;
     case x_long_long:
-        sz = getVectorSize<long long> (data_);
+        sz = getVectorSize<int64_t> (data_);
         break;
     case x_double:
         sz = getVectorSize<double> (data_);

--- a/src/backends/firebird/vector-use-type.cpp
+++ b/src/backends/firebird/vector-use-type.cpp
@@ -129,8 +129,8 @@ void firebird_vector_use_type_backend::exchangeData(std::size_t row)
             var);
         break;
     case x_long_long:
-        to_isc<long long>(
-            static_cast<void*>(getUseVectorValue<long long>(data_, row)),
+        to_isc<int64_t>(
+            static_cast<void*>(getUseVectorValue<int64_t>(data_, row)),
             var);
         break;
     case x_double:
@@ -174,7 +174,7 @@ std::size_t firebird_vector_use_type_backend::size()
         sz = getVectorSize<int> (data_);
         break;
     case x_long_long:
-        sz = getVectorSize<long long> (data_);
+        sz = getVectorSize<int64_t> (data_);
         break;
     case x_double:
         sz = getVectorSize<double> (data_);

--- a/src/backends/mysql/common.cpp
+++ b/src/backends/mysql/common.cpp
@@ -15,7 +15,7 @@ char * soci::details::mysql::quote(MYSQL * conn, const char *s, size_t len)
 {
     char *retv = new char[2 * len + 3];
     retv[0] = '\'';
-    int len_esc = mysql_real_escape_string(conn, retv + 1, s, static_cast<unsigned long>(len));
+    int len_esc = mysql_real_escape_string(conn, retv + 1, s, static_cast<uint64_t>(len));
     retv[len_esc + 1] = '\'';
     retv[len_esc + 2] = '\0';
 

--- a/src/backends/mysql/session.cpp
+++ b/src/backends/mysql/session.cpp
@@ -136,7 +136,7 @@ bool valid_int(const string & s)
     char *tail;
     const char *cstr = s.c_str();
     errno = 0;
-    long n = std::strtol(cstr, &tail, 10);
+    int64_t n = std::strtol(cstr, &tail, 10);
     if (errno != 0 || n > INT_MAX || n < INT_MIN)
     {
         return false;
@@ -153,7 +153,7 @@ bool valid_uint(const string & s)
     char *tail;
     const char *cstr = s.c_str();
     errno = 0;
-    unsigned long n = std::strtoul(cstr, &tail, 10);
+    uint64_t n = std::strtoul(cstr, &tail, 10);
     if (errno != 0 || n == 0 || n > UINT_MAX)
         return false;
     if (*tail != '\0')
@@ -435,7 +435,7 @@ namespace // unnamed
 void hard_exec(MYSQL *conn, const string & query)
 {
     if (0 != mysql_real_query(conn, query.c_str(),
-            static_cast<unsigned long>(query.size())))
+            static_cast<uint64_t>(query.size())))
     {
         //throw soci_error(mysql_error(conn));
         string errMsg = mysql_error(conn);
@@ -463,9 +463,9 @@ void mysql_session_backend::rollback()
 }
 
 bool mysql_session_backend::get_last_insert_id(
-    session & /* s */, std::string const & /* table */, long & value)
+    session & /* s */, std::string const & /* table */, int64_t & value)
 {
-    value = static_cast<long>(mysql_insert_id(conn_));
+    value = static_cast<int64_t>(mysql_insert_id(conn_));
 
     return true;
 }

--- a/src/backends/mysql/standard-into-type.cpp
+++ b/src/backends/mysql/standard-into-type.cpp
@@ -84,7 +84,7 @@ void mysql_standard_into_type_backend::post_fetch(
         case x_stdstring:
             {
                 std::string& dest = exchange_type_cast<x_stdstring>(data_);
-                unsigned long * lengths =
+                unsigned long* lengths =
                     mysql_fetch_lengths(statement_.result_);
                 dest.assign(buf, lengths[pos]);
             }

--- a/src/backends/mysql/standard-use-type.cpp
+++ b/src/backends/mysql/standard-use-type.cpp
@@ -84,7 +84,7 @@ void mysql_standard_use_type_backend::pre_use(indicator const *ind)
         case x_long_long:
             {
                 std::size_t const bufSize
-                    = std::numeric_limits<long long>::digits10 + 3;
+                    = std::numeric_limits<int64_t>::digits10 + 3;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%" LL_FMT_FLAGS "d", exchange_type_cast<x_long_long>(data_));
             }
@@ -92,7 +92,7 @@ void mysql_standard_use_type_backend::pre_use(indicator const *ind)
         case x_unsigned_long_long:
             {
                 std::size_t const bufSize
-                    = std::numeric_limits<unsigned long long>::digits10 + 3;
+                    = std::numeric_limits<uint64_t>::digits10 + 3;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%" LL_FMT_FLAGS "u",
                          exchange_type_cast<x_unsigned_long_long>(data_));

--- a/src/backends/mysql/statement.cpp
+++ b/src/backends/mysql/statement.cpp
@@ -163,7 +163,7 @@ mysql_statement_backend::execute(int number)
                     "Binding for use elements must be either by position "
                     "or by name.");
             }
-            long long rowsAffectedBulkTemp = -1;
+            int64_t rowsAffectedBulkTemp = -1;
             for (int i = 0; i != numberOfExecutions; ++i)
             {
                 std::vector<char *> paramValues;
@@ -232,7 +232,7 @@ mysql_statement_backend::execute(int number)
                     // bulk operation
                     //std::cerr << "bulk operation:\n" << query << std::endl;
                     if (0 != mysql_real_query(session_.conn_, query.c_str(),
-                            static_cast<unsigned long>(query.size())))
+                            static_cast<uint64_t>(query.size())))
                     {
                         // preserve the number of rows affected so far.
                         rowsAffectedBulk_ = rowsAffectedBulkTemp;
@@ -245,7 +245,7 @@ mysql_statement_backend::execute(int number)
                         {
                             rowsAffectedBulkTemp = 0;
                         }
-                        rowsAffectedBulkTemp += static_cast<long long>(mysql_affected_rows(session_.conn_));
+                        rowsAffectedBulkTemp += static_cast<int64_t>(mysql_affected_rows(session_.conn_));
                     }
                     if (mysql_field_count(session_.conn_) != 0)
                     {
@@ -269,7 +269,7 @@ mysql_statement_backend::execute(int number)
 
         //std::cerr << query << std::endl;
         if (0 != mysql_real_query(session_.conn_, query.c_str(),
-                static_cast<unsigned long>(query.size())))
+                static_cast<uint64_t>(query.size())))
         {
             throw mysql_soci_error(mysql_error(session_.conn_),
                 mysql_errno(session_.conn_));
@@ -365,13 +365,13 @@ mysql_statement_backend::fetch(int number)
     }
 }
 
-long long mysql_statement_backend::get_affected_rows()
+int64_t mysql_statement_backend::get_affected_rows()
 {
     if (rowsAffectedBulk_ >= 0)
     {
         return rowsAffectedBulk_;
     }
-    return static_cast<long long>(mysql_affected_rows(session_.conn_));
+    return static_cast<int64_t>(mysql_affected_rows(session_.conn_));
 }
 
 int mysql_statement_backend::get_number_of_rows()

--- a/src/backends/mysql/vector-into-type.cpp
+++ b/src/backends/mysql/vector-into-type.cpp
@@ -97,7 +97,7 @@ void mysql_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
                 break;
             case x_stdstring:
                 {
-                    unsigned long * lengths =
+                    unsigned long* lengths =
                         mysql_fetch_lengths(statement_.result_);
                     // Not sure if it's necessary, but the code below is used
                     // instead of
@@ -124,14 +124,14 @@ void mysql_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
                 break;
             case x_long_long:
                 {
-                    long long val;
+                    int64_t val;
                     parse_num(buf, val);
                     set_invector_(data_, i, val);
                 }
                 break;
             case x_unsigned_long_long:
                 {
-                    unsigned long long val;
+                    uint64_t val;
                     parse_num(buf, val);
                     set_invector_(data_, i, val);
                 }
@@ -184,9 +184,9 @@ void mysql_vector_into_type_backend::resize(std::size_t sz)
     case x_char:         resizevector_<char>         (data_, sz); break;
     case x_short:        resizevector_<short>        (data_, sz); break;
     case x_integer:      resizevector_<int>          (data_, sz); break;
-    case x_long_long:     resizevector_<long long>    (data_, sz); break;
+    case x_long_long:     resizevector_<int64_t>    (data_, sz); break;
     case x_unsigned_long_long:
-        resizevector_<unsigned long long>(data_, sz);
+        resizevector_<uint64_t>(data_, sz);
         break;
     case x_double:       resizevector_<double>       (data_, sz); break;
     case x_stdstring:    resizevector_<std::string>  (data_, sz); break;
@@ -206,9 +206,9 @@ std::size_t mysql_vector_into_type_backend::size()
     case x_char:         sz = get_vector_size<char>         (data_); break;
     case x_short:        sz = get_vector_size<short>        (data_); break;
     case x_integer:      sz = get_vector_size<int>          (data_); break;
-    case x_long_long:     sz = get_vector_size<long long>    (data_); break;
+    case x_long_long:     sz = get_vector_size<int64_t>    (data_); break;
     case x_unsigned_long_long:
-        sz = get_vector_size<unsigned long long>(data_);
+        sz = get_vector_size<uint64_t>(data_);
         break;
     case x_double:       sz = get_vector_size<double>       (data_); break;
     case x_stdstring:    sz = get_vector_size<std::string>  (data_); break;

--- a/src/backends/mysql/vector-use-type.cpp
+++ b/src/backends/mysql/vector-use-type.cpp
@@ -107,24 +107,24 @@ void mysql_vector_use_type_backend::pre_use(indicator const *ind)
                 break;
             case x_long_long:
                 {
-                    std::vector<long long> *pv
-                        = static_cast<std::vector<long long> *>(data_);
-                    std::vector<long long> &v = *pv;
+                    std::vector<int64_t> *pv
+                        = static_cast<std::vector<int64_t> *>(data_);
+                    std::vector<int64_t> &v = *pv;
 
                     std::size_t const bufSize
-                        = std::numeric_limits<long long>::digits10 + 3;
+                        = std::numeric_limits<int64_t>::digits10 + 3;
                     buf = new char[bufSize];
                     snprintf(buf, bufSize, "%" LL_FMT_FLAGS "d", v[i]);
                 }
                 break;
             case x_unsigned_long_long:
                 {
-                    std::vector<unsigned long long> *pv
-                        = static_cast<std::vector<unsigned long long> *>(data_);
-                    std::vector<unsigned long long> &v = *pv;
+                    std::vector<uint64_t> *pv
+                        = static_cast<std::vector<uint64_t> *>(data_);
+                    std::vector<uint64_t> &v = *pv;
 
                     std::size_t const bufSize
-                        = std::numeric_limits<unsigned long long>::digits10 + 3;
+                        = std::numeric_limits<uint64_t>::digits10 + 3;
                     buf = new char[bufSize];
                     snprintf(buf, bufSize, "%" LL_FMT_FLAGS "u", v[i]);
                 }
@@ -192,9 +192,9 @@ std::size_t mysql_vector_use_type_backend::size()
     case x_char:         sz = get_vector_size<char>         (data_); break;
     case x_short:        sz = get_vector_size<short>        (data_); break;
     case x_integer:      sz = get_vector_size<int>          (data_); break;
-    case x_long_long:    sz = get_vector_size<long long>    (data_); break;
+    case x_long_long:    sz = get_vector_size<int64_t>    (data_); break;
     case x_unsigned_long_long:
-        sz = get_vector_size<unsigned long long>(data_);
+        sz = get_vector_size<uint64_t>(data_);
         break;
     case x_double:       sz = get_vector_size<double>       (data_); break;
     case x_stdstring:    sz = get_vector_size<std::string>  (data_); break;

--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -152,7 +152,7 @@ void odbc_session_backend::configure_connection()
         };
 
         // Also configure the driver to handle unknown types, such as "xml",
-        // that we use for x_xmltype, as long varchar instead of limiting them
+        // that we use for x_xmltype, as int64_t varchar instead of limiting them
         // to 256 characters (by default).
         rc = SQLSetConnectAttr(hdbc_, SQL_ATTR_PGOPT_UNKNOWNSASLONGVARCHAR, (SQLPOINTER)1, 0);
 
@@ -200,7 +200,7 @@ void odbc_session_backend::rollback()
 }
 
 bool odbc_session_backend::get_next_sequence_value(
-    session & s, std::string const & sequence, long & value)
+    session & s, std::string const & sequence, int64_t & value)
 {
     std::string query;
 
@@ -245,7 +245,7 @@ bool odbc_session_backend::get_next_sequence_value(
 }
 
 bool odbc_session_backend::get_last_insert_id(
-    session & s, std::string const & table, long & value)
+    session & s, std::string const & table, int64_t & value)
 {
     std::string query;
 

--- a/src/backends/odbc/standard-into-type.cpp
+++ b/src/backends/odbc/standard-into-type.cpp
@@ -63,7 +63,7 @@ void odbc_standard_into_type_backend::define_by_pos(
         else // Normal case, use ODBC support.
         {
           odbcType_ = SQL_C_SBIGINT;
-          size = sizeof(long long);
+          size = sizeof(int64_t);
         }
         break;
     case x_unsigned_long_long:
@@ -77,7 +77,7 @@ void odbc_standard_into_type_backend::define_by_pos(
         else // Normal case, use ODBC support.
         {
           odbcType_ = SQL_C_UBIGINT;
-          size = sizeof(unsigned long long);
+          size = sizeof(uint64_t);
         }
         break;
     case x_double:
@@ -92,7 +92,7 @@ void odbc_standard_into_type_backend::define_by_pos(
         break;
     case x_rowid:
         odbcType_ = SQL_C_ULONG;
-        size = sizeof(unsigned long);
+        size = sizeof(uint64_t);
         break;
     default:
         throw soci_error("Into element used with non-supported type.");
@@ -181,7 +181,7 @@ void odbc_standard_into_type_backend::post_fetch(
         }
         else if (type_ == x_long_long && use_string_for_bigint())
         {
-          long long& ll = exchange_type_cast<x_long_long>(data_);
+          int64_t& ll = exchange_type_cast<x_long_long>(data_);
           if (sscanf(buf_, "%" LL_FMT_FLAGS "d", &ll) != 1)
           {
             throw soci_error("Failed to parse the returned 64-bit integer value");
@@ -189,7 +189,7 @@ void odbc_standard_into_type_backend::post_fetch(
         }
         else if (type_ == x_unsigned_long_long && use_string_for_bigint())
         {
-          unsigned long long& ll = exchange_type_cast<x_unsigned_long_long>(data_);
+          uint64_t& ll = exchange_type_cast<x_unsigned_long_long>(data_);
           if (sscanf(buf_, "%" LL_FMT_FLAGS "u", &ll) != 1)
           {
             throw soci_error("Failed to parse the returned 64-bit integer value");

--- a/src/backends/odbc/standard-use-type.cpp
+++ b/src/backends/odbc/standard-use-type.cpp
@@ -47,7 +47,7 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
         {
           sqlType = SQL_BIGINT;
           cType = SQL_C_SBIGINT;
-          size = sizeof(long long);
+          size = sizeof(int64_t);
         }
         break;
     case x_unsigned_long_long:
@@ -65,7 +65,7 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
         {
           sqlType = SQL_BIGINT;
           cType = SQL_C_UBIGINT;
-          size = sizeof(unsigned long long);
+          size = sizeof(uint64_t);
         }
         break;
     case x_double:

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -235,7 +235,7 @@ odbc_statement_backend::fetch(int number)
     return ef_success;
 }
 
-long long odbc_statement_backend::get_affected_rows()
+int64_t odbc_statement_backend::get_affected_rows()
 {
     return rowsAffected_;
 }

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -65,9 +65,9 @@ void odbc_vector_into_type_backend::define_by_pos(
         break;
     case x_long_long:
         {
-            std::vector<long long> *vp =
-                static_cast<std::vector<long long> *>(data);
-            std::vector<long long> &v(*vp);
+            std::vector<int64_t> *vp =
+                static_cast<std::vector<int64_t> *>(data);
+            std::vector<int64_t> &v(*vp);
             prepare_indicators(v.size());
             if (use_string_for_bigint())
             {
@@ -81,16 +81,16 @@ void odbc_vector_into_type_backend::define_by_pos(
             else // Normal case, use ODBC support.
             {
                 odbcType_ = SQL_C_SBIGINT;
-                size = sizeof(long long);
+                size = sizeof(int64_t);
                 data = &v[0];
             }
         }
         break;
     case x_unsigned_long_long:
         {
-            std::vector<unsigned long long> *vp =
-                static_cast<std::vector<unsigned long long> *>(data);
-            std::vector<unsigned long long> &v(*vp);
+            std::vector<uint64_t> *vp =
+                static_cast<std::vector<uint64_t> *>(data);
+            std::vector<uint64_t> &v(*vp);
             prepare_indicators(v.size());
             if (use_string_for_bigint())
             {
@@ -104,7 +104,7 @@ void odbc_vector_into_type_backend::define_by_pos(
             else // Normal case, use ODBC support.
             {
                 odbcType_ = SQL_C_UBIGINT;
-                size = sizeof(unsigned long long);
+                size = sizeof(uint64_t);
                 data = &v[0];
             }
         }
@@ -278,9 +278,9 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
         }
         else if (type_ == x_long_long && use_string_for_bigint())
         {
-            std::vector<long long> *vp
-                = static_cast<std::vector<long long> *>(data_);
-            std::vector<long long> &v(*vp);
+            std::vector<int64_t> *vp
+                = static_cast<std::vector<int64_t> *>(data_);
+            std::vector<int64_t> &v(*vp);
             char *pos = buf_;
             std::size_t const vsize = v.size();
             for (std::size_t i = 0; i != vsize; ++i)
@@ -294,9 +294,9 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
         }
         else if (type_ == x_unsigned_long_long && use_string_for_bigint())
         {
-            std::vector<unsigned long long> *vp
-                = static_cast<std::vector<unsigned long long> *>(data_);
-            std::vector<unsigned long long> &v(*vp);
+            std::vector<uint64_t> *vp
+                = static_cast<std::vector<uint64_t> *>(data_);
+            std::vector<uint64_t> &v(*vp);
             char *pos = buf_;
             std::size_t const vsize = v.size();
             for (std::size_t i = 0; i != vsize; ++i)
@@ -377,15 +377,15 @@ void odbc_vector_into_type_backend::resize(std::size_t sz)
         break;
     case x_long_long:
         {
-            std::vector<long long> *v =
-                static_cast<std::vector<long long> *>(data_);
+            std::vector<int64_t> *v =
+                static_cast<std::vector<int64_t> *>(data_);
             v->resize(sz);
         }
         break;
     case x_unsigned_long_long:
         {
-            std::vector<unsigned long long> *v =
-                static_cast<std::vector<unsigned long long> *>(data_);
+            std::vector<uint64_t> *v =
+                static_cast<std::vector<uint64_t> *>(data_);
             v->resize(sz);
         }
         break;
@@ -442,15 +442,15 @@ std::size_t odbc_vector_into_type_backend::size()
         break;
     case x_long_long:
         {
-            std::vector<long long> *v =
-                static_cast<std::vector<long long> *>(data_);
+            std::vector<int64_t> *v =
+                static_cast<std::vector<int64_t> *>(data_);
             sz = v->size();
         }
         break;
     case x_unsigned_long_long:
         {
-            std::vector<unsigned long long> *v =
-                static_cast<std::vector<unsigned long long> *>(data_);
+            std::vector<uint64_t> *v =
+                static_cast<std::vector<uint64_t> *>(data_);
             sz = v->size();
         }
         break;

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -66,9 +66,9 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
         break;
     case x_long_long:
         {
-            std::vector<long long> *vp =
-                static_cast<std::vector<long long> *>(data);
-            std::vector<long long> &v(*vp);
+            std::vector<int64_t> *vp =
+                static_cast<std::vector<int64_t> *>(data);
+            std::vector<int64_t> &v(*vp);
             std::size_t const vsize = v.size();
             prepare_indicators(vsize);
 
@@ -84,16 +84,16 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
             {
                 sqlType = SQL_BIGINT;
                 cType = SQL_C_SBIGINT;
-                size = sizeof(long long);
+                size = sizeof(int64_t);
                 data = &v[0];
             }
         }
         break;
     case x_unsigned_long_long:
         {
-            std::vector<unsigned long long> *vp =
-                static_cast<std::vector<unsigned long long> *>(data);
-            std::vector<unsigned long long> &v(*vp);
+            std::vector<uint64_t> *vp =
+                static_cast<std::vector<uint64_t> *>(data);
+            std::vector<uint64_t> &v(*vp);
             std::size_t const vsize = v.size();
             prepare_indicators(vsize);
 
@@ -109,7 +109,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
             {
                 sqlType = SQL_BIGINT;
                 cType = SQL_C_SBIGINT;
-                size = sizeof(unsigned long long);
+                size = sizeof(uint64_t);
                 data = &v[0];
             }
         }
@@ -166,7 +166,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
             for (std::size_t i = 0; i != vecSize; ++i)
             {
                 std::size_t sz = v[i].length();
-                set_sqllen_from_vector_at(i, static_cast<long>(sz));
+                set_sqllen_from_vector_at(i, static_cast<int64_t>(sz));
                 maxSize = sz > maxSize ? sz : maxSize;
             }
 
@@ -335,9 +335,9 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
         case x_long_long:
             if (use_string_for_bigint())
             {
-                std::vector<long long> *vp
-                     = static_cast<std::vector<long long> *>(data_);
-                std::vector<long long> &v(*vp);
+                std::vector<int64_t> *vp
+                     = static_cast<std::vector<int64_t> *>(data_);
+                std::vector<int64_t> &v(*vp);
 
                 char *pos = buf_;
                 std::size_t const vsize = v.size();
@@ -354,9 +354,9 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
         case x_unsigned_long_long:
             if (use_string_for_bigint())
             {
-                std::vector<unsigned long long> *vp
-                     = static_cast<std::vector<unsigned long long> *>(data_);
-                std::vector<unsigned long long> &v(*vp);
+                std::vector<uint64_t> *vp
+                     = static_cast<std::vector<uint64_t> *>(data_);
+                std::vector<uint64_t> &v(*vp);
 
                 char *pos = buf_;
                 std::size_t const vsize = v.size();
@@ -443,15 +443,15 @@ std::size_t odbc_vector_use_type_backend::size()
         break;
     case x_long_long:
         {
-            std::vector<long long> *vp =
-                static_cast<std::vector<long long> *>(data_);
+            std::vector<int64_t> *vp =
+                static_cast<std::vector<int64_t> *>(data_);
             sz = vp->size();
         }
         break;
     case x_unsigned_long_long:
         {
-            std::vector<unsigned long long> *vp =
-                static_cast<std::vector<unsigned long long> *>(data_);
+            std::vector<uint64_t> *vp =
+                static_cast<std::vector<uint64_t> *>(data_);
             sz = vp->size();
         }
         break;

--- a/src/backends/oracle/session.cpp
+++ b/src/backends/oracle/session.cpp
@@ -219,7 +219,7 @@ oracle_session_backend::oracle_session_backend(std::string const & serviceName,
         }
         else
         {
-            throw soci_error("Service name is too long.");
+            throw soci_error("Service name is too int64_t.");
         }
 
         nlsUserNameLen = userName.size();
@@ -229,7 +229,7 @@ oracle_session_backend::oracle_session_backend(std::string const & serviceName,
         }
         else
         {
-            throw soci_error("User name is too long.");
+            throw soci_error("User name is too int64_t.");
         }
 
         nlsPasswordLen = password.size();
@@ -239,7 +239,7 @@ oracle_session_backend::oracle_session_backend(std::string const & serviceName,
         }
         else
         {
-            throw soci_error("Password is too long.");
+            throw soci_error("Password is too int64_t.");
         }
     }
     

--- a/src/backends/oracle/standard-use-type.cpp
+++ b/src/backends/oracle/standard-use-type.cpp
@@ -460,8 +460,8 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
         case x_long_long:
             if (readOnly_)
             {
-                long long const original = exchange_type_cast<x_long_long>(data_);
-                long long const bound = std::strtoll(buf_, NULL, 10);
+                int64_t const original = exchange_type_cast<x_long_long>(data_);
+                int64_t const bound = std::strtoll(buf_, NULL, 10);
 
                 if (original != bound)
                 {
@@ -472,8 +472,8 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
         case x_unsigned_long_long:
             if (readOnly_)
             {
-                unsigned long long const original = exchange_type_cast<x_unsigned_long_long>(data_);
-                unsigned long long const bound = std::strtoull(buf_, NULL, 10);
+                uint64_t const original = exchange_type_cast<x_unsigned_long_long>(data_);
+                uint64_t const bound = std::strtoull(buf_, NULL, 10);
 
                 if (original != bound)
                 {

--- a/src/backends/oracle/statement.cpp
+++ b/src/backends/oracle/statement.cpp
@@ -117,7 +117,7 @@ statement_backend::exec_fetch_result oracle_statement_backend::fetch(int number)
     }
 }
 
-long long oracle_statement_backend::get_affected_rows()
+int64_t oracle_statement_backend::get_affected_rows()
 {
     ub4 row_count;
     sword res = OCIAttrGet(static_cast<dvoid*>(stmtp_),

--- a/src/backends/oracle/vector-into-type.cpp
+++ b/src/backends/oracle/vector-into-type.cpp
@@ -187,7 +187,7 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator * ind)
     {
         // first, deal with data
 
-        // only std::string, std::tm, long long and Statement need special handling
+        // only std::string, std::tm, int64_t and Statement need special handling
         if (type_ == x_stdstring)
         {
             std::vector<std::string> *vp
@@ -208,10 +208,10 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator * ind)
         }
         else if (type_ == x_long_long)
         {
-            std::vector<long long> *vp
-                = static_cast<std::vector<long long> *>(data_);
+            std::vector<int64_t> *vp
+                = static_cast<std::vector<int64_t> *>(data_);
 
-            std::vector<long long> &v(*vp);
+            std::vector<int64_t> &v(*vp);
 
             char *pos = buf_;
             std::size_t const vecSize = size();
@@ -226,10 +226,10 @@ void oracle_vector_into_type_backend::post_fetch(bool gotData, indicator * ind)
         }
         else if (type_ == x_unsigned_long_long)
         {
-            std::vector<unsigned long long> *vp
-                = static_cast<std::vector<unsigned long long> *>(data_);
+            std::vector<uint64_t> *vp
+                = static_cast<std::vector<uint64_t> *>(data_);
 
-            std::vector<unsigned long long> &v(*vp);
+            std::vector<uint64_t> &v(*vp);
 
             char *pos = buf_;
             std::size_t const vecSize = size();
@@ -349,15 +349,15 @@ void oracle_vector_into_type_backend::resize(std::size_t sz)
             break;
         case x_long_long:
             {
-                std::vector<long long> *v
-                    = static_cast<std::vector<long long> *>(data_);
+                std::vector<int64_t> *v
+                    = static_cast<std::vector<int64_t> *>(data_);
                 v->resize(sz);
             }
             break;
         case x_unsigned_long_long:
             {
-                std::vector<unsigned long long> *v
-                    = static_cast<std::vector<unsigned long long> *>(data_);
+                std::vector<uint64_t> *v
+                    = static_cast<std::vector<uint64_t> *>(data_);
                 v->resize(sz);
             }
             break;
@@ -444,15 +444,15 @@ std::size_t oracle_vector_into_type_backend::full_size()
         break;
     case x_long_long:
         {
-            std::vector<long long> *v
-                = static_cast<std::vector<long long> *>(data_);
+            std::vector<int64_t> *v
+                = static_cast<std::vector<int64_t> *>(data_);
             sz = v->size();
         }
         break;
     case x_unsigned_long_long:
         {
-            std::vector<unsigned long long> *v
-                = static_cast<std::vector<unsigned long long> *>(data_);
+            std::vector<uint64_t> *v
+                = static_cast<std::vector<uint64_t> *>(data_);
             sz = v->size();
         }
         break;

--- a/src/backends/oracle/vector-use-type.cpp
+++ b/src/backends/oracle/vector-use-type.cpp
@@ -242,9 +242,9 @@ void oracle_vector_use_type_backend::pre_use(indicator const *ind)
     }
     else if (type_ == x_long_long)
     {
-        std::vector<long long> *vp
-            = static_cast<std::vector<long long> *>(data_);
-        std::vector<long long> &v(*vp);
+        std::vector<int64_t> *vp
+            = static_cast<std::vector<int64_t> *>(data_);
+        std::vector<int64_t> &v(*vp);
 
         char *pos = buf_;
         std::size_t const entrySize = 100; // arbitrary, but consistent
@@ -257,9 +257,9 @@ void oracle_vector_use_type_backend::pre_use(indicator const *ind)
     }
     else if (type_ == x_unsigned_long_long)
     {
-        std::vector<unsigned long long> *vp
-            = static_cast<std::vector<unsigned long long> *>(data_);
-        std::vector<unsigned long long> &v(*vp);
+        std::vector<uint64_t> *vp
+            = static_cast<std::vector<uint64_t> *>(data_);
+        std::vector<uint64_t> &v(*vp);
 
         char *pos = buf_;
         std::size_t const entrySize = 100; // arbitrary, but consistent
@@ -366,15 +366,15 @@ std::size_t oracle_vector_use_type_backend::full_size()
         break;
     case x_long_long:
         {
-            std::vector<long long> *vp
-                = static_cast<std::vector<long long> *>(data_);
+            std::vector<int64_t> *vp
+                = static_cast<std::vector<int64_t> *>(data_);
             sz = vp->size();
         }
         break;
     case x_unsigned_long_long:
         {
-            std::vector<unsigned long long> *vp
-                = static_cast<std::vector<unsigned long long> *>(data_);
+            std::vector<uint64_t> *vp
+                = static_cast<std::vector<uint64_t> *>(data_);
             sz = vp->size();
         }
         break;

--- a/src/backends/postgresql/common.h
+++ b/src/backends/postgresql/common.h
@@ -28,18 +28,18 @@ namespace postgresql
 template <typename T>
 T string_to_integer(char const * buf)
 {
-    long long t(0);
+    int64_t t(0);
     int n(0);
     int const converted = std::sscanf(buf, "%" LL_FMT_FLAGS "d%n", &t, &n);
     if (converted == 1 && static_cast<std::size_t>(n) == std::strlen(buf))
     {
-        // successfully converted to long long
+        // successfully converted to int64_t
         // and no other characters were found in the buffer
 
         const T max = (std::numeric_limits<T>::max)();
         const T min = (std::numeric_limits<T>::min)();
-        if (t <= static_cast<long long>(max) &&
-            t >= static_cast<long long>(min))
+        if (t <= static_cast<int64_t>(max) &&
+            t >= static_cast<int64_t>(min))
         {
             return static_cast<T>(t);
         }
@@ -73,16 +73,16 @@ T string_to_integer(char const * buf)
 template <typename T>
 T string_to_unsigned_integer(char const * buf)
 {
-    unsigned long long t(0);
+    uint64_t t(0);
     int n(0);
     int const converted = std::sscanf(buf, "%" LL_FMT_FLAGS "u%n", &t, &n);
     if (converted == 1 && static_cast<std::size_t>(n) == std::strlen(buf))
     {
-        // successfully converted to unsigned long long
+        // successfully converted to uint64_t
         // and no other characters were found in the buffer
 
         const T max = (std::numeric_limits<T>::max)();
-        if (t <= static_cast<unsigned long long>(max))
+        if (t <= static_cast<uint64_t>(max))
         {
             return static_cast<T>(t);
         }

--- a/src/backends/postgresql/session.cpp
+++ b/src/backends/postgresql/session.cpp
@@ -101,7 +101,7 @@ void postgresql_session_backend::deallocate_prepared_statement(
 }
 
 bool postgresql_session_backend::get_next_sequence_value(
-    session & s, std::string const & sequence, long & value)
+    session & s, std::string const & sequence, int64_t & value)
 {
     s << "select nextval('" + sequence + "')", into(value);
 

--- a/src/backends/postgresql/standard-into-type.cpp
+++ b/src/backends/postgresql/standard-into-type.cpp
@@ -97,10 +97,10 @@ void postgresql_standard_into_type_backend::post_fetch(
             exchange_type_cast<x_integer>(data_) = string_to_integer<int>(buf);
             break;
         case x_long_long:
-            exchange_type_cast<x_long_long>(data_) = string_to_integer<long long>(buf);
+            exchange_type_cast<x_long_long>(data_) = string_to_integer<int64_t>(buf);
             break;
         case x_unsigned_long_long:
-            exchange_type_cast<x_unsigned_long_long>(data_) = string_to_unsigned_integer<unsigned long long>(buf);
+            exchange_type_cast<x_unsigned_long_long>(data_) = string_to_unsigned_integer<uint64_t>(buf);
             break;
         case x_double:
             exchange_type_cast<x_double>(data_) = cstring_to_double(buf);
@@ -111,20 +111,20 @@ void postgresql_standard_into_type_backend::post_fetch(
             break;
         case x_rowid:
             {
-                // RowID is internally identical to unsigned long
+                // RowID is internally identical to uint64_t
 
                 rowid * rid = static_cast<rowid *>(data_);
                 postgresql_rowid_backend * rbe
                     = static_cast<postgresql_rowid_backend *>(
                         rid->get_backend());
 
-                rbe->value_ = string_to_unsigned_integer<unsigned long>(buf);
+                rbe->value_ = string_to_unsigned_integer<uint64_t>(buf);
             }
             break;
         case x_blob:
             {
-                unsigned long oid =
-                    string_to_unsigned_integer<unsigned long>(buf);
+                uint64_t oid =
+                    string_to_unsigned_integer<uint64_t>(buf);
 
                 int fd = lo_open(statement_.session_.conn_, oid,
                     INV_READ | INV_WRITE);

--- a/src/backends/postgresql/standard-use-type.cpp
+++ b/src/backends/postgresql/standard-use-type.cpp
@@ -88,7 +88,7 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
         case x_long_long:
             {
                 std::size_t const bufSize
-                    = std::numeric_limits<long long>::digits10 + 3;
+                    = std::numeric_limits<int64_t>::digits10 + 3;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%" LL_FMT_FLAGS "d",
                     exchange_type_cast<x_long_long>(data_));
@@ -97,7 +97,7 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
         case x_unsigned_long_long:
             {
                 std::size_t const bufSize
-                    = std::numeric_limits<unsigned long long>::digits10 + 2;
+                    = std::numeric_limits<uint64_t>::digits10 + 2;
                 buf_ = new char[bufSize];
                 snprintf(buf_, bufSize, "%" LL_FMT_FLAGS "u",
                     exchange_type_cast<x_unsigned_long_long>(data_));
@@ -119,7 +119,7 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
             break;
         case x_rowid:
             {
-                // RowID is internally identical to unsigned long
+                // RowID is internally identical to uint64_t
 
                 rowid * rid = static_cast<rowid *>(data_);
                 postgresql_rowid_backend * rbe
@@ -127,10 +127,10 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
                         rid->get_backend());
 
                 std::size_t const bufSize
-                    = std::numeric_limits<unsigned long>::digits10 + 2;
+                    = std::numeric_limits<uint64_t>::digits10 + 2;
                 buf_ = new char[bufSize];
 
-                snprintf(buf_, bufSize, "%lu", rbe->value_);
+                snprintf(buf_, bufSize, "%" LLU_FMT_FLAGS, rbe->value_);
             }
             break;
         case x_blob:
@@ -140,9 +140,9 @@ void postgresql_standard_use_type_backend::pre_use(indicator const * ind)
                     static_cast<postgresql_blob_backend *>(b->get_backend());
 
                 std::size_t const bufSize
-                    = std::numeric_limits<unsigned long>::digits10 + 2;
+                    = std::numeric_limits<uint64_t>::digits10 + 2;
                 buf_ = new char[bufSize];
-                snprintf(buf_, bufSize, "%lu", bbe->oid_);
+                snprintf(buf_, bufSize, "%" LLU_FMT_FLAGS, bbe->oid_);
             }
             break;
         case x_xmltype:

--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -301,7 +301,7 @@ postgresql_statement_backend::execute(int number)
                     "Binding for use elements must be either by position "
                     "or by name.");
             }
-            long long rowsAffectedBulkTemp = 0;
+            int64_t rowsAffectedBulkTemp = 0;
             for (int i = 0; i != numberOfExecutions; ++i)
             {
                 std::vector<char *> paramValues;
@@ -660,13 +660,13 @@ postgresql_statement_backend::fetch(int number)
     }
 }
 
-long long postgresql_statement_backend::get_affected_rows()
+int64_t postgresql_statement_backend::get_affected_rows()
 {
     // PQcmdTuples() doesn't really modify the result but it takes a non-const
     // pointer to it, so we can't rely on implicit conversion here.
     const char * const resultStr = PQcmdTuples(result_.get_result());
     char * end;
-    long long result = std::strtoll(resultStr, &end, 0);
+    int64_t result = std::strtoll(resultStr, &end, 0);
     if (end != resultStr)
     {
         return result;
@@ -714,7 +714,7 @@ void postgresql_statement_backend::describe_column(int colNum, data_type & type,
     // In postgresql_ column numbers start from 0
     int const pos = colNum - 1;
 
-    unsigned long const typeOid = PQftype(result_, pos);
+    uint64_t const typeOid = PQftype(result_, pos);
     switch (typeOid)
     {
     // Note: the following list of OIDs was taken from the pg_type table

--- a/src/backends/postgresql/vector-into-type.cpp
+++ b/src/backends/postgresql/vector-into-type.cpp
@@ -129,14 +129,14 @@ void postgresql_vector_into_type_backend::post_fetch(bool gotData, indicator * i
                 break;
             case x_long_long:
                 {
-                    long long const val = string_to_integer<long long>(buf);
+                    int64_t const val = string_to_integer<int64_t>(buf);
                     set_invector_(data_, i, val);
                 }
                 break;
             case x_unsigned_long_long:
                 {
-                    unsigned long long const val =
-                        string_to_unsigned_integer<unsigned long long>(buf);
+                    uint64_t const val =
+                        string_to_unsigned_integer<uint64_t>(buf);
                     set_invector_(data_, i, val);
                 }
                 break;
@@ -206,10 +206,10 @@ void postgresql_vector_into_type_backend::resize(std::size_t sz)
             resizevector_<int>(data_, sz);
             break;
         case x_long_long:
-            resizevector_<long long>(data_, sz);
+            resizevector_<int64_t>(data_, sz);
             break;
         case x_unsigned_long_long:
-            resizevector_<unsigned long long>(data_, sz);
+            resizevector_<uint64_t>(data_, sz);
             break;
         case x_double:
             resizevector_<double>(data_, sz);
@@ -274,10 +274,10 @@ std::size_t postgresql_vector_into_type_backend::full_size()
         sz = get_vector_size<int>(data_);
         break;
     case x_long_long:
-        sz = get_vector_size<long long>(data_);
+        sz = get_vector_size<int64_t>(data_);
         break;
     case x_unsigned_long_long:
-        sz = get_vector_size<unsigned long long>(data_);
+        sz = get_vector_size<uint64_t>(data_);
         break;
     case x_double:
         sz = get_vector_size<double>(data_);

--- a/src/backends/postgresql/vector-use-type.cpp
+++ b/src/backends/postgresql/vector-use-type.cpp
@@ -124,24 +124,24 @@ void postgresql_vector_use_type_backend::pre_use(indicator const * ind)
                 break;
             case x_long_long:
                 {
-                    std::vector<long long>* pv
-                        = static_cast<std::vector<long long>*>(data_);
-                    std::vector<long long>& v = *pv;
+                    std::vector<int64_t>* pv
+                        = static_cast<std::vector<int64_t>*>(data_);
+                    std::vector<int64_t>& v = *pv;
 
                     std::size_t const bufSize
-                        = std::numeric_limits<long long>::digits10 + 3;
+                        = std::numeric_limits<int64_t>::digits10 + 3;
                     buf = new char[bufSize];
                     snprintf(buf, bufSize, "%" LL_FMT_FLAGS "d", v[i]);
                 }
                 break;
             case x_unsigned_long_long:
                 {
-                    std::vector<unsigned long long>* pv
-                        = static_cast<std::vector<unsigned long long>*>(data_);
-                    std::vector<unsigned long long>& v = *pv;
+                    std::vector<uint64_t>* pv
+                        = static_cast<std::vector<uint64_t>*>(data_);
+                    std::vector<uint64_t>& v = *pv;
 
                     std::size_t const bufSize
-                        = std::numeric_limits<unsigned long long>::digits10 + 2;
+                        = std::numeric_limits<uint64_t>::digits10 + 2;
                     buf = new char[bufSize];
                     snprintf(buf, bufSize, "%" LL_FMT_FLAGS "u", v[i]);
                 }
@@ -251,10 +251,10 @@ std::size_t postgresql_vector_use_type_backend::full_size()
         sz = get_vector_size<int>(data_);
         break;
     case x_long_long:
-        sz = get_vector_size<long long>(data_);
+        sz = get_vector_size<int64_t>(data_);
         break;
     case x_unsigned_long_long:
-        sz = get_vector_size<unsigned long long>(data_);
+        sz = get_vector_size<uint64_t>(data_);
         break;
     case x_double:
         sz = get_vector_size<double>(data_);

--- a/src/backends/sqlite3/common.h
+++ b/src/backends/sqlite3/common.h
@@ -37,18 +37,18 @@ void resize_vector(void *p, std::size_t sz)
 template <typename T>
 T string_to_integer(char const * buf)
 {
-    long long t(0);
+    int64_t t(0);
     int n(0);
     int const converted = std::sscanf(buf, "%" LL_FMT_FLAGS "d%n", &t, &n);
     if (converted == 1 && static_cast<std::size_t>(n) == std::strlen(buf))
     {
-        // successfully converted to long long
+        // successfully converted to int64_t
         // and no other characters were found in the buffer
 
         const T max = (std::numeric_limits<T>::max)();
         const T min = (std::numeric_limits<T>::min)();
-        if (t <= static_cast<long long>(max) &&
-            t >= static_cast<long long>(min))
+        if (t <= static_cast<int64_t>(max) &&
+            t >= static_cast<int64_t>(min))
         {
             return static_cast<T>(t);
         }
@@ -61,16 +61,16 @@ T string_to_integer(char const * buf)
 template <typename T>
 T string_to_unsigned_integer(char const * buf)
 {
-    unsigned long long t(0);
+    uint64_t t(0);
     int n(0);
     int const converted = std::sscanf(buf, "%" LL_FMT_FLAGS "u%n", &t, &n);
     if (converted == 1 && static_cast<std::size_t>(n) == std::strlen(buf))
     {
-        // successfully converted to unsigned long long
+        // successfully converted to uint64_t
         // and no other characters were found in the buffer
 
         T const max = (std::numeric_limits<T>::max)();
-        if (t <= static_cast<unsigned long long>(max))
+        if (t <= static_cast<uint64_t>(max))
         {
             return static_cast<T>(t);
         }

--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -142,9 +142,9 @@ void sqlite3_session_backend::rollback()
 }
 
 bool sqlite3_session_backend::get_last_insert_id(
-    session & /* s */, std::string const & /* table */, long & value)
+    session & /* s */, std::string const & /* table */, int64_t & value)
 {
-    value = static_cast<long>(sqlite3_last_insert_rowid(conn_));
+    value = static_cast<int64_t>(sqlite3_last_insert_rowid(conn_));
 
     return true;
 }

--- a/src/backends/sqlite3/standard-into-type.cpp
+++ b/src/backends/sqlite3/standard-into-type.cpp
@@ -142,10 +142,10 @@ void sqlite3_standard_into_type_backend::post_fetch(bool gotData,
 
             case x_rowid:
             {
-                // RowID is internally identical to unsigned long
+                // RowID is internally identical to uint64_t
                 rowid *rid = static_cast<rowid *>(data_);
                 sqlite3_rowid_backend *rbe = static_cast<sqlite3_rowid_backend *>(rid->get_backend());
-                rbe->value_ = static_cast<unsigned long>(sqlite3_column_int64(statement_.stmt_, pos));
+                rbe->value_ = static_cast<uint64_t>(sqlite3_column_int64(statement_.stmt_, pos));
                 break;
             }
 

--- a/src/backends/sqlite3/standard-use-type.cpp
+++ b/src/backends/sqlite3/standard-use-type.cpp
@@ -154,7 +154,7 @@ void sqlite3_standard_use_type_backend::pre_use(indicator const * ind)
         case x_rowid:
         {
             col.type_ = dt_long_long;
-            // RowID is internally identical to unsigned long
+            // RowID is internally identical to uint64_t
             rowid *rid = static_cast<rowid *>(data_);
             sqlite3_rowid_backend *rbe = static_cast<sqlite3_rowid_backend *>(rid->get_backend());
 

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -242,7 +242,7 @@ sqlite3_statement_backend::bind_and_execute(int number)
 {
     statement_backend::exec_fetch_result retVal = ef_no_data;
 
-    long long rowsAffectedBulkTemp = 0;
+    int64_t rowsAffectedBulkTemp = 0;
 
     rowsAffectedBulk_ = -1;
 
@@ -357,7 +357,7 @@ sqlite3_statement_backend::fetch(int number)
 
 }
 
-long long sqlite3_statement_backend::get_affected_rows()
+int64_t sqlite3_statement_backend::get_affected_rows()
 {
     if (rowsAffectedBulk_ >= 0)
     {

--- a/src/backends/sqlite3/vector-into-type.cpp
+++ b/src/backends/sqlite3/vector-into-type.cpp
@@ -288,10 +288,10 @@ void sqlite3_vector_into_type_backend::resize(std::size_t sz)
         resize_vector<int>(data_, sz);
         break;
     case x_long_long:
-        resize_vector<long long>(data_, sz);
+        resize_vector<int64_t>(data_, sz);
         break;
     case x_unsigned_long_long:
-        resize_vector<unsigned long long>(data_, sz);
+        resize_vector<uint64_t>(data_, sz);
         break;
     case x_double:
         resize_vector<double>(data_, sz);
@@ -326,10 +326,10 @@ std::size_t sqlite3_vector_into_type_backend::size()
         sz = get_vector_size<int>(data_);
         break;
     case x_long_long:
-        sz = get_vector_size<long long>(data_);
+        sz = get_vector_size<int64_t>(data_);
         break;
     case x_unsigned_long_long:
-        sz = get_vector_size<unsigned long long>(data_);
+        sz = get_vector_size<uint64_t>(data_);
         break;
     case x_double:
         sz = get_vector_size<double>(data_);

--- a/src/backends/sqlite3/vector-use-type.cpp
+++ b/src/backends/sqlite3/vector-use-type.cpp
@@ -174,10 +174,10 @@ std::size_t sqlite3_vector_use_type_backend::size()
         sz = get_vector_size<int>(data_);
         break;
     case x_long_long:
-        sz = get_vector_size<long long>(data_);
+        sz = get_vector_size<int64_t>(data_);
         break;
     case x_unsigned_long_long:
-        sz = get_vector_size<unsigned long long>(data_);
+        sz = get_vector_size<uint64_t>(data_);
         break;
     case x_double:
         sz = get_vector_size<double>(data_);

--- a/src/core/common.cpp
+++ b/src/core/common.cpp
@@ -19,7 +19,7 @@ namespace // anonymous
 // helper function for parsing decimal data (for std::tm)
 int parse10(char const * & p1, char * & p2)
 {
-    long v = std::strtol(p1, &p2, 10);
+    int64_t v = std::strtol(p1, &p2, 10);
     if (p2 != p1)
     {
         if (v < 0)

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -415,14 +415,14 @@ bool session::get_uppercase_column_names() const
     }
 }
 
-bool session::get_next_sequence_value(std::string const & sequence, long & value)
+bool session::get_next_sequence_value(std::string const & sequence, int64_t & value)
 {
     ensureConnected(backEnd_);
 
     return backEnd_->get_next_sequence_value(*this, sequence, value);
 }
 
-bool session::get_last_insert_id(std::string const & sequence, long & value)
+bool session::get_last_insert_id(std::string const & sequence, int64_t & value)
 {
     ensureConnected(backEnd_);
 

--- a/src/core/soci-simple.cpp
+++ b/src/core/soci-simple.cpp
@@ -311,7 +311,7 @@ struct statement_wrapper
     std::vector<indicator> into_indicators;
     std::map<int, std::string> into_strings;
     std::map<int, int> into_ints;
-    std::map<int, long long> into_longlongs;
+    std::map<int, int64_t> into_longlongs;
     std::map<int, double> into_doubles;
     std::map<int, std::tm> into_dates;
     std::map<int, blob_wrapper *> into_blob;
@@ -319,7 +319,7 @@ struct statement_wrapper
     std::vector<std::vector<indicator> > into_indicators_v;
     std::map<int, std::vector<std::string> > into_strings_v;
     std::map<int, std::vector<int> > into_ints_v;
-    std::map<int, std::vector<long long> > into_longlongs_v;
+    std::map<int, std::vector<int64_t> > into_longlongs_v;
     std::map<int, std::vector<double> > into_doubles_v;
     std::map<int, std::vector<std::tm> > into_dates_v;
 
@@ -327,7 +327,7 @@ struct statement_wrapper
     std::map<std::string, indicator> use_indicators;
     std::map<std::string, std::string> use_strings;
     std::map<std::string, int> use_ints;
-    std::map<std::string, long long> use_longlongs;
+    std::map<std::string, int64_t> use_longlongs;
     std::map<std::string, double> use_doubles;
     std::map<std::string, std::tm> use_dates;
     std::map<std::string, blob_wrapper *> use_blob;
@@ -335,7 +335,7 @@ struct statement_wrapper
     std::map<std::string, std::vector<indicator> > use_indicators_v;
     std::map<std::string, std::vector<std::string> > use_strings_v;
     std::map<std::string, std::vector<int> > use_ints_v;
-    std::map<std::string, std::vector<long long> > use_longlongs_v;
+    std::map<std::string, std::vector<int64_t> > use_longlongs_v;
     std::map<std::string, std::vector<double> > use_doubles_v;
     std::map<std::string, std::vector<std::tm> > use_dates_v;
 
@@ -558,7 +558,7 @@ bool name_exists_check_failed(statement_wrapper & wrapper,
         case dt_long_long:
         case dt_unsigned_long_long:
             {
-                typedef std::map<std::string, long long>::const_iterator
+                typedef std::map<std::string, int64_t>::const_iterator
                     iterator;
                 iterator const it = wrapper.use_longlongs.find(name);
                 name_exists = (it != wrapper.use_longlongs.end());
@@ -623,7 +623,7 @@ bool name_exists_check_failed(statement_wrapper & wrapper,
                 typedef std::map
                     <
                         std::string,
-                        std::vector<long long>
+                        std::vector<int64_t>
                     >::const_iterator iterator;
                 iterator const it = wrapper.use_longlongs_v.find(name);
                 name_exists = (it != wrapper.use_longlongs_v.end());
@@ -988,15 +988,15 @@ SOCI_DECL int soci_get_into_int(statement_handle st, int position)
     return wrapper->into_ints[position];
 }
 
-SOCI_DECL long long soci_get_into_long_long(statement_handle st, int position)
+SOCI_DECL int64_t soci_get_into_long_long(statement_handle st, int position)
 {
     statement_wrapper * wrapper = static_cast<statement_wrapper *>(st);
 
     if (position_check_failed(*wrapper,
-            statement_wrapper::single, position, dt_long_long, "long long") ||
+            statement_wrapper::single, position, dt_long_long, "int64_t") ||
         not_null_check_failed(*wrapper, position))
     {
-        return 0LL;
+        return 0L;
     }
 
     return wrapper->into_longlongs[position];
@@ -1170,17 +1170,17 @@ SOCI_DECL int soci_get_into_int_v(statement_handle st, int position, int index)
     return v[index];
 }
 
-SOCI_DECL long long soci_get_into_long_long_v(statement_handle st, int position, int index)
+SOCI_DECL int64_t soci_get_into_long_long_v(statement_handle st, int position, int index)
 {
     statement_wrapper * wrapper = static_cast<statement_wrapper *>(st);
 
     if (position_check_failed(*wrapper,
-            statement_wrapper::bulk, position, dt_long_long, "long long"))
+            statement_wrapper::bulk, position, dt_long_long, "int64_t"))
     {
         return 0;
     }
 
-    std::vector<long long> const & v = wrapper->into_longlongs_v[position];
+    std::vector<int64_t> const & v = wrapper->into_longlongs_v[position];
     if (index_check_failed(v, *wrapper, index) ||
         not_null_check_failed(*wrapper, position, index))
     {
@@ -1462,12 +1462,12 @@ SOCI_DECL void soci_set_use_int(statement_handle st, char const * name, int val)
     wrapper->use_ints[name] = val;
 }
 
-SOCI_DECL void soci_set_use_long_long(statement_handle st, char const * name, long long val)
+SOCI_DECL void soci_set_use_long_long(statement_handle st, char const * name, int64_t val)
 {
     statement_wrapper * wrapper = static_cast<statement_wrapper *>(st);
 
     if (name_exists_check_failed(*wrapper,
-            name, dt_long_long, statement_wrapper::single, "long long"))
+            name, dt_long_long, statement_wrapper::single, "int64_t"))
     {
         return;
     }
@@ -1645,17 +1645,17 @@ SOCI_DECL void soci_set_use_int_v(statement_handle st,
 }
 
 SOCI_DECL void soci_set_use_long_long_v(statement_handle st,
-    char const * name, int index, long long val)
+    char const * name, int index, int64_t val)
 {
     statement_wrapper * wrapper = static_cast<statement_wrapper *>(st);
 
     if (name_exists_check_failed(*wrapper,
-            name, dt_long_long, statement_wrapper::bulk, "vector long long"))
+            name, dt_long_long, statement_wrapper::bulk, "vector int64_t"))
     {
         return;
     }
 
-    std::vector<long long> & v = wrapper->use_longlongs_v[name];
+    std::vector<int64_t> & v = wrapper->use_longlongs_v[name];
     if (index_check_failed(v, *wrapper, index))
     {
         return;
@@ -1757,14 +1757,14 @@ SOCI_DECL int soci_get_use_int(statement_handle st, char const * name)
     return wrapper->use_ints[name];
 }
 
-SOCI_DECL long long soci_get_use_long_long(statement_handle st, char const * name)
+SOCI_DECL int64_t soci_get_use_long_long(statement_handle st, char const * name)
 {
     statement_wrapper * wrapper = static_cast<statement_wrapper *>(st);
 
     if (name_exists_check_failed(*wrapper,
-            name, dt_long_long, statement_wrapper::bulk, "long long"))
+            name, dt_long_long, statement_wrapper::bulk, "int64_t"))
     {
-        return 0LL;
+        return 0L;
     }
 
     return wrapper->use_longlongs[name];
@@ -1928,13 +1928,13 @@ SOCI_DECL void soci_prepare(statement_handle st, char const * query)
         }
         {
             // longlongs
-            typedef std::map<std::string, long long>::iterator iterator;
+            typedef std::map<std::string, int64_t>::iterator iterator;
             iterator uit = wrapper->use_longlongs.begin();
             iterator const uend = wrapper->use_longlongs.end();
             for ( ; uit != uend; ++uit)
             {
                 std::string const & use_name = uit->first;
-                long long & use_longlong = uit->second;
+                int64_t & use_longlong = uit->second;
                 indicator & use_ind = wrapper->use_indicators[use_name];
                 wrapper->st.exchange(use(use_longlong, use_ind, use_name));
             }
@@ -2013,13 +2013,13 @@ SOCI_DECL void soci_prepare(statement_handle st, char const * query)
         {
             // longlongs
             typedef std::map<std::string,
-                std::vector<long long> >::iterator iterator;
+                std::vector<int64_t> >::iterator iterator;
             iterator uit = wrapper->use_longlongs_v.begin();
             iterator const uend = wrapper->use_longlongs_v.end();
             for ( ; uit != uend; ++uit)
             {
                 std::string const & use_name = uit->first;
-                std::vector<long long> & use_longlong = uit->second;
+                std::vector<int64_t> & use_longlong = uit->second;
                 std::vector<indicator> & use_ind =
                     wrapper->use_indicators_v[use_name];
                 wrapper->st.exchange(use(use_longlong, use_ind, use_name));
@@ -2090,7 +2090,7 @@ SOCI_DECL int soci_execute(statement_handle st, int withDataExchange)
     }
 }
 
-SOCI_DECL long long soci_get_affected_rows(statement_handle st)
+SOCI_DECL int64_t soci_get_affected_rows(statement_handle st)
 {
     statement_wrapper * wrapper = static_cast<statement_wrapper *>(st);
 

--- a/src/core/statement.cpp
+++ b/src/core/statement.cpp
@@ -358,7 +358,7 @@ bool statement_impl::execute(bool withDataExchange)
     }
 }
 
-long long statement_impl::get_affected_rows()
+int64_t statement_impl::get_affected_rows()
 {
     try
     {
@@ -460,10 +460,10 @@ std::size_t statement_impl::intos_size()
         {
             std::ostringstream msg;
             msg << "Bind variable size mismatch (into["
-                << static_cast<unsigned long>(i) << "] has size "
-                << static_cast<unsigned long>(intos_[i]->size())
+                << static_cast<uint64_t>(i) << "] has size "
+                << static_cast<uint64_t>(intos_[i]->size())
                 << ", into[0] has size "
-                << static_cast<unsigned long>(intos_size);
+                << static_cast<uint64_t>(intos_size);
             throw soci_error(msg.str());
         }
     }
@@ -489,10 +489,10 @@ std::size_t statement_impl::uses_size()
         {
             std::ostringstream msg;
             msg << "Bind variable size mismatch (use["
-                << static_cast<unsigned long>(i) << "] has size "
-                << static_cast<unsigned long>(uses_[i]->size())
+                << static_cast<uint64_t>(i) << "] has size "
+                << static_cast<uint64_t>(uses_[i]->size())
                 << ", use[0] has size "
-                << static_cast<unsigned long>(usesSize);
+                << static_cast<uint64_t>(usesSize);
             throw soci_error(msg.str());
         }
     }
@@ -648,13 +648,13 @@ void statement_impl::bind_into<dt_integer>()
 template<>
 void statement_impl::bind_into<dt_long_long>()
 {
-    into_row<long long>();
+    into_row<int64_t>();
 }
 
 template<>
 void statement_impl::bind_into<dt_unsigned_long_long>()
 {
-    into_row<unsigned long long>();
+    into_row<uint64_t>();
 }
 
 template<>

--- a/src/core/use-type.cpp
+++ b/src/core/use-type.cpp
@@ -107,7 +107,7 @@ void standard_use_type::dump_value(std::ostream& os) const
             return;
 
         case x_longstring:
-            os << "<long string>";
+            os << "<int64_t string>";
             return;
     }
 

--- a/tests/db2/test-db2.cpp
+++ b/tests/db2/test-db2.cpp
@@ -126,17 +126,17 @@ TEST_CASE("DB2 test 1", "[db2]")
     }
 
     {
-        const long int li = 9;
+        const int64_t li = 9;
         sql << "insert into db2inst1.SOCI_TEST (id) values (:id)", use(li,"id");
-        long int lj = 0;;
+        int64_t lj = 0;;
         sql << "select id from db2inst1.SOCI_TEST where id=9", into(lj);
         CHECK(lj == li);
     }
 
     {
-        const long long ll = 11;
+        const int64_t ll = 11;
         sql << "insert into db2inst1.SOCI_TEST (id) values (:id)", use(ll,"id");
-        long long lj = 0;
+        int64_t lj = 0;
         sql << "select id from db2inst1.SOCI_TEST where id=11", into(lj);
         CHECK(lj == ll);
     }
@@ -344,7 +344,7 @@ TEST_CASE("DB2 test 3", "[db2]")
     std::string query = "CREATE TABLE DB2INST1.SOCI_TEST (ID BIGINT,DATA VARCHAR(8),DT TIMESTAMP)";
     sql << query;
 
-    std::vector<long long> ids(100);
+    std::vector<int64_t> ids(100);
     std::vector<std::string> data(100);
     std::vector<std::tm> dts(100);
     for (int i = 0; i < 100; i++)
@@ -367,7 +367,7 @@ TEST_CASE("DB2 test 3", "[db2]")
     for (rowset<row>::const_iterator it = rs.begin(); it != rs.end(); it++)
     {
         const row & r = *it;
-        const long long id = r.get<long long>(0);
+        const int64_t id = r.get<int64_t>(0);
         const std::string data = r.get<std::string>(1);
         const std::tm dt = r.get<std::tm>(2);
 

--- a/tests/empty/test-empty.cpp
+++ b/tests/empty/test-empty.cpp
@@ -78,15 +78,15 @@ TEST_CASE("Dummy test", "[empty]")
     sql << query, into(i);
 
 #if defined (__LP64__) || ( __WORDSIZE == 64 )
-    long int li = 9;
+    int64_t li = 9;
     sql << "insert", use(li);
     sql << "select", into(li);
 #endif
-
-    long long ll = 11;
+/*
+    int64_t ll = 11;
     sql << "insert", use(ll);
     sql << "select", into(ll);
-
+*/
     indicator ind = i_ok;
     sql << "insert", use(i, ind);
     sql << "select", into(i, ind);

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -120,7 +120,7 @@ TEST_CASE("Firebird char types", "[firebird][string]")
 #endif
 
     {
-        // The test string is exactly 10 bytes long, i.e. same as column length.
+        // The test string is exactly 10 bytes int64_t, i.e. same as column length.
         std::string b1("Hello, FB!"), b2, b3;
 
         sql << "insert into test2(p1, p2) values (?,?)", use(b1), use(b1);
@@ -308,7 +308,7 @@ TEST_CASE("Firebird integers", "[firebird][int]")
     }
 
     {
-        unsigned long ul(0);
+        uint64_t ul(0);
         sql << "select 7 from rdb$database", into(ul);
         CHECK(ul == 7);
     }
@@ -961,7 +961,7 @@ namespace soci
 
     // Returns number of rows afected by last statement
     // or -1 if there is no such counter available.
-    long getRowCount(soci::statement & statement, eRowCountType type)
+    int64_t getRowCount(soci::statement & statement, eRowCountType type)
     {
         ISC_STATUS stat[20];
         char cnt_req[2], cnt_info[128];
@@ -982,7 +982,7 @@ namespace soci
             soci::details::firebird::throw_iscerror(stat);
         }
 
-        long count = -1;
+        int64_t count = -1;
         char type_ = static_cast<char>(type);
         for (char *ptr = cnt_info + 3; *ptr != isc_info_end;)
         {

--- a/tests/mysql/test-mysql.cpp
+++ b/tests/mysql/test-mysql.cpp
@@ -147,29 +147,29 @@ struct bigint_unsigned_table_creator : table_creator_base
     }
 };
 
-TEST_CASE("MySQL long long", "[mysql][longlong]")
+TEST_CASE("MySQL int64_t", "[mysql][longlong]")
 {
     {
         soci::session sql(backEnd, connectString);
 
         bigint_table_creator tableCreator(sql);
 
-        long long v1 = 1000000000000LL;
+        int64_t v1 = 1000000000000LL;
         sql << "insert into soci_test(val) values(:val)", use(v1);
 
-        long long v2 = 0LL;
+        int64_t v2 = 0LL;
         sql << "select val from soci_test", into(v2);
 
         CHECK(v2 == v1);
     }
 
-    // vector<long long>
+    // vector<int64_t>
     {
         soci::session sql(backEnd, connectString);
 
         bigint_table_creator tableCreator(sql);
 
-        std::vector<long long> v1;
+        std::vector<int64_t> v1;
         v1.push_back(1000000000000LL);
         v1.push_back(1000000000001LL);
         v1.push_back(1000000000002LL);
@@ -178,7 +178,7 @@ TEST_CASE("MySQL long long", "[mysql][longlong]")
 
         sql << "insert into soci_test(val) values(:val)", use(v1);
 
-        std::vector<long long> v2(10);
+        std::vector<int64_t> v2(10);
         sql << "select val from soci_test order by val desc", into(v2);
 
         REQUIRE(v2.size() == 5);
@@ -206,7 +206,7 @@ TEST_CASE("MySQL long long", "[mysql][longlong]")
 
         const char* source = "18446744073709551615";
         sql << "insert into soci_test set val = " << source;
-        unsigned long long vv = 0;
+        uint64_t vv = 0;
         sql << "select val from soci_test", into(vv);
         std::stringstream buf;
         buf << vv;
@@ -220,7 +220,7 @@ TEST_CASE("MySQL long long", "[mysql][longlong]")
 
         const char* source = "18446744073709551615";
         sql << "insert into soci_test set val = " << source;
-        std::vector<unsigned long long> v(1);
+        std::vector<uint64_t> v(1);
         sql << "select val from soci_test", into(v);
         std::stringstream buf;
         buf << v.at(0);
@@ -232,9 +232,9 @@ TEST_CASE("MySQL long long", "[mysql][longlong]")
 
         bigint_unsigned_table_creator tableCreator(sql);
 
-        unsigned long long n = 18446744073709551615ULL;
+        uint64_t n = 18446744073709551615ULL;
         sql << "insert into soci_test(val) values (:n)", use(n);
-        unsigned long long m = 0;
+        uint64_t m = 0;
         sql << "select val from soci_test", into(m);
         CHECK(n == m);
     }
@@ -244,13 +244,13 @@ TEST_CASE("MySQL long long", "[mysql][longlong]")
 
         bigint_unsigned_table_creator tableCreator(sql);
 
-        std::vector<unsigned long long> v1;
+        std::vector<uint64_t> v1;
         v1.push_back(18446744073709551615ULL);
         v1.push_back(18446744073709551614ULL);
         v1.push_back(18446744073709551613ULL);
         sql << "insert into soci_test(val) values(:val)", use(v1);
 
-        std::vector<unsigned long long> v2(10);
+        std::vector<uint64_t> v2(10);
         sql << "select val from soci_test order by val", into(v2);
 
         REQUIRE(v2.size() == 3);
@@ -353,9 +353,9 @@ TEST_CASE("MySQL number conversion", "[mysql][float][int]")
     test_num<int>("-0", true, 0);
     test_num<int>("1.1", false, 0);
 
-    test_num<long long>("123", true, 123);
-    test_num<long long>("9223372036854775807", true, 9223372036854775807LL);
-    test_num<long long>("9223372036854775808", false, 0);
+    test_num<int64_t>("123", true, 123);
+    test_num<int64_t>("9223372036854775807", true, 9223372036854775807LL);
+    test_num<int64_t>("9223372036854775808", false, 0);
 }
 
 TEST_CASE("MySQL datetime", "[mysql][datetime]")
@@ -689,7 +689,7 @@ TEST_CASE("MySQL tinyint", "[mysql][int][tinyint]")
     sql << "select val from soci_test", into(r);
     REQUIRE(r.size() == 1);
     CHECK(r.get_properties("val").get_data_type() == dt_long_long);
-    CHECK(r.get<long long>("val") == 0xffffff00);
+    CHECK(r.get<int64_t>("val") == 0xffffff00);
     CHECK(r.get<unsigned>("val") == 0xffffff00);
   }
   {
@@ -720,7 +720,7 @@ TEST_CASE("MySQL tinyint", "[mysql][int][tinyint]")
     sql << "select val from soci_test", into(r);
     REQUIRE(r.size() == 1);
     CHECK(r.get_properties("val").get_data_type() == dt_unsigned_long_long);
-    CHECK(r.get<unsigned long long>("val") == 123456789012345ULL);
+    CHECK(r.get<uint64_t>("val") == 123456789012345ULL);
   }
   {
     soci::session sql(backEnd, connectString);
@@ -730,7 +730,7 @@ TEST_CASE("MySQL tinyint", "[mysql][int][tinyint]")
     sql << "select val from soci_test", into(r);
     REQUIRE(r.size() == 1);
     CHECK(r.get_properties("val").get_data_type() == dt_long_long);
-    CHECK(r.get<long long>("val") == -123456789012345LL);
+    CHECK(r.get<int64_t>("val") == -123456789012345LL);
   }
 }
 
@@ -791,7 +791,7 @@ TEST_CASE("MySQL last insert id", "[mysql][last-insert-id]")
     soci::session sql(backEnd, connectString);
     table_creator_for_get_last_insert_id tableCreator(sql);
     sql << "insert into soci_test () values ()";
-    long id;
+    int64_t id;
     bool result = sql.get_last_insert_id("soci_test", id);
     CHECK(result == true);
     CHECK(id == 42);
@@ -802,7 +802,7 @@ std::string escape_string(soci::session& sql, const std::string& s)
     mysql_session_backend* backend = static_cast<mysql_session_backend*>(
         sql.get_backend());
     char* escaped = new char[2 * s.size() + 1];
-    mysql_real_escape_string(backend->conn_, escaped, s.data(), static_cast<unsigned long>(s.size()));
+    mysql_real_escape_string(backend->conn_, escaped, s.data(), static_cast<uint64_t>(s.size()));
     std::string retv = escaped;
     delete [] escaped;
     return retv;

--- a/tests/mysql/test-mysql.h
+++ b/tests/mysql/test-mysql.h
@@ -109,7 +109,7 @@ public:
         sql << "select @@session.sql_mode", into(sql_mode);
 
         // The database must be configured to use STRICT_{ALL,TRANS}_TABLES in
-        // SQL mode to avoid silent truncation of too long values.
+        // SQL mode to avoid silent truncation of too int64_t values.
         return sql_mode.find("STRICT_") == std::string::npos;
     }
 

--- a/tests/odbc/test-odbc-db2.cpp
+++ b/tests/odbc/test-odbc-db2.cpp
@@ -109,14 +109,14 @@ struct table_creator_bigint : table_creator_base
     }
 };
 
-TEST_CASE("ODBC/DB2 long long", "[odbc][db2][longlong]")
+TEST_CASE("ODBC/DB2 int64_t", "[odbc][db2][longlong]")
 {
     const int num_recs = 100;
     soci::session sql(backEnd, connectString);
     table_creator_bigint table(sql);
 
     {
-        long long n;
+        int64_t n;
         statement st = (sql.prepare <<
             "INSERT INTO SOCI_TEST (VAL) VALUES (:val)", use(n));
         for (int i = 0; i < num_recs; i++)
@@ -126,7 +126,7 @@ TEST_CASE("ODBC/DB2 long long", "[odbc][db2][longlong]")
         }
     }
     {
-        long long n2;
+        int64_t n2;
         statement st = (sql.prepare <<
             "SELECT VAL FROM SOCI_TEST ORDER BY VAL", into(n2));
         st.execute();
@@ -138,14 +138,14 @@ TEST_CASE("ODBC/DB2 long long", "[odbc][db2][longlong]")
     }
 }
 
-TEST_CASE("ODBC/DB2 unsigned long long", "[odbc][db2][unsigned][longlong]")
+TEST_CASE("ODBC/DB2 uint64_t", "[odbc][db2][unsigned][longlong]")
 {
     const int num_recs = 100;
     soci::session sql(backEnd, connectString);
     table_creator_bigint table(sql);
 
     {
-        unsigned long long n;
+        uint64_t n;
         statement st = (sql.prepare <<
             "INSERT INTO SOCI_TEST (VAL) VALUES (:val)", use(n));
         for (int i = 0; i < num_recs; i++)
@@ -155,7 +155,7 @@ TEST_CASE("ODBC/DB2 unsigned long long", "[odbc][db2][unsigned][longlong]")
         }
     }
     {
-        unsigned long long n2;
+        uint64_t n2;
         statement st = (sql.prepare <<
             "SELECT VAL FROM SOCI_TEST ORDER BY VAL", into(n2));
         st.execute();
@@ -167,14 +167,14 @@ TEST_CASE("ODBC/DB2 unsigned long long", "[odbc][db2][unsigned][longlong]")
     }
 }
 
-TEST_CASE("ODBC/DB2 vector long long", "[odbc][db2][vector][longlong]")
+TEST_CASE("ODBC/DB2 vector int64_t", "[odbc][db2][vector][longlong]")
 {
     const std::size_t num_recs = 100;
     soci::session sql(backEnd, connectString);
     table_creator_bigint table(sql);
 
     {
-        std::vector<long long> v(num_recs);
+        std::vector<int64_t> v(num_recs);
         for (std::size_t i = 0; i < num_recs; i++)
         {
             v[i] = 1000000000LL + i;
@@ -185,7 +185,7 @@ TEST_CASE("ODBC/DB2 vector long long", "[odbc][db2][vector][longlong]")
     {
         std::size_t recs = 0;
 
-        std::vector<long long> v(num_recs / 2 + 1);
+        std::vector<int64_t> v(num_recs / 2 + 1);
         statement st = (sql.prepare <<
             "SELECT VAL FROM SOCI_TEST ORDER BY VAL", into(v));
         st.execute();
@@ -200,7 +200,7 @@ TEST_CASE("ODBC/DB2 vector long long", "[odbc][db2][vector][longlong]")
             for (std::size_t i = 0; i < vsize; i++)
             {
                 CHECK(v[i] == 1000000000LL +
-                    static_cast<long long>(recs));
+                    static_cast<int64_t>(recs));
                 recs++;
             }
         }
@@ -208,14 +208,14 @@ TEST_CASE("ODBC/DB2 vector long long", "[odbc][db2][vector][longlong]")
     }
 }
 
-TEST_CASE("ODBC/DB2 vector unsigned long long", "[odbc][db2][vector][unsigned][longlong]")
+TEST_CASE("ODBC/DB2 vector uint64_t", "[odbc][db2][vector][unsigned][longlong]")
 {
     const std::size_t num_recs = 100;
     soci::session sql(backEnd, connectString);
     table_creator_bigint table(sql);
 
     {
-        std::vector<unsigned long long> v(num_recs);
+        std::vector<uint64_t> v(num_recs);
         for (std::size_t i = 0; i < num_recs; i++)
         {
             v[i] = 1000000000LL + i;
@@ -226,7 +226,7 @@ TEST_CASE("ODBC/DB2 vector unsigned long long", "[odbc][db2][vector][unsigned][l
     {
         std::size_t recs = 0;
 
-        std::vector<unsigned long long> v(num_recs / 2 + 1);
+        std::vector<uint64_t> v(num_recs / 2 + 1);
         statement st = (sql.prepare <<
             "SELECT VAL FROM SOCI_TEST ORDER BY VAL", into(v));
         st.execute();
@@ -241,7 +241,7 @@ TEST_CASE("ODBC/DB2 vector unsigned long long", "[odbc][db2][vector][unsigned][l
             for (std::size_t i = 0; i < vsize; i++)
             {
                 CHECK(v[i] == 1000000000LL +
-                    static_cast<unsigned long long>(recs));
+                    static_cast<uint64_t>(recs));
                 recs++;
             }
         }

--- a/tests/odbc/test-odbc-mssql.cpp
+++ b/tests/odbc/test-odbc-mssql.cpp
@@ -20,7 +20,7 @@ std::string connectString;
 backend_factory const &backEnd = *soci::factory_odbc();
 
 // MS SQL-specific tests
-TEST_CASE("MS SQL long string", "[odbc][mssql][long]")
+TEST_CASE("MS SQL int64_t string", "[odbc][mssql][int64_t]")
 {
     soci::session sql(backEnd, connectString);
 
@@ -38,7 +38,7 @@ TEST_CASE("MS SQL long string", "[odbc][mssql][long]")
         }
     } long_text_table_creator(sql);
 
-    // Build a string at least 8000 characters long to test that it survives
+    // Build a string at least 8000 characters int64_t to test that it survives
     // the round trip unscathed.
     std::ostringstream os;
     for ( int n = 0; n < 1000; ++n )
@@ -67,7 +67,7 @@ TEST_CASE("MS SQL long string", "[odbc][mssql][long]")
         CHECK(str_out == str_in);
     }
 
-    // The long string should be truncated when inserting it into a fixed size
+    // The int64_t string should be truncated when inserting it into a fixed size
     // column.
     CHECK_THROWS_AS(
         (sql << "insert into soci_test(fixed_text) values(:str)", use(str_in)),

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -1010,11 +1010,11 @@ struct long_table_creator : public table_creator_base
     long_table_creator(soci::session & sql)
         : table_creator_base(sql)
     {
-        sql << "create table soci_test(l long)";
+        sql << "create table soci_test(l int64_t)";
     }
 };
 
-TEST_CASE("Oracle large strings as long", "[oracle][compatibility]")
+TEST_CASE("Oracle large strings as int64_t", "[oracle][compatibility]")
 {
     soci::session sql(backEnd, connectString);
     long_table_creator creator(sql);
@@ -1067,30 +1067,30 @@ struct longlong_table_creator : table_creator_base
     }
 };
 
-// long long test
-TEST_CASE("Oracle long long", "[oracle][longlong]")
+// int64_t test
+TEST_CASE("Oracle int64_t", "[oracle][longlong]")
 {
     {
         soci::session sql(backEnd, connectString);
 
         longlong_table_creator tableCreator(sql);
 
-        long long v1 = 1000000000000LL;
+        int64_t v1 = 1000000000000LL;
         sql << "insert into soci_test(val) values(:val)", use(v1);
 
-        long long v2 = 0LL;
+        int64_t v2 = 0LL;
         sql << "select val from soci_test", into(v2);
 
         CHECK(v2 == v1);
     }
 
-    // vector<long long>
+    // vector<int64_t>
     {
         soci::session sql(backEnd, connectString);
 
         longlong_table_creator tableCreator(sql);
 
-        std::vector<long long> v1;
+        std::vector<int64_t> v1;
         v1.push_back(1000000000000LL);
         v1.push_back(1000000000001LL);
         v1.push_back(1000000000002LL);
@@ -1099,7 +1099,7 @@ TEST_CASE("Oracle long long", "[oracle][longlong]")
 
         sql << "insert into soci_test(val) values(:val)", use(v1);
 
-        std::vector<long long> v2(10);
+        std::vector<int64_t> v2(10);
         sql << "select val from soci_test order by val desc", into(v2);
 
         REQUIRE(v2.size() == 5);

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -180,7 +180,7 @@ TEST_CASE("PostgreSQL blob", "[postgresql][blob]")
             CHECK(std::strncmp(buf2, "abcdefghij", 10) == 0);
         }
 
-        unsigned long oid;
+        uint64_t oid;
         sql << "select img from soci_test where id = 7", into(oid);
         sql << "select lo_unlink(" << oid << ")";
     }
@@ -219,7 +219,7 @@ TEST_CASE("PostgreSQL blob", "[postgresql][blob]")
             CHECK(std::strncmp(buf2, "abcdefghij", 10) == 0);
         }
 
-        unsigned long oid;
+        uint64_t oid;
         sql << "select img from soci_test where id = 7", into(oid);
         sql << "select lo_unlink(" << oid << ")";
     }
@@ -234,30 +234,30 @@ struct longlong_table_creator : table_creator_base
     }
 };
 
-// long long test
-TEST_CASE("PostgreSQL long long", "[postgresql][longlong]")
+// int64_t test
+TEST_CASE("PostgreSQL int64_t", "[postgresql][longlong]")
 {
     soci::session sql(backEnd, connectString);
 
     longlong_table_creator tableCreator(sql);
 
-    long long v1 = 1000000000000LL;
+    int64_t v1 = 1000000000000LL;
     sql << "insert into soci_test(val) values(:val)", use(v1);
 
-    long long v2 = 0LL;
+    int64_t v2 = 0LL;
     sql << "select val from soci_test", into(v2);
 
     CHECK(v2 == v1);
 }
 
-// vector<long long>
-TEST_CASE("PostgreSQL vector long long", "[postgresql][vector][longlong]")
+// vector<int64_t>
+TEST_CASE("PostgreSQL vector int64_t", "[postgresql][vector][longlong]")
 {
     soci::session sql(backEnd, connectString);
 
     longlong_table_creator tableCreator(sql);
 
-    std::vector<long long> v1;
+    std::vector<int64_t> v1;
     v1.push_back(1000000000000LL);
     v1.push_back(1000000000001LL);
     v1.push_back(1000000000002LL);
@@ -266,7 +266,7 @@ TEST_CASE("PostgreSQL vector long long", "[postgresql][vector][longlong]")
 
     sql << "insert into soci_test(val) values(:val)", use(v1);
 
-    std::vector<long long> v2(10);
+    std::vector<int64_t> v2(10);
     sql << "select val from soci_test order by val desc", into(v2);
 
     REQUIRE(v2.size() == 5);
@@ -277,17 +277,17 @@ TEST_CASE("PostgreSQL vector long long", "[postgresql][vector][longlong]")
     CHECK(v2[4] == 1000000000000LL);
 }
 
-// unsigned long long test
-TEST_CASE("PostgreSQL unsigned long long", "[postgresql][unsigned][longlong]")
+// uint64_t test
+TEST_CASE("PostgreSQL uint64_t", "[postgresql][unsigned][longlong]")
 {
     soci::session sql(backEnd, connectString);
 
     longlong_table_creator tableCreator(sql);
 
-    unsigned long long v1 = 1000000000000ULL;
+    uint64_t v1 = 1000000000000ULL;
     sql << "insert into soci_test(val) values(:val)", use(v1);
 
-    unsigned long long v2 = 0ULL;
+    uint64_t v2 = 0ULL;
     sql << "select val from soci_test", into(v2);
 
     CHECK(v2 == v1);
@@ -510,16 +510,16 @@ TEST_CASE("PostgreSQL insert into ... returning", "[postgresql]")
 
     table_creator_for_test12 tableCreator(sql);
 
-    std::vector<long> ids(10);
+    std::vector<int64_t> ids(10);
     for (std::size_t i = 0; i != ids.size(); i++)
     {
-        long sid(0);
+        int64_t sid(0);
         std::string txt("abc");
         sql << "insert into soci_test(txt) values(:txt) returning sid", use(txt, "txt"), into(sid);
         ids[i] = sid;
     }
 
-    std::vector<long> ids2(ids.size());
+    std::vector<int64_t> ids2(ids.size());
     sql << "select sid from soci_test order by sid", into(ids2);
     CHECK(std::equal(ids.begin(), ids.end(), ids2.begin()));
 }

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -195,29 +195,29 @@ struct longlong_table_creator : table_creator_base
     }
 };
 
-// long long test
-TEST_CASE("SQLite long long", "[sqlite][longlong]")
+// int64_t test
+TEST_CASE("SQLite int64_t", "[sqlite][longlong]")
 {
     soci::session sql(backEnd, connectString);
 
     longlong_table_creator tableCreator(sql);
 
-    long long v1 = 1000000000000LL;
+    int64_t v1 = 1000000000000LL;
     sql << "insert into soci_test(val) values(:val)", use(v1);
 
-    long long v2 = 0LL;
+    int64_t v2 = 0LL;
     sql << "select val from soci_test", into(v2);
 
     CHECK(v2 == v1);
 }
 
-TEST_CASE("SQLite vector long long", "[sqlite][vector][longlong]")
+TEST_CASE("SQLite vector int64_t", "[sqlite][vector][longlong]")
 {
     soci::session sql(backEnd, connectString);
 
     longlong_table_creator tableCreator(sql);
 
-    std::vector<long long> v1;
+    std::vector<int64_t> v1;
     v1.push_back(1000000000000LL);
     v1.push_back(1000000000001LL);
     v1.push_back(1000000000002LL);
@@ -226,7 +226,7 @@ TEST_CASE("SQLite vector long long", "[sqlite][vector][longlong]")
 
     sql << "insert into soci_test(val) values(:val)", use(v1);
 
-    std::vector<long long> v2(10);
+    std::vector<int64_t> v2(10);
     sql << "select val from soci_test order by val desc", into(v2);
 
     REQUIRE(v2.size() == 5);
@@ -266,7 +266,7 @@ TEST_CASE("SQLite last insert id", "[sqlite][last-insert-id]")
     soci::session sql(backEnd, connectString);
     table_creator_for_get_last_insert_id tableCreator(sql);
     sql << "insert into soci_test default values";
-    long id;
+    int64_t id;
     bool result = sql.get_last_insert_id("soci_test", id);
     CHECK(result == true);
     CHECK(id == 42);


### PR DESCRIPTION
Hi,

We use SOCI in our project and we have some servers in 32 and 64 bits.

32 bits use long long and 64 bits use long type for bigint.

In this fork, we have only replaced {unsigned}{long long, long) by {u}int64_t from stdint.h

/usr/include/stdint.h
...
#if __WORDSIZE == 64
typedef long int                int64_t;
# else
__extension__
typedef long long int           int64_t;
#endif

And so we have just one branch to maintain.