### PR TITLE
Fix sqlite3 CMake variable names in installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -148,8 +148,8 @@ List of variables to control common SOCI features and dependencies:
 #### SQLite 3
 
 * `WITH_SQLITE3` - boolean - Should CMak try to detect SQLite C/C++ library. As bonus, the configuration tries OSGeo4W distribution if OSGEO4W_ROOT environment variable is set.
-* `SQLITE_INCLUDE_DIR` - string - Path to SQLite 3 include directory where CMake should look for `sqlite3.h` header.
-* `SQLITE_LIBRARIES` - string - Full paths to libraries to link SOCI against to enable the backend support.
+* `SQLITE3_INCLUDE_DIR` - string - Path to SQLite 3 include directory where CMake should look for `sqlite3.h` header.
+* `SQLITE3_LIBRARIES` - string - Full paths to libraries to link SOCI against to enable the backend support.
 * `SOCI_SQLITE3` - boolean - Requests to build [SQLite3](backends/sqlite3.md) backend. Automatically switched on, if `WITH_SQLITE3` is set to ON.
 * `SOCI_SQLITE3_TEST_CONNSTR` - string - Connection string is simply a file path where SQLite3 test database will be created (e.g. /home/john/soci_test.db). Check [SQLite3 backend reference](backends/sqlite3.md) for details. Example: `-DSOCI_SQLITE3_TEST_CONNSTR="my.db"` or `-DSOCI_SQLITE3_TEST_CONNSTR=":memory:"`.
 


### PR DESCRIPTION
Using `SQLITE3_INCLUDE_DIR` and `SQLITE3_LIBRARIES` in `FindSQLite3.cmake`, but documents `SQLITE_INCLUDE_DIR` and `SQLITE_LIBRARIES` in `installation.md`.

https://github.com/SOCI/soci/blob/02a45a53a69632d814ee7001f98c8801efce058e/cmake/modules/FindSQLite3.cmake#L17-L19

https://github.com/SOCI/soci/blob/02a45a53a69632d814ee7001f98c8801efce058e/cmake/modules/FindSQLite3.cmake#L49-L51
