### PR TITLE
[travis] Switch to Vincit/travis-oracledb-xe installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ matrix:
         - env: SOCI_TRAVIS_BACKEND=sqlite3
         - env: SOCI_TRAVIS_BACKEND=valgrind
         - env: SOCI_TRAVIS_BACKEND=oracle WITH_BOOST=OFF
-    allow_failures:
-        - env: SOCI_TRAVIS_BACKEND=oracle WITH_BOOST=OFF
 
 addons:
   coverity_scan:

--- a/scripts/travis/before_install.sh
+++ b/scripts/travis/before_install.sh
@@ -5,13 +5,8 @@
 #
 source ${TRAVIS_BUILD_DIR}/scripts/travis/common.sh
 
-sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 16126D3A3E5C1192
-sudo add-apt-repository -y ppa:apt-fast/stable
-
 sudo apt-get update -qq -y
-sudo apt-get install -qq -y apt-fast
-sudo apt-fast update -qq -y
-sudo apt-fast install -qq -y libboost-dev libboost-date-time-dev valgrind
+sudo apt-get install -qq -y libboost-dev libboost-date-time-dev valgrind
 
 sh ${TRAVIS_BUILD_DIR}/scripts/travis/install_cmake.sh
 

--- a/scripts/travis/before_install_oracle.sh
+++ b/scripts/travis/before_install_oracle.sh
@@ -6,22 +6,5 @@
 # set -ex
 source ${TRAVIS_BUILD_DIR}/scripts/travis/oracle.sh
 
-# Install Oracle and travis-oracle requirements
-sudo apt-get install -y libaio1 rpm
-
-curl -s -o $HOME/.nvm/nvm.sh https://raw.githubusercontent.com/creationix/nvm/v0.31.0/nvm.sh
-source $HOME/.nvm/nvm.sh
-nvm install stable
-node --version
-
-# Install travis-oracle
-wget 'https://github.com/cbandy/travis-oracle/archive/v2.0.3.tar.gz'
-mkdir -p .travis/oracle
-tar x -C .travis/oracle --strip-components=1 -f v2.0.3.tar.gz
-
-# Download Oracle (do not use Travis CI secure environment!)
-export ORACLE_LOGIN_pass="T$(echo $ORACLE_LOGIN_userid | rev)#2017"
-bash .travis/oracle/download.sh
-
-# Install Oracle
-bash .travis/oracle/install.sh
+wget https://raw.githubusercontent.com/Vincit/travis-oracledb-xe/master/accept_the_license_agreement_for_oracledb_xe_11g_and_install.sh
+bash ./accept_the_license_agreement_for_oracledb_xe_11g_and_install.sh

--- a/scripts/travis/before_script_oracle.sh
+++ b/scripts/travis/before_script_oracle.sh
@@ -13,27 +13,27 @@ echo "ORACLE_SID=${ORACLE_SID}"
 
 # travis-oracle installer created travis user w/o password
 echo "ALTER USER travis IDENTIFIED BY travis;" | \
-$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/travis AS SYSDBA
 
 echo "grant connect, resource to travis;" | \
-$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/travis AS SYSDBA
 
 echo "grant create session, alter any procedure to travis;" | \
-$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/travis AS SYSDBA
 
 # to enable xa recovery, see: https://community.oracle.com/thread/378954
 echo "grant select on sys.dba_pending_transactions to travis;" | \
-$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/travis AS SYSDBA
 echo "grant select on sys.pending_trans$ to travis;" | \
-$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/travis AS SYSDBA
 echo "grant select on sys.dba_2pc_pending to travis;" | \
-$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/travis AS SYSDBA
 echo "grant execute on sys.dbms_system to travis;" | \
-$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/travis AS SYSDBA
 
 # increase default=40 value of processes to prevent ORA-12520 failures while testing
 echo "alter system set processes=100 scope=spfile;" | \
-$ORACLE_HOME/bin/sqlplus -S -L sys/admin AS SYSDBA
+$ORACLE_HOME/bin/sqlplus -S -L sys/travis AS SYSDBA
 
 # check connection as user for testing
 echo "Connecting using travis/travis@XE"

--- a/scripts/travis/oracle.sh
+++ b/scripts/travis/oracle.sh
@@ -5,8 +5,6 @@
 # Notice that this file is not executable, it is supposed to be sourced from
 # the other files.
 
-# Oracle environment required by https://github.com/cbandy/travis-oracle
-export ORACLE_COOKIE=sqldev
-export ORACLE_FILE=oracle11g/xe/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
+# Oracle environment required by https://github.com/Vincit/travis-oracledb-xe
 export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
 export ORACLE_SID=XE


### PR DESCRIPTION
Source: https://github.com/Vincit/travis-oracledb-xe
Author of the instaler, @elhigu, received permission from Oracle to release this installer for use with Travis CI and others: https://github.com/wnameless/docker-oracle-xe-11g/issues/118#issuecomment-473227959

Switch from apt-fast to apt-get.
Due to issues with certificate and/or keyserver, installation of apt-fast has often been failing.

------

This should replace #684 due to issues discussed in https://github.com/wnameless/docker-oracle-xe-11g/issues/118 which have been taking ages to resolve.