### PR TITLE
No define snprintf for VS2015 and above

### DIFF
--- a/include/soci/soci-platform.h
+++ b/include/soci/soci-platform.h
@@ -44,7 +44,9 @@
 #endif
 
 // Define if you have the snprintf variants.
-#define snprintf _snprintf
+#if _MSC_VER < 1900
+# define snprintf _snprintf
+#endif
 
 // Define if you have the strtoll and strtoull variants.
 #if _MSC_VER < 1300


### PR DESCRIPTION
There is no need to define `snprintf` for Visual Studio 2015 and above.

References:

https://stackoverflow.com/questions/2915672/snprintf-and-visual-studio-2010

https://github.com/Microsoft/vcpkg/blob/master/ports/soci/no-define-snprintf.patch