### PR TITLE
Add finished call in pg failover callback

### DIFF
--- a/src/backends/postgresql/error.cpp
+++ b/src/backends/postgresql/error.cpp
@@ -126,6 +126,10 @@ details::postgresql_result::check_for_data(char const* errMsg) const
                             // ignore exceptions from user callbacks
                         }
                     }
+                    else
+                    {
+                      callback->finished(*sessionBackend_.session_);
+                    }
                 }
             }
             


### PR DESCRIPTION
Signed-off-by: Fedor Muratov <muratovfyodor@yandex.ru>

### Proposed changes
Regarding the description of `soci::failover_callback`, method `finished` should be called on successful reconnection.
The PR provides a fix for that.

### Drawbacks
I have not found usages of `failover_callback` in tests. So checking test is missing.