### PR TITLE
Fix 723 stdtm dst problem

### DIFF
--- a/include/private/soci-mktime.h
+++ b/include/private/soci-mktime.h
@@ -11,7 +11,7 @@
 // Not <ctime> because we also want to get timegm() if available.
 #include <time.h>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #define timegm _mkgmtime
 #endif
 

--- a/include/private/soci-mktime.h
+++ b/include/private/soci-mktime.h
@@ -28,15 +28,19 @@ mktime_from_ymdhms(tm& t,
                    int year, int month, int day,
                    int hour, int minute, int second)
 {
-    t.tm_isdst = -1;
+    t.tm_isdst = -1;  // DST is unknown
+    t.tm_wday = -1;   // Not set
+    t.tm_yday = -1;   // Not set
+    
     t.tm_year = year - 1900;
     t.tm_mon  = month - 1;
     t.tm_mday = day;
     t.tm_hour = hour;
     t.tm_min  = minute;
     t.tm_sec  = second;
-
-    mktime(&t);
+    
+    // There is no normalisation via mktime() due to Daylight Saving Time
+    // and time zone complications. See issue 723.
 }
 
 // Helper function for parsing datetime values.

--- a/include/private/soci-mktime.h
+++ b/include/private/soci-mktime.h
@@ -11,6 +11,10 @@
 // Not <ctime> because we also want to get timegm() if available.
 #include <time.h>
 
+#ifdef _MSC_VER
+#define timegm _mkgmtime
+#endif
+
 namespace soci
 {
 
@@ -28,19 +32,15 @@ mktime_from_ymdhms(tm& t,
                    int year, int month, int day,
                    int hour, int minute, int second)
 {
-    t.tm_isdst = -1;  // DST is unknown
-    t.tm_wday = -1;   // Not set
-    t.tm_yday = -1;   // Not set
-    
+    t.tm_isdst = -1;
     t.tm_year = year - 1900;
     t.tm_mon  = month - 1;
     t.tm_mday = day;
     t.tm_hour = hour;
     t.tm_min  = minute;
     t.tm_sec  = second;
-    
-    // There is no normalisation via mktime() due to Daylight Saving Time
-    // and time zone complications. See issue 723.
+
+    timegm(&t);
 }
 
 // Helper function for parsing datetime values.

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4025,7 +4025,7 @@ TEST_CASE_METHOD(common_tests, "Bind memory leak", "[core][leak]")
 
 // The issue 723 test does not work under Windows as TZ environment variable
 // does not reliably override the system time zone
-#ifndef _MSC_VER
+#ifndef _WIN32
 
 // Helper functions for issue 723 test
 namespace {

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4071,7 +4071,7 @@ TEST_CASE_METHOD(common_tests, "std::tm timestamp problem with DST", "[core][int
     // Store original TZ value so it can be replaced when the test finishes
     std::string original_tz_value;
     char* tz_value = getenv("TZ");
-    if (tz_value != nullptr)
+    if (tz_value != NULL)
     {
         original_tz_value = tz_value;
     }

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -38,9 +38,9 @@ TEST_CASE("Oracle datetime", "[oracle][datetime]")
         CHECK(t1.tm_mday == t2.tm_mday);
         CHECK(t1.tm_mon == t2.tm_mon);
         CHECK(t1.tm_year == t2.tm_year);
-        CHECK(t1.tm_wday == t2.tm_wday);
-        CHECK(t1.tm_yday == t2.tm_yday);
-        CHECK(t1.tm_isdst == t2.tm_isdst);
+        CHECK(t1.tm_wday == -1);  // Not calculated by SOCI, always -1
+        CHECK(t1.tm_yday == -1);  // Not calculated by SOCI, always -1
+        CHECK(t1.tm_isdst == -1); // DST is unknown
 
         // make sure the date is stored properly in Oracle
         char buf[25];
@@ -69,9 +69,9 @@ TEST_CASE("Oracle datetime", "[oracle][datetime]")
         CHECK(t1.tm_mday == t2.tm_mday);
         CHECK(t1.tm_mon == t2.tm_mon);
         CHECK(t1.tm_year == t2.tm_year);
-        CHECK(t1.tm_wday == t2.tm_wday);
-        CHECK(t1.tm_yday == t2.tm_yday);
-        CHECK(t1.tm_isdst == t2.tm_isdst);
+        CHECK(t1.tm_wday == -1);  // Not calculated by SOCI, always -1
+        CHECK(t1.tm_yday == -1);  // Not calculated by SOCI, always -1
+        CHECK(t1.tm_isdst == -1); // DST is unknown
 
         // make sure the date is stored properly in Oracle
         char buf[25];

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -38,9 +38,9 @@ TEST_CASE("Oracle datetime", "[oracle][datetime]")
         CHECK(t1.tm_mday == t2.tm_mday);
         CHECK(t1.tm_mon == t2.tm_mon);
         CHECK(t1.tm_year == t2.tm_year);
-        CHECK(t1.tm_wday == -1);  // Not calculated by SOCI, always -1
-        CHECK(t1.tm_yday == -1);  // Not calculated by SOCI, always -1
-        CHECK(t1.tm_isdst == -1); // DST is unknown
+        CHECK(t1.tm_wday == t2.tm_wday);
+        CHECK(t1.tm_yday == t2.tm_yday);
+        CHECK(t1.tm_isdst == t2.tm_isdst);
 
         // make sure the date is stored properly in Oracle
         char buf[25];
@@ -69,9 +69,9 @@ TEST_CASE("Oracle datetime", "[oracle][datetime]")
         CHECK(t1.tm_mday == t2.tm_mday);
         CHECK(t1.tm_mon == t2.tm_mon);
         CHECK(t1.tm_year == t2.tm_year);
-        CHECK(t1.tm_wday == -1);  // Not calculated by SOCI, always -1
-        CHECK(t1.tm_yday == -1);  // Not calculated by SOCI, always -1
-        CHECK(t1.tm_isdst == -1); // DST is unknown
+        CHECK(t1.tm_wday == t2.tm_wday);
+        CHECK(t1.tm_yday == t2.tm_yday);
+        CHECK(t1.tm_isdst == t2.tm_isdst);
 
         // make sure the date is stored properly in Oracle
         char buf[25];


### PR DESCRIPTION
This is a fix for Issue #723 which causes date/time inaccuracies reading dates when the date/time is on a Daylight Savings Time threshold.

The main fix is to replace the mktime() call in mktime_from_ymdhms() in soci-mktime.h with a call to timegm() instead, which is time-zone agnostic.

A regression test has been added for Issue #723. This will only work on non-Windows platforms so has been #ifdef'd out on Windows.

The code has been compiled on VC++ 2017 and GCC 7.5.0. Test suite has been run on Oracle/Postgres on Windows 10 and Postgres/SQLite on Ubuntu Linux18.04.

(Edited to reflect change in bug fix to use timegm())