### PR TITLE
For performance reasons, use strtoll() instead of sscanf()

### DIFF
--- a/include/private/soci-cstrtoi.h
+++ b/include/private/soci-cstrtoi.h
@@ -1,0 +1,87 @@
+//
+// Copyright (C) 2020 Vadim Zeitlin.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_PRIVATE_SOCI_CSTRTOI_H_INCLUDED
+#define SOCI_PRIVATE_SOCI_CSTRTOI_H_INCLUDED
+
+#include "soci/error.h"
+
+#include <cstdlib>
+#include <limits>
+
+namespace soci
+{
+
+namespace details
+{
+
+// Convert string to a signed value of the given type, checking for overflow.
+//
+// Fill the provided result parameter and return true on success or false on
+// error, e.g. if the string couldn't be converted at all, if anything remains
+// in the string after conversion or if the value is out of range.
+template <typename T>
+bool cstring_to_integer(T& result, char const* buf)
+{
+    char * end;
+
+    // No strtoll() on MSVC versions prior to Visual Studio 2013
+#if !defined (_MSC_VER) || (_MSC_VER >= 1800)
+    long long t = strtoll(buf, &end, 10);
+#else
+    long long t = _strtoi64(buf, &end, 10);
+#endif
+
+    if (end == buf || *end != '\0')
+        return false;
+
+    // successfully converted to long long
+    // and no other characters were found in the buffer
+
+    const T max = (std::numeric_limits<T>::max)();
+    const T min = (std::numeric_limits<T>::min)();
+    if (t > static_cast<long long>(max) || t < static_cast<long long>(min))
+        return false;
+
+    result = static_cast<T>(t);
+
+    return true;
+}
+
+// Similar to the above, but for the unsigned integral types.
+template <typename T>
+bool cstring_to_unsigned(T& result, char const* buf)
+{
+    char * end;
+
+    // No strtoll() on MSVC versions prior to Visual Studio 2013
+#if !defined (_MSC_VER) || (_MSC_VER >= 1800)
+    unsigned long long t = strtoull(buf, &end, 10);
+#else
+    unsigned long long t = _strtoui64(buf, &end, 10);
+#endif
+
+    if (end == buf || *end != '\0')
+        return false;
+
+    // successfully converted to unsigned long long
+    // and no other characters were found in the buffer
+
+    const T max = (std::numeric_limits<T>::max)();
+    if (t > static_cast<unsigned long long>(max))
+        return false;
+
+    result = static_cast<T>(t);
+
+    return true;
+}
+
+} // namespace details
+
+} // namespace soci
+
+#endif // SOCI_PRIVATE_SOCI_CSTRTOI_H_INCLUDED

--- a/src/backends/odbc/standard-into-type.cpp
+++ b/src/backends/odbc/standard-into-type.cpp
@@ -8,10 +8,10 @@
 #define SOCI_ODBC_SOURCE
 #include "soci/soci-platform.h"
 #include "soci/odbc/soci-odbc.h"
+#include "soci-cstrtoi.h"
 #include "soci-exchange-cast.h"
 #include "soci-mktime.h"
 #include <ctime>
-#include <stdio.h>  // sscanf()
 
 using namespace soci;
 using namespace soci::details;
@@ -182,7 +182,7 @@ void odbc_standard_into_type_backend::post_fetch(
         else if (type_ == x_long_long && use_string_for_bigint())
         {
           long long& ll = exchange_type_cast<x_long_long>(data_);
-          if (sscanf(buf_, "%" LL_FMT_FLAGS "d", &ll) != 1)
+          if (!cstring_to_integer(ll, buf_))
           {
             throw soci_error("Failed to parse the returned 64-bit integer value");
           }
@@ -190,7 +190,7 @@ void odbc_standard_into_type_backend::post_fetch(
         else if (type_ == x_unsigned_long_long && use_string_for_bigint())
         {
           unsigned long long& ll = exchange_type_cast<x_unsigned_long_long>(data_);
-          if (sscanf(buf_, "%" LL_FMT_FLAGS "u", &ll) != 1)
+          if (!cstring_to_unsigned(ll, buf_))
           {
             throw soci_error("Failed to parse the returned 64-bit integer value");
           }

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -8,6 +8,7 @@
 #define SOCI_ODBC_SOURCE
 #include "soci/soci-platform.h"
 #include "soci/odbc/soci-odbc.h"
+#include "soci-cstrtoi.h"
 #include "soci-mktime.h"
 #include "soci-static-assert.h"
 #include <cctype>
@@ -15,7 +16,6 @@
 #include <cstring>
 #include <ctime>
 #include <sstream>
-#include <stdio.h>  // sscanf()
 
 using namespace soci;
 using namespace soci::details;
@@ -285,7 +285,7 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             std::size_t const vsize = v.size();
             for (std::size_t i = 0; i != vsize; ++i)
             {
-                if (sscanf(pos, "%" LL_FMT_FLAGS "d", &v[i]) != 1)
+                if (!cstring_to_integer(v[i], pos))
                 {
                     throw soci_error("Failed to parse the returned 64-bit integer value");
                 }
@@ -301,7 +301,7 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             std::size_t const vsize = v.size();
             for (std::size_t i = 0; i != vsize; ++i)
             {
-                if (sscanf(pos, "%" LL_FMT_FLAGS "u", &v[i]) != 1)
+                if (!cstring_to_unsigned(v[i], pos))
                 {
                     throw soci_error("Failed to parse the returned 64-bit integer value");
                 }

--- a/src/backends/postgresql/common.h
+++ b/src/backends/postgresql/common.h
@@ -11,6 +11,7 @@
 #include "soci/postgresql/soci-postgresql.h"
 #include <limits>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <vector>
@@ -28,10 +29,16 @@ namespace postgresql
 template <typename T>
 T string_to_integer(char const * buf)
 {
-    long long t(0);
-    int n(0);
-    int const converted = std::sscanf(buf, "%" LL_FMT_FLAGS "d%n", &t, &n);
-    if (converted == 1 && static_cast<std::size_t>(n) == std::strlen(buf))
+    char * end;
+
+    // No strtoll() on MSVC versions prior to Visual Studio 2013
+#if !defined (_MSC_VER) || (_MSC_VER >= 1800)
+    long long t = strtoll(buf, &end, 10);
+#else
+    long long t = _strtoi64(buf, &end, 10);
+#endif
+
+    if (*buf != '\0' && *end == '\0')
     {
         // successfully converted to long long
         // and no other characters were found in the buffer

--- a/src/backends/sqlite3/common.h
+++ b/src/backends/sqlite3/common.h
@@ -14,7 +14,6 @@
 #include <cstring>
 #include <ctime>
 #include <vector>
-#include <limits>
 
 namespace soci { namespace details { namespace sqlite3 {
 
@@ -31,52 +30,6 @@ void resize_vector(void *p, std::size_t sz)
 {
     std::vector<T> *v = static_cast<std::vector<T> *>(p);
     v->resize(sz);
-}
-
-// helper function for parsing integers
-template <typename T>
-T string_to_integer(char const * buf)
-{
-    long long t(0);
-    int n(0);
-    int const converted = std::sscanf(buf, "%" LL_FMT_FLAGS "d%n", &t, &n);
-    if (converted == 1 && static_cast<std::size_t>(n) == std::strlen(buf))
-    {
-        // successfully converted to long long
-        // and no other characters were found in the buffer
-
-        const T max = (std::numeric_limits<T>::max)();
-        const T min = (std::numeric_limits<T>::min)();
-        if (t <= static_cast<long long>(max) &&
-            t >= static_cast<long long>(min))
-        {
-            return static_cast<T>(t);
-        }
-    }
-
-    throw soci_error("Cannot convert data.");
-}
-
-// helper function for parsing unsigned integers
-template <typename T>
-T string_to_unsigned_integer(char const * buf)
-{
-    unsigned long long t(0);
-    int n(0);
-    int const converted = std::sscanf(buf, "%" LL_FMT_FLAGS "u%n", &t, &n);
-    if (converted == 1 && static_cast<std::size_t>(n) == std::strlen(buf))
-    {
-        // successfully converted to unsigned long long
-        // and no other characters were found in the buffer
-
-        T const max = (std::numeric_limits<T>::max)();
-        if (t <= static_cast<unsigned long long>(max))
-        {
-            return static_cast<T>(t);
-        }
-    }
-
-    throw soci_error("Cannot convert data.");
 }
 
 }}} // namespace soci::details::sqlite3

--- a/src/backends/sqlite3/vector-into-type.cpp
+++ b/src/backends/sqlite3/vector-into-type.cpp
@@ -10,6 +10,7 @@
 #endif
 
 #define SOCI_SQLITE3_SOURCE
+#include "soci-cstrtoi.h"
 #include "soci-dtocstr.h"
 #include "soci-exchange-cast.h"
 #include "soci/blob.h"
@@ -64,7 +65,13 @@ void set_number_in_vector(void *p, int idx, const sqlite3_column &col)
         case dt_date:
         case dt_string:
         case dt_blob:
-            set_in_vector(p, idx, string_to_integer<T>(col.buffer_.size_ > 0 ? col.buffer_.constData_ : ""));
+            {
+                T value;
+                if (!details::cstring_to_integer(value, col.buffer_.size_ > 0 ? col.buffer_.constData_ : ""))
+                    throw soci_error("Cannot convert data");
+
+                set_in_vector(p, idx, value);
+            }
             break;
 
         case dt_double:


### PR DESCRIPTION
Should be functionally identical.

---

This is the updated version of #724.