### PR TITLE
Add call to OCIDescriptorFree() to free LOB Locator and fix memory leak

### DIFF
--- a/src/backends/oracle/standard-use-type.cpp
+++ b/src/backends/oracle/standard-use-type.cpp
@@ -593,6 +593,10 @@ void oracle_standard_use_type_backend::clean_up()
         // ignore errors from this call
         (void) OCILobFreeTemporary(statement_.session_.svchp_, statement_.session_.errhp_,
             lobp);
+
+        // free LOB Locator
+        OCIDescriptorFree(lobp, OCI_DTYPE_LOB);
+        ociData_ = NULL;
     }
     
     if (bindp_ != NULL)


### PR DESCRIPTION
This is a fix for issue #808 where writing to Oracle CLOBs causes a memory leak in Windows.

`oracle_standard_use_type_backend::clean_up()` is modified so it calls `OCIDescriptorFree(lobp, OCI_TYPE_LOB)` following the call to `OCILobFreeTemporary()`. This will deallocate the LOB Locator for the temporary LOB and seems to fix the leak.

