### PR TITLE
Suppress -Wcast-align in ODBC backend code under ARM

### DIFF
--- a/src/backends/odbc/standard-into-type.cpp
+++ b/src/backends/odbc/standard-into-type.cpp
@@ -8,6 +8,7 @@
 #define SOCI_ODBC_SOURCE
 #include "soci/soci-platform.h"
 #include "soci/odbc/soci-odbc.h"
+#include "soci-compiler.h"
 #include "soci-cstrtoi.h"
 #include "soci-exchange-cast.h"
 #include "soci-mktime.h"
@@ -173,7 +174,14 @@ void odbc_standard_into_type_backend::post_fetch(
         {
             std::tm& t = exchange_type_cast<x_stdtm>(data_);
 
+            // Our pointer should, in fact, be sufficiently aligned, as we
+            // allocate it on the heap, but gcc on ARMv7hl warns about this not
+            // being the case, so just suppress this warning explicitly here.
+            GCC_WARNING_SUPPRESS(cast-align)
+
             TIMESTAMP_STRUCT * ts = reinterpret_cast<TIMESTAMP_STRUCT*>(buf_);
+
+            GCC_WARNING_RESTORE(cast-align)
 
             details::mktime_from_ymdhms(t,
                                         ts->year, ts->month, ts->day,


### PR DESCRIPTION
This warning should be harmless, so just suppress it to allow building
SOCI under ARMv7hl architecture (all warnings are fatal due to the use
of -Werror).

Closes #812.