### PR TITLE
For performance reasons, use strtoll instead of sscanf.

### DIFF
--- a/src/backends/postgresql/common.h
+++ b/src/backends/postgresql/common.h
@@ -11,6 +11,7 @@
 #include "soci/postgresql/soci-postgresql.h"
 #include <limits>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <vector>

--- a/src/backends/postgresql/common.h
+++ b/src/backends/postgresql/common.h
@@ -30,7 +30,14 @@ template <typename T>
 T string_to_integer(char const * buf)
 {
     char * end;
+
+    // No strtoll() on MSVC versions prior to Visual Studio 2013
+#if defined (_MSC_VER) && (_MSC_VER < 1700)
+    long long t = _strtoi64(buf, &end, 10);
+#else
     long long t = strtoll(buf, &end, 10);
+#endif
+
     if (*buf != '\0' && *end == '\0')
     {
         // successfully converted to long long

--- a/src/backends/postgresql/common.h
+++ b/src/backends/postgresql/common.h
@@ -28,10 +28,9 @@ namespace postgresql
 template <typename T>
 T string_to_integer(char const * buf)
 {
-    long long t(0);
-    int n(0);
-    int const converted = std::sscanf(buf, "%" LL_FMT_FLAGS "d%n", &t, &n);
-    if (converted == 1 && static_cast<std::size_t>(n) == std::strlen(buf))
+    char * end;
+    long long t = strtoll(buf, &end, 10);
+    if (*buf != '\0' && *end == '\0')
     {
         // successfully converted to long long
         // and no other characters were found in the buffer


### PR DESCRIPTION
Saves about 50% instructions on my rather large PostgreSQL query result set as measured using valgrind.
Sscanf showed up as a hotspot. Both versions should be functionally identical.