### PR TITLE
Fix crash in Windows by correctly initializing session member in copy…

### DIFF
--- a/src/core/once-temp-type.cpp
+++ b/src/core/once-temp-type.cpp
@@ -60,13 +60,14 @@ ddl_type::ddl_type(session & s)
 }
 
 ddl_type::ddl_type(const ddl_type & d)
-    :rcst_(d.rcst_)
+    : s_( d.s_ ), rcst_(d.rcst_)
 {
     rcst_->inc_ref();
 }
 
 ddl_type & ddl_type::operator=(const ddl_type & d)
 {
+    s_ = d.s_;
     d.rcst_->inc_ref();
     rcst_->dec_ref();
     rcst_ = d.rcst_;


### PR DESCRIPTION
… constructor.  This happened to work fine in Linux/MacOS but crashed in Windows.

-----

Fixes #565