### PR TITLE
Refine try-catch scopes in failover for PostgreSQL

### DIFF
--- a/src/backends/postgresql/error.cpp
+++ b/src/backends/postgresql/error.cpp
@@ -108,7 +108,9 @@ details::postgresql_result::check_for_data(char const* errMsg) const
                         }
                         catch (...)
                         {
-                            // ignore exceptions from user callbacks
+                            // do not continue execution because 
+                            // user callback generated an exception
+                            retry = false;
                         }
 
                         if (retry)

--- a/src/backends/postgresql/error.cpp
+++ b/src/backends/postgresql/error.cpp
@@ -113,7 +113,8 @@ details::postgresql_result::check_for_data(char const* errMsg) const
 
                         if (retry)
                         {
-                            connection_parameters parameters("postgresql", newTarget);
+                            connection_parameters parameters;
+                            parameters.set_connect_string(newTarget);
 
                             sessionBackend_.clean_up();
 

--- a/src/backends/postgresql/error.cpp
+++ b/src/backends/postgresql/error.cpp
@@ -93,29 +93,35 @@ details::postgresql_result::check_for_data(char const* errMsg) const
                     try
                     {
                         callback->started();
-                        
-                        bool retry = false;
-                        do {
-                            std::string newTarget;
-
-                            callback->failed(retry, newTarget);
-
-                            if (retry)
-                            {
-                                connection_parameters parameters("postgresql", newTarget);
-
-                                sessionBackend_.clean_up();
-
-                                sessionBackend_.connect(parameters);
-
-                                reconnected = true;
-                            }
-                        } while (retry && !reconnected);
                     }
                     catch (...)
                     {
                         // ignore exceptions from user callbacks
                     }
+                    bool retry = false;
+                    do {
+                        std::string newTarget;
+
+                        try
+                        {
+                            callback->failed(retry, newTarget);
+                        }
+                        catch (...)
+                        {
+                            // ignore exceptions from user callbacks
+                        }
+
+                        if (retry)
+                        {
+                            connection_parameters parameters("postgresql", newTarget);
+
+                            sessionBackend_.clean_up();
+
+                            sessionBackend_.connect(parameters);
+
+                            reconnected = true;
+                        }
+                    } while (retry && !reconnected);
                     
                     if (reconnected == false)
                     {
@@ -130,7 +136,14 @@ details::postgresql_result::check_for_data(char const* errMsg) const
                     }
                     else
                     {
-                      callback->finished(*sessionBackend_.session_);
+                        try
+                        {
+                            callback->finished(*sessionBackend_.session_);
+                        }
+                        catch (...)
+                        {
+                            // ignore exceptions from user callbacks
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description of the Change
- Remove `sessionBackend_` calls from try-catch, making it possible to catch exceptions from them
- Add missing try-catch for `finished` call
- Remove backend argument from connection parameters to avoid "Failed to find shared library for backend postgresql" error

### Benefits
- Consistent exception handling
- No issues when using static library 

### To discuss
In case of exception from `failed` callback and when `retry` was set to true, the execution will continue. Is this behavior acceptable? Maybe set `retry` to `false` in catch block?
