### PR TITLE
Add pg reconnection loop

### DIFF
--- a/src/backends/postgresql/error.cpp
+++ b/src/backends/postgresql/error.cpp
@@ -95,20 +95,22 @@ details::postgresql_result::check_for_data(char const* errMsg) const
                         callback->started();
                         
                         bool retry = false;
-                        std::string newTarget;
-                        
-                        callback->failed(retry, newTarget);
-                        
-                        if (retry)
-                        {
-                            connection_parameters parameters("postgresql", newTarget);
-                            
-                            sessionBackend_.clean_up();
-                            
-                            sessionBackend_.connect(parameters);
-                            
-                            reconnected = true;
-                        }
+                        do {
+                            std::string newTarget;
+
+                            callback->failed(retry, newTarget);
+
+                            if (retry)
+                            {
+                                connection_parameters parameters("postgresql", newTarget);
+
+                                sessionBackend_.clean_up();
+
+                                sessionBackend_.connect(parameters);
+
+                                reconnected = true;
+                            }
+                        } while (retry && !reconnected);
                     }
                     catch (...)
                     {


### PR DESCRIPTION
Signed-off-by: Fedor Muratov <muratovfyodor@yandex.ru>

### Proposed changes
In the current implementation, PG backend tries to reconnect only once. But regarding `soci::failover_callback` documentation, a number of connections should be restricted by client code via `failed` method.
The PR contains improvement for PG backend which allows restoring a connection more than once.

### Drawbacks
I haven't seen the usage of `failover_callback` in tests. So the test of the functionality is missed.

### Discussion points
- The implementation is not elegant, and maintainers could guide me in finding better ways to do such changes.
- The number of attempts is limited only by a client's code, and probably there may happen some problems with the connection (e.g. expiration of connection).
