### PR TITLE
dt_blob and dt_xml can be returned in rowset

### DIFF
--- a/src/core/statement.cpp
+++ b/src/core/statement.cpp
@@ -684,6 +684,12 @@ void statement_impl::describe()
         case dt_string:
             bind_into<dt_string>();
             break;
+        case dt_blob:
+            bind_into<dt_string>();
+            break;
+        case dt_xml:
+            bind_into<dt_string>();
+            break;
         case dt_double:
             bind_into<dt_double>();
             break;


### PR DESCRIPTION
I see no reason why these types could not be returned in rowset