### PR TITLE
Define SOCI_NOEXCEPT and use it instead of deprecated "throw()"

### DIFF
--- a/include/soci/db2/soci-db2.h
+++ b/include/soci/db2/soci-db2.h
@@ -64,7 +64,7 @@ namespace soci
 class SOCI_DB2_DECL db2_soci_error : public soci_error {
 public:
     db2_soci_error(std::string const & msg, SQLRETURN rc) : soci_error(msg),errorCode(rc) {};
-    ~db2_soci_error() throw() SOCI_OVERRIDE { };
+    ~db2_soci_error() SOCI_NOEXCEPT SOCI_OVERRIDE { };
 
     //We have to extract error information before exception throwing, cause CLI handles could be broken at the construction time
     static const std::string sqlState(std::string const & msg,const SQLSMALLINT htype,const SQLHANDLE hndl);

--- a/include/soci/error.h
+++ b/include/soci/error.h
@@ -25,14 +25,14 @@ public:
     soci_error(soci_error const& e);
     soci_error& operator=(soci_error const& e);
 
-    ~soci_error() throw() SOCI_OVERRIDE;
+    ~soci_error() SOCI_NOEXCEPT SOCI_OVERRIDE;
 
     // Returns just the error message itself, without the context.
     std::string get_error_message() const;
 
     // Returns the full error message combining the message given to the ctor
     // with all the available context records.
-    char const* what() const throw() SOCI_OVERRIDE;
+    char const* what() const SOCI_NOEXCEPT SOCI_OVERRIDE;
 
     // This is used only by SOCI itself to provide more information about the
     // exception as it bubbles up. It can be called multiple times, with the

--- a/include/soci/firebird/soci-firebird.h
+++ b/include/soci/firebird/soci-firebird.h
@@ -49,7 +49,7 @@ public:
     firebird_soci_error(std::string const & msg,
         ISC_STATUS const * status = 0);
 
-    ~firebird_soci_error() throw() SOCI_OVERRIDE {};
+    ~firebird_soci_error() SOCI_NOEXCEPT SOCI_OVERRIDE {};
 
     std::vector<ISC_STATUS> status_;
 };

--- a/include/soci/soci-platform.h
+++ b/include/soci/soci-platform.h
@@ -137,6 +137,7 @@ namespace cxx_details
 #define SOCI_UNUSED(x) (void)x;
 
 #if defined(SOCI_HAVE_CXX11) || (defined(_MSC_VER) && _MSC_VER >= 1900)
+    #define SOCI_NOEXCEPT noexcept
     #define SOCI_NOEXCEPT_FALSE noexcept(false)
 #else
     #if defined(__cplusplus) && __cplusplus >= 201103L
@@ -145,6 +146,7 @@ namespace cxx_details
         #error "SOCI must be configured with C++11 support when using C++11"
     #endif
 
+    #define SOCI_NOEXCEPT throw()
     #define SOCI_NOEXCEPT_FALSE
 #endif
 

--- a/src/core/error.cpp
+++ b/src/core/error.cpp
@@ -118,7 +118,7 @@ soci_error& soci_error::operator=(soci_error const& e)
     return *this;
 }
 
-soci_error::~soci_error() throw()
+soci_error::~soci_error() SOCI_NOEXCEPT
 {
     delete info_;
 }
@@ -128,7 +128,7 @@ std::string soci_error::get_error_message() const
     return std::runtime_error::what();
 }
 
-char const* soci_error::what() const throw()
+char const* soci_error::what() const SOCI_NOEXCEPT
 {
     if (info_)
         return info_->get_full_message(get_error_message());


### PR DESCRIPTION
Add another C++11-like macro (similar to SOCI_OVERRIDE) which can also
be used in C++98 code.

The main advantage is that new code can now use SOCI_NOEXCEPT instead of
the old "throw()" and it will be possible to simply replace it with
"noexcept" after dropping C++98 support.