### PR TITLE
Support "vfs" flag in SQLite3 backend connection parameters

### DIFF
--- a/docs/backends/sqlite3.md
+++ b/docs/backends/sqlite3.md
@@ -52,6 +52,7 @@ The set of parameters used in the connection string for SQLite is:
 * `readonly` - open database in read-only mode instead of the default read-write (note that the database file must already exist in this case, see [the documentation](https://www.sqlite.org/c3ref/open.html))
 * `synchronous` - set the pragma synchronous flag ([link](http://www.sqlite.org/pragma.html#pragma_synchronous))
 * `shared_cache` - should be `true` ([link](http://www.sqlite.org/c3ref/enable_shared_cache.html))
+* `vfs` - set the SQLite VFS used to as OS interface. The VFS should be registered before opening the connection, see [the documenation](https://www.sqlite.org/vfs.html)
 
 Once you have created a `session` object as shown above, you can use it to access the database, for example:
 

--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -58,6 +58,7 @@ sqlite3_session_backend::sqlite3_session_backend(
 {
     int timeout = 0;
     int connection_flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
+    std::string vfs;
     std::string synchronous;
     std::string const & connectString = parameters.get_connect_string();
     std::string dbname(connectString);
@@ -108,9 +109,14 @@ sqlite3_session_backend::sqlite3_session_backend(
         {
             connection_flags |= SQLITE_OPEN_SHAREDCACHE;
         }
+        else if ("vfs" == key)
+        {
+            vfs = val;
+        }
+
     }
 
-    int res = sqlite3_open_v2(dbname.c_str(), &conn_, connection_flags, NULL);
+    int res = sqlite3_open_v2(dbname.c_str(), &conn_, connection_flags, (vfs.empty()?NULL:vfs.c_str()));
     check_sqlite_err(conn_, res, "Cannot establish connection to the database. ");
 
     if (!synchronous.empty())


### PR DESCRIPTION
Allow passing a pre-registered sqlite3 vfs string identifier to the
database open function