### PR TITLE
Ignore spaces in SQLite column decltypes

### DIFF
--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -413,6 +413,8 @@ static sqlite3_data_type_map get_data_type_map()
 {
     sqlite3_data_type_map m;
 
+    // Spaces are removed from decltype before looking up in this map, so we don't use them here as well
+
     // dt_blob
     m["blob"]               = dt_blob;
 
@@ -424,7 +426,7 @@ static sqlite3_data_type_map get_data_type_map()
     // dt_double
     m["decimal"]            = dt_double;
     m["double"]             = dt_double;
-    m["double precision"]   = dt_double;
+    m["doubleprecision"]    = dt_double;
     m["float"]              = dt_double;
     m["number"]             = dt_double;
     m["numeric"]            = dt_double;
@@ -447,15 +449,15 @@ static sqlite3_data_type_map get_data_type_map()
     m["char"]               = dt_string;
     m["character"]          = dt_string;
     m["clob"]               = dt_string;
-    m["native character"]   = dt_string;
+    m["nativecharacter"]    = dt_string;
     m["nchar"]              = dt_string;
     m["nvarchar"]           = dt_string;
     m["text"]               = dt_string;
     m["varchar"]            = dt_string;
-    m["varying character"]  = dt_string;
+    m["varyingcharacter"]   = dt_string;
 
     // dt_unsigned_long_long
-    m["unsigned big int"]   = dt_unsigned_long_long;
+    m["unsignedbigint"]   = dt_unsigned_long_long;
 
 
     return m;
@@ -494,10 +496,14 @@ void sqlite3_statement_backend::describe_column(int colNum, data_type & type,
 
     std::string dt = declType;
 
-    // remove extra characters for example "(20)" in "varchar(20)"
+    // remove extra characters for example "(20)" in "varchar(20)" and all spaces
 #if defined(SOCI_HAVE_CXX11) || (defined(_MSC_VER) && _MSC_VER >= 1800)
+    dt.erase(std::remove_if(dt.begin(), dt.end(), [](char const c) { return std::isspace(c); }), dt.end());
+
     std::string::iterator siter = std::find_if(dt.begin(), dt.end(), [](char const c) { return !std::isalnum(c); });
 #else
+    dt.erase(std::remove_if(dt.begin(), dt.end(), std::ptr_fun(isspace)), dt.end());
+
     std::string::iterator siter = std::find_if(dt.begin(), dt.end(), std::not1(std::ptr_fun(isalnum)));
 #endif
     if (siter != dt.end())

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -237,6 +237,44 @@ TEST_CASE("SQLite vector long long", "[sqlite][vector][longlong]")
     CHECK(v2[4] == 1000000000000LL);
 }
 
+struct type_inference_table_creator : table_creator_base
+{
+    type_inference_table_creator(soci::session & sql)
+        : table_creator_base(sql)
+    {
+        sql << "create table soci_test(cvc varchar (10), cdec decimal (20), "
+               "cll bigint, cull unsigned bigint, clls big int, culls unsigned big int)";
+    }
+};
+
+// test for correct type inference form sqlite column type
+TEST_CASE("SQLite type inference", "[sqlite][sequence]")
+{
+    soci::session sql(backEnd, connectString);
+
+    type_inference_table_creator tableCreator(sql);
+
+    std::string cvc = "john";
+    double cdec = 12345.0;  // integers can be stored precisely in IEEE 754
+    long long cll = 1000000000003LL;
+    unsigned long long cull = 1000000000004ULL;
+
+    sql << "insert into soci_test(cvc, cdec, cll, cull, clls, culls) values(:cvc, :cdec, :cll, :cull, :clls, :culls)",
+        use(cvc), use(cdec), use(cll), use(cull), use(cll), use(cull);
+
+    {
+        rowset<row> rs = (sql.prepare << "select * from soci_test");
+        rowset<row>::const_iterator it = rs.begin();
+        row const& r1 = (*it);
+        CHECK(r1.get<std::string>(0) == cvc);
+        CHECK(r1.get<double>(1) == Approx(cdec));
+        CHECK(r1.get<long long>(2) == cll);
+        CHECK(r1.get<unsigned long long>(3) == cull);
+        CHECK(r1.get<long long>(4) == cll);
+        CHECK(r1.get<unsigned long long>(5) == cull);
+    }
+}
+
 TEST_CASE("SQLite DDL wrappers", "[sqlite][ddl]")
 {
     soci::session sql(backEnd, connectString);


### PR DESCRIPTION
This allows for "BIG INT" as well as "BIGINT", and fixed previouisly broken "UNSIGNED BIG INT"