### PR TITLE
Fall back on SQL_DRIVER_NOPROMPT when pooling ODBC connections

### DIFF
--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -73,26 +73,56 @@ odbc_session_backend::odbc_session_backend(
 #endif // _WIN32
 
     std::string const & connectString = parameters.get_connect_string();
-    rc = SQLDriverConnect(hdbc_, hwnd_for_prompt,
-                          sqlchar_cast(connectString),
-                          (SQLSMALLINT)connectString.size(),
-                          outConnString, 1024, &strLength,
-                          static_cast<SQLUSMALLINT>(completion));
 
-    // Don't use is_odbc_error() here as it doesn't consider SQL_NO_DATA to be
-    // an error -- but it is one here, as it's returned if a message box shown
-    // by SQLDriverConnect() was cancelled and this means we failed to connect.
-    switch (rc)
+    // This "infinite" loop can be executed at most twice.
+    std::string errContext;
+    for (;;)
     {
-      case SQL_SUCCESS:
-      case SQL_SUCCESS_WITH_INFO:
+        rc = SQLDriverConnect(hdbc_, hwnd_for_prompt,
+                              sqlchar_cast(connectString),
+                              (SQLSMALLINT)connectString.size(),
+                              outConnString, 1024, &strLength,
+                              static_cast<SQLUSMALLINT>(completion));
+
+        // Don't use is_odbc_error() here as it doesn't consider SQL_NO_DATA to be
+        // an error -- but it is one here, as it's returned if a message box shown
+        // by SQLDriverConnect() was cancelled and this means we failed to connect.
+        switch (rc)
+        {
+          case SQL_SUCCESS:
+          case SQL_SUCCESS_WITH_INFO:
+            break;
+
+          case SQL_NO_DATA:
+            throw soci_error("Connecting to the database cancelled by user.");
+
+          default:
+            odbc_soci_error err(SQL_HANDLE_DBC, hdbc_, "connecting to database");
+
+            // If connection pooling had been enabled by the application, we
+            // would get HY110 ODBC error for any connection attempt not using
+            // SQL_DRIVER_NOPROMPT, so it's worth retrying with it in this
+            // case: in the worst case, we'll hit 28000 ODBC error (login
+            // failed), which we'll report together with the context helping to
+            // understand where it came from.
+            if (memcmp(err.odbc_error_code(), "HY110", 6) == 0 &&
+                    completion != SQL_DRIVER_NOPROMPT)
+            {
+                errContext = "while retrying to connect without prompting, as "
+                             "prompting the user is not supported when using "
+                             "pooled connections";
+                completion = SQL_DRIVER_NOPROMPT;
+                continue;
+            }
+
+            if (!errContext.empty())
+                err.add_context(errContext);
+
+            throw err;
+        }
+
+        // This loop only runs once unless we retry in case of HY110 above.
         break;
-
-      case SQL_NO_DATA:
-        throw soci_error("Connecting to the database cancelled by user.");
-
-      default:
-        throw odbc_soci_error(SQL_HANDLE_DBC, hdbc_, "connecting to database");
     }
 
     connection_string_.assign((const char*)outConnString, strLength);


### PR DESCRIPTION
The application may enable (sometimes even inadvertently, simply due to
its use of another ODBC library which does it, e.g. pyODBC does this by
default) the use of pooled ODBC connections before trying to open a SOCI
session.

In this case, only the use of SQL_DRIVER_NOPROMPT is allowed by ODBC
driver manager and attempts to connect with any other "completion"
parameter value result in ODBC error "HY110". As the code using SOCI
may be completely oblivious to the use of pooled connections (e.g. SOCI
is used by another library in the same application and has no knowledge
whatsoever about the first library), it makes sense to try to do our
best in this situation and automatically try to fall back on connecting
with SQL_DRIVER_NOPROMPT in this case.

This commit implements this solution by adding a special check for this
case.

Note that these changes are best viewed ignoring whitespace.