### PR TITLE
Try using localhost/XE service name for Oracle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,6 @@ env:
 
 matrix:
   include:
-    - env: SOCI_TRAVIS_BACKEND=db2
-    - env: SOCI_TRAVIS_BACKEND=empty CMAKE_CXX_STANDARD=98 TEST_RELEASE_PACKAGE=YES
-    - env: SOCI_TRAVIS_BACKEND=empty CMAKE_CXX_STANDARD=11
-    - env: SOCI_TRAVIS_BACKEND=firebird
-    - env: SOCI_TRAVIS_BACKEND=mysql
-    - env: SOCI_TRAVIS_BACKEND=odbc
-    - env: SOCI_TRAVIS_BACKEND=postgresql
-    - env: SOCI_TRAVIS_BACKEND=sqlite3
-    - env: SOCI_TRAVIS_BACKEND=valgrind
     - env: SOCI_TRAVIS_BACKEND=oracle WITH_BOOST=OFF
 
 addons:

--- a/scripts/travis/script_oracle.sh
+++ b/scripts/travis/script_oracle.sh
@@ -21,7 +21,7 @@ cmake \
     -DSOCI_ORACLE=ON \
     -DSOCI_POSTGRESQL=OFF \
     -DSOCI_SQLITE3=OFF \
-    -DSOCI_ORACLE_TEST_CONNSTR:STRING="service=XE user=travis password=travis" \
+    -DSOCI_ORACLE_TEST_CONNSTR:STRING="service=localhost/XE user=travis password=travis" \
     ..
 
 run_make


### PR DESCRIPTION
Locally using `service=XE` doesn't work for me (gives ORA-12154), but `service=localhost/XE` does, so I wonder if it could explain the Travis build failures as well. Although I have no idea why did it work before but doesn't any more...