### PR TITLE
Add private auto_statement RAII helper

### DIFF
--- a/include/private/soci-autostatement.h
+++ b/include/private/soci-autostatement.h
@@ -1,0 +1,42 @@
+//
+// Copyright (C) 2020 Vadim Zeitlin
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_PRIVATE_SOCI_AUTOSTATEMENT_H_INCLUDED
+#define SOCI_PRIVATE_SOCI_AUTOSTATEMENT_H_INCLUDED
+
+namespace soci
+{
+
+namespace details
+{
+
+// This helper class can be used with any statement backend to initialize and
+// cleanup a statement backend object in a RAII way. Normally this is not
+// needed because it's done by statement_impl, but this can be handy when using
+// a concrete backend inside this backend own code, see e.g. ODBC session
+// implementation.
+template <typename Backend>
+struct auto_statement : Backend
+{
+    template <typename Session>
+    explicit auto_statement(Session& session)
+        : Backend(session)
+    {
+        this->alloc();
+    }
+
+    ~auto_statement() SOCI_OVERRIDE
+    {
+        this->clean_up();
+    }
+};
+
+} // namespace details
+
+} // namespace soci
+
+#endif // SOCI_PRIVATE_SOCI_AUTOSTATEMENT_H_INCLUDED

--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -10,6 +10,8 @@
 #include "soci/odbc/soci-odbc.h"
 #include "soci/session.h"
 
+#include "soci-autostatement.h"
+
 #include <cstdio>
 
 using namespace soci;
@@ -160,14 +162,11 @@ void odbc_session_backend::configure_connection()
                              "\" in unrecognizable format.");
         }
 
-        odbc_statement_backend st(*this);
-        st.alloc();
+        details::auto_statement<odbc_statement_backend> st(*this);
 
         std::string const q(major_ver >= 9 ? "SET extra_float_digits = 3"
                                            : "SET extra_float_digits = 2");
         rc = SQLExecDirect(st.hstmt_, sqlchar_cast(q), static_cast<SQLINTEGER>(q.size()));
-
-        st.clean_up();
 
         if (is_odbc_error(rc))
         {


### PR DESCRIPTION
When working directly with concrete statement_backend classes, their
alloc() and clean_up() methods must be called directly, which suffers
from all the usual problems, especially in presence of exceptions.

Avoid them by using the new auto_statement class which takes care of
calling these methods in its ctor/dtor instead.

An alternative could be to make the concrete classes themselves use
RAII, but this would be more error prone (e.g. there would be a risk of
alloc() being called twice) and require many more changes, so, at least
for now, use this more lightweight solution.

No real changes.