### PR TITLE
Ignore alignment warnings/errors in firebird backend

### DIFF
--- a/include/private/firebird/common.h
+++ b/include/private/firebird/common.h
@@ -9,6 +9,7 @@
 #define SOCI_FIREBIRD_COMMON_H_INCLUDED
 
 #include "soci/firebird/soci-firebird.h"
+#include "soci-compiler.h"
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
@@ -231,6 +232,8 @@ T1 from_isc(XSQLVAR * var)
         }
     }
 
+    GCC_WARNING_SUPPRESS(cast-align)
+
     switch (var->sqltype & ~1)
     {
     case SQL_SHORT:
@@ -246,6 +249,8 @@ T1 from_isc(XSQLVAR * var)
     default:
         throw soci_error("Incorrect data type for numeric conversion");
     }
+
+    GCC_WARNING_RESTORE(cast-align)
 }
 
 template <typename T>

--- a/src/backends/firebird/common.cpp
+++ b/src/backends/firebird/common.cpp
@@ -8,6 +8,7 @@
 #include "soci/soci-platform.h"
 #include "firebird/common.h"
 #include "soci/soci-backend.h"
+#include "soci-compiler.h"
 #include <ibase.h> // FireBird
 #include <cstddef>
 #include <cstring>
@@ -189,7 +190,12 @@ std::string getTextParam(XSQLVAR const *var)
 
     if ((var->sqltype & ~1) == SQL_VARYING)
     {
+	GCC_WARNING_SUPPRESS(cast-align)
+
         size = *reinterpret_cast<short*>(var->sqldata);
+
+	GCC_WARNING_RESTORE(cast-align)
+
         offset = sizeof(short);
     }
     else if ((var->sqltype & ~1) == SQL_TEXT)

--- a/src/backends/firebird/standard-into-type.cpp
+++ b/src/backends/firebird/standard-into-type.cpp
@@ -8,6 +8,7 @@
 #define SOCI_FIREBIRD_SOURCE
 #include "soci/firebird/soci-firebird.h"
 #include "soci-exchange-cast.h"
+#include "soci-compiler.h"
 #include "firebird/common.h"
 #include "soci/soci.h"
 
@@ -118,7 +119,11 @@ void firebird_standard_into_type_backend::exchangeData()
                     throw soci_error("Can't get Firebid BLOB BackEnd");
                 }
 
+		GCC_WARNING_SUPPRESS(cast-align)
+
                 blob->assign(*reinterpret_cast<ISC_QUAD*>(buf_));
+
+		GCC_WARNING_RESTORE(cast-align)
             }
             break;
 
@@ -138,7 +143,12 @@ void firebird_standard_into_type_backend::exchangeData()
 void firebird_standard_into_type_backend::copy_from_blob(std::string& out)
 {
     firebird_blob_backend blob(statement_.session_);
+
+    GCC_WARNING_SUPPRESS(cast-align)
+
     blob.assign(*reinterpret_cast<ISC_QUAD*>(buf_));
+
+    GCC_WARNING_RESTORE(cast-align)
 
     std::size_t const len_total = blob.get_len();
     out.resize(len_total);


### PR DESCRIPTION
When building on various non-x86 architectures (including arm, mips, sparc), SOCI fails to build from source due to the combination of -Wcast-align and -Werror.

This issue is somewhat related to #812, #813, and #815.  However, rather than being an issue with the ODBC backend, it's the Firebird backend in this case.

Since the warning/error cases all cast the first array element and pass/return the result by value, the alignment should be guaranteed. So it seems appropriate to ignore the warnings as was done in #813.

Applying the changes in this commit (as well as the commits from #813) allows for successful builds on all Debian-supported architectures where the dependencies can be satisfied (i.e., everything but kfreebsd and hurd).