### PR TITLE
Make it easier to implement trivial connection keep alive mechanism

### DIFF
--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -51,6 +51,8 @@ public:
     void close();
     void reconnect();
 
+    bool is_connected() const;
+
     void begin();
     void commit();
     void rollback();
@@ -94,7 +96,7 @@ session sql("postgresql://dbname=mydb");
 ```
 
 * The constructors that take backend name as string load the shared library (if not yet loaded) with name computed as `libsoci_ABC.so` (or `libsoci_ABC.dll` on Windows) where `ABC` is the given backend name.
-* `open`, `close` and `reconnect` functions for   reusing the same session object many times; the `reconnect` function attempts to establish the connection with the same parameters as most recently used with constructor or `open`. The arguments for `open` are treated in the same way as for constructors.
+* `open`, `close` and `reconnect` functions for   reusing the same session object many times; the `reconnect` function attempts to establish the connection with the same parameters as most recently used with constructor or `open`. The arguments for `open` are treated in the same way as for constructors. `is_connected` can be used to check if there is an existing usable connection.
 * `begin`, `commit` and `rollback` functions for transaction control.
 * `once` member, which is used for performing *instant* queries that do not need to be separately prepared. Example:
 

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -104,7 +104,7 @@ sql.open(parameters);
 
 The rules for backend naming are the same as with the constructors described above.
 
-The session can be also explicitly `close`d and `reconnect`ed, which can help with basic session error recovery.
+The session can be also explicitly `close`d and `reconnect`ed, which can help with basic session error recovery, e.g. the application could check if `is_connected` still returns true after getting an error and attempt to call `reconnect` if it doesn't.
 The `reconnect` function has no parameters and attempts to use the same values as those provided with earlier constructor or `open` calls.
 
 See also the page devoted to [multithreading](multithreading.md) for a detailed description of connection pools.

--- a/include/soci/db2/soci-db2.h
+++ b/include/soci/db2/soci-db2.h
@@ -252,6 +252,8 @@ struct db2_session_backend : details::session_backend
 
     ~db2_session_backend() SOCI_OVERRIDE;
 
+    bool is_connected() SOCI_OVERRIDE;
+
     void begin() SOCI_OVERRIDE;
     void commit() SOCI_OVERRIDE;
     void rollback() SOCI_OVERRIDE;

--- a/include/soci/empty/soci-empty.h
+++ b/include/soci/empty/soci-empty.h
@@ -159,6 +159,8 @@ struct empty_session_backend : details::session_backend
 
     ~empty_session_backend() SOCI_OVERRIDE;
 
+    bool is_connected() SOCI_OVERRIDE { return true; }
+
     void begin() SOCI_OVERRIDE;
     void commit() SOCI_OVERRIDE;
     void rollback() SOCI_OVERRIDE;

--- a/include/soci/firebird/soci-firebird.h
+++ b/include/soci/firebird/soci-firebird.h
@@ -310,6 +310,8 @@ struct firebird_session_backend : details::session_backend
 
     ~firebird_session_backend() SOCI_OVERRIDE;
 
+    bool is_connected() SOCI_OVERRIDE;
+
     void begin() SOCI_OVERRIDE;
     void commit() SOCI_OVERRIDE;
     void rollback() SOCI_OVERRIDE;

--- a/include/soci/mysql/soci-mysql.h
+++ b/include/soci/mysql/soci-mysql.h
@@ -235,6 +235,8 @@ struct mysql_session_backend : details::session_backend
 
     ~mysql_session_backend() SOCI_OVERRIDE;
 
+    bool is_connected() SOCI_OVERRIDE;
+
     void begin() SOCI_OVERRIDE;
     void commit() SOCI_OVERRIDE;
     void rollback() SOCI_OVERRIDE;

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -310,6 +310,8 @@ struct odbc_session_backend : details::session_backend
 
     ~odbc_session_backend() SOCI_OVERRIDE;
 
+    bool is_connected() SOCI_OVERRIDE;
+
     void begin() SOCI_OVERRIDE;
     void commit() SOCI_OVERRIDE;
     void rollback() SOCI_OVERRIDE;

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -376,6 +376,25 @@ public:
     {
     }
 
+    error_category get_error_category() const SOCI_OVERRIDE
+    {
+        const char* const s = reinterpret_cast<const char*>(sqlstate_);
+
+        if ((s[0] == '0' && s[1] == '8') ||
+            strcmp(s, "HYT01") == 0)
+            return connection_error;
+
+        if (strcmp(s, "23000") == 0 ||
+            strcmp(s, "40002") == 0 ||
+            strcmp(s, "44000") == 0)
+            return constraint_violation;
+
+        if (strcmp(s, "HY014") == 0)
+            return system_error;
+
+        return unknown;
+    }
+
     SQLCHAR const * odbc_error_code() const
     {
         return sqlstate_;

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -317,6 +317,8 @@ struct oracle_session_backend : details::session_backend
 
     ~oracle_session_backend() SOCI_OVERRIDE;
 
+    bool is_connected() SOCI_OVERRIDE;
+
     void begin() SOCI_OVERRIDE;
     void commit() SOCI_OVERRIDE;
     void rollback() SOCI_OVERRIDE;

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -372,6 +372,8 @@ struct postgresql_session_backend : details::session_backend
 
     void connect(connection_parameters const & parameters);
 
+    bool is_connected() SOCI_OVERRIDE;
+
     void begin() SOCI_OVERRIDE;
     void commit() SOCI_OVERRIDE;
     void rollback() SOCI_OVERRIDE;

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -25,6 +25,7 @@
 #endif
 
 #include <soci/soci-backend.h>
+#include "soci/connection-parameters.h"
 #include <libpq-fe.h>
 #include <vector>
 
@@ -395,6 +396,7 @@ struct postgresql_session_backend : details::session_backend
     int statementCount_;
     bool single_row_mode_;
     PGconn * conn_;
+    connection_parameters connectionParameters_;
 };
 
 

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -64,6 +64,9 @@ public:
     void close();
     void reconnect();
 
+    // check if we have a working connection to the database
+    bool is_connected() const SOCI_NOEXCEPT;
+
     void begin();
     void commit();
     void rollback();

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -261,6 +261,8 @@ public:
     session_backend() : failoverCallback_(NULL), session_(NULL) {}
     virtual ~session_backend() {}
 
+    virtual bool is_connected() = 0;
+
     virtual void begin() = 0;
     virtual void commit() = 0;
     virtual void rollback() = 0;

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -285,6 +285,8 @@ struct sqlite3_session_backend : details::session_backend
 
     ~sqlite3_session_backend() SOCI_OVERRIDE;
 
+    bool is_connected() SOCI_OVERRIDE { return true; }
+
     void begin() SOCI_OVERRIDE;
     void commit() SOCI_OVERRIDE;
     void rollback() SOCI_OVERRIDE;

--- a/src/backends/db2/session.cpp
+++ b/src/backends/db2/session.cpp
@@ -10,6 +10,8 @@
 #include "soci/db2/soci-db2.h"
 #include "soci/connection-parameters.h"
 
+#include "soci-autostatement.h"
+
 #include <cstdio>
 
 #ifdef _MSC_VER
@@ -156,6 +158,19 @@ db2_session_backend::db2_session_backend(
 db2_session_backend::~db2_session_backend()
 {
     clean_up();
+}
+
+bool db2_session_backend::is_connected()
+{
+    details::auto_statement<db2_statement_backend> st(*this);
+
+    // Force preparing the statement immediately (documentation states that
+    // "Deferred prepare is on by default").
+    SQLSetStmtAttr(st.hStmt, SQL_ATTR_DEFERRED_PREPARE, SQL_DEFERRED_PREPARE_OFF, 0);
+
+    st.prepare("values 1", st_one_time_query);
+
+    return true;
 }
 
 void db2_session_backend::begin()

--- a/src/backends/firebird/session.cpp
+++ b/src/backends/firebird/session.cpp
@@ -282,6 +282,15 @@ firebird_session_backend::~firebird_session_backend()
     cleanUp();
 }
 
+bool firebird_session_backend::is_connected()
+{
+    ISC_STATUS stat[stat_size];
+    ISC_SCHAR req[] = { isc_info_ods_version, isc_info_end };
+    ISC_SCHAR res[256];
+
+    return isc_database_info(stat, &dbhp_, sizeof(req), req, sizeof(res), res) == 0;
+}
+
 void firebird_session_backend::commit()
 {
     ISC_STATUS stat[stat_size];

--- a/src/backends/mysql/session.cpp
+++ b/src/backends/mysql/session.cpp
@@ -447,6 +447,11 @@ void hard_exec(MYSQL *conn, const string & query)
 
 } // namespace unnamed
 
+bool mysql_session_backend::is_connected()
+{
+    return mysql_ping(conn_) == 0;
+}
+
 void mysql_session_backend::begin()
 {
     hard_exec(conn_, "BEGIN");

--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -198,6 +198,19 @@ odbc_session_backend::~odbc_session_backend()
     clean_up();
 }
 
+bool odbc_session_backend::is_connected()
+{
+    details::auto_statement<odbc_statement_backend> st(*this);
+
+    // The name of the table we check for is irrelevant, as long as we have a
+    // working connection, it should still find (or, hopefully, not) something.
+    return !is_odbc_error(SQLTables(st.hstmt_,
+                                    NULL, SQL_NTS,
+                                    NULL, SQL_NTS,
+                                    sqlchar_cast("bloordyblop"), SQL_NTS,
+                                    NULL, SQL_NTS));
+}
+
 void odbc_session_backend::begin()
 {
     SQLRETURN rc = SQLSetConnectAttr( hdbc_, SQL_ATTR_AUTOCOMMIT,

--- a/src/backends/oracle/error.cpp
+++ b/src/backends/oracle/error.cpp
@@ -22,7 +22,11 @@ using namespace soci::details::oracle;
 oracle_soci_error::oracle_soci_error(std::string const & msg, int errNum)
     : soci_error(msg), err_num_(errNum), cat_(unknown)
 {
-    if (errNum == 12162 || errNum == 25403)
+    if (errNum ==  3113 ||
+        errNum ==  3114 ||
+        errNum == 12162 ||
+        errNum == 12541 ||
+        errNum == 25403)
     {
         cat_ = connection_error;
     }

--- a/src/backends/oracle/session.cpp
+++ b/src/backends/oracle/session.cpp
@@ -369,6 +369,11 @@ oracle_session_backend::~oracle_session_backend()
     clean_up();
 }
 
+bool oracle_session_backend::is_connected()
+{
+    return OCIPing(svchp_, errhp_, OCI_DEFAULT) == OCI_SUCCESS;
+}
+
 void oracle_session_backend::begin()
 {
     // This code is commented out because it causes one of the transaction

--- a/src/backends/postgresql/error.cpp
+++ b/src/backends/postgresql/error.cpp
@@ -123,8 +123,11 @@ details::postgresql_result::check_for_data(char const* errMsg) const
 
                         if (retry)
                         {
-                            connection_parameters parameters;
-                            parameters.set_connect_string(newTarget);
+                            connection_parameters parameters =
+                                sessionBackend_.connectionParameters_;
+
+                            if (!newTarget.empty())
+                                parameters.set_connect_string(newTarget);
 
                             sessionBackend_.clean_up();
 

--- a/src/backends/postgresql/error.cpp
+++ b/src/backends/postgresql/error.cpp
@@ -63,6 +63,9 @@ details::postgresql_result::check_for_errors(char const* errMsg) const
 bool
 details::postgresql_result::check_for_data(char const* errMsg) const
 {
+    // This SQL state will be used if we can't get anything more precise.
+    const char* fallback_sql_state = "     ";
+
     std::string msg(errMsg);
 
     ExecStatusType const status = PQresultStatus(result_);
@@ -82,6 +85,11 @@ details::postgresql_result::check_for_data(char const* errMsg) const
             if (PQstatus(sessionBackend_.conn_) == CONNECTION_BAD)
             {
                 msg += " Connection failed.";
+
+                // It's useful to set it here to something at least slightly
+                // more specific, as we're not going to get anything from
+                // PG_DIAG_SQLSTATE below if the connection is lost.
+                fallback_sql_state = "08000"; // connection_exception
                 
                 // call the failover callback, if registered
                 
@@ -169,10 +177,9 @@ details::postgresql_result::check_for_data(char const* errMsg) const
     }
 
     const char* sqlstate = PQresultErrorField(result_, PG_DIAG_SQLSTATE);
-    const char* const blank_sql_state = "     ";
     if (!sqlstate)
     {
-        sqlstate = blank_sql_state;
+        sqlstate = fallback_sql_state;
     }
 
     throw postgresql_soci_error(msg, sqlstate);

--- a/src/backends/postgresql/session.cpp
+++ b/src/backends/postgresql/session.cpp
@@ -9,7 +9,6 @@
 #include "soci/soci-platform.h"
 #include "soci/postgresql/soci-postgresql.h"
 #include "soci/session.h"
-#include "soci/connection-parameters.h"
 #include <libpq/libpq-fs.h> // libpq
 #include <cctype>
 #include <cstdio>
@@ -69,6 +68,7 @@ void postgresql_session_backend::connect(
         "Cannot set extra_float_digits parameter");
 
     conn_ = conn;
+    connectionParameters_ = parameters;
 }
 
 postgresql_session_backend::~postgresql_session_backend()

--- a/src/backends/postgresql/session.cpp
+++ b/src/backends/postgresql/session.cpp
@@ -76,6 +76,20 @@ postgresql_session_backend::~postgresql_session_backend()
     clean_up();
 }
 
+bool postgresql_session_backend::is_connected()
+{
+    // For the connection to work, its status must be OK, but this is not
+    // sufficient, so try to actually do something with it, even if it's
+    // something as trivial as sending an empty command to the server.
+    if ( PQstatus(conn_) != CONNECTION_OK )
+        return false;
+
+    postgresql_result(*this, PQexec(conn_, "/* ping */"));
+
+    // And then check it again.
+    return PQstatus(conn_) == CONNECTION_OK;
+}
+
 void postgresql_session_backend::begin()
 {
     hard_exec(*this, conn_, "BEGIN", "Cannot begin transaction.");

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -227,6 +227,20 @@ void session::reconnect()
     }
 }
 
+bool session::is_connected() const SOCI_NOEXCEPT
+{
+    try
+    {
+        return backEnd_ && backEnd_->is_connected();
+    }
+    catch (...)
+    {
+        // We must not throw from here, so just handle any exception as an
+        // indication that the database connection is not available any longer.
+        return false;
+    }
+}
+
 void session::begin()
 {
     ensureConnected(backEnd_);

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4667,8 +4667,17 @@ TEST_CASE_METHOD(common_tests, "Reconnect", "[keep-alive][.]")
     }
     catch (soci_error const& e)
     {
-        INFO( "Exception message: " << e.what() );
-        CHECK( e.get_error_category() == soci_error::connection_error );
+        if ( sql.get_backend_name() == "odbc" ||
+                e.get_error_category() == soci_error::unknown )
+        {
+            WARN( "Skipping error check because ODBC driver returned "
+                  "unknown error: " << e.what() );
+        }
+        else
+        {
+            INFO( "Exception message: " << e.what() );
+            CHECK( e.get_error_category() == soci_error::connection_error );
+        }
     }
 
     std::cout << "Please undo the previous action "

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -23,6 +23,8 @@
 
 #include "soci-compiler.h"
 
+#include "soci/callbacks.h"
+
 #define CATCH_CONFIG_RUNNER
 #include <catch.hpp>
 
@@ -4625,6 +4627,9 @@ TEST_CASE_METHOD(common_tests, "Logger", "[core][log]")
     sql.set_logger(logger_orig);
 }
 
+// These tests are disabled by default, as they require manual intevention, but
+// can be run by explicitly giving their names on the command line.
+
 // Check if reconnecting to the database after losing connection to it works.
 TEST_CASE_METHOD(common_tests, "Reconnect", "[keep-alive][.]")
 {
@@ -4665,6 +4670,74 @@ TEST_CASE_METHOD(common_tests, "Reconnect", "[keep-alive][.]")
     int id2 = 1234;
     sql << "select id from soci_test", into(id2);
     CHECK( id2 == id );
+}
+
+// Check if automatically reconnecting to the database works.
+//
+// Note: this test doesn't work at all, failover doesn't happen neither with
+// Oracle nor with PostgreSQL (which are the only backends for which it's
+// implemented at all) and it's not clear how is it even supposed to work.
+TEST_CASE_METHOD(common_tests, "Failover", "[keep-alive][.]")
+{
+    soci::session sql(backEndFactory_, connectString_);
+
+    class MyCallback : public soci::failover_callback
+    {
+    public:
+        MyCallback() : attempted_(false), reconnected_(false)
+        {
+        }
+
+        bool did_reconnect() const { return reconnected_; }
+
+        void started() SOCI_OVERRIDE
+        {
+            std::cout << "Please undo the previous action "
+                         "(restart the server, plug the cable back, ...) "
+                         "and press Enter" << std::endl;
+            std::cin.get();
+        }
+
+        void failed(bool& retry, std::string&) SOCI_OVERRIDE
+        {
+            // We only retry once.
+            retry = !attempted_;
+            attempted_ = true;
+        }
+
+        void finished(soci::session&) SOCI_OVERRIDE
+        {
+            reconnected_ = true;
+        }
+
+        void aborted() SOCI_OVERRIDE
+        {
+            FAIL( "Failover aborted" );
+        }
+
+    private:
+        bool attempted_;
+        bool reconnected_;
+    } myCallback;
+
+    sql.set_failover_callback(myCallback);
+
+    auto_table_creator tableCreator(tc_.table_creator_1(sql));
+
+    int id = 17;
+    sql << "insert into soci_test (id) values (:id)", use(id);
+    REQUIRE_NOTHROW( sql.commit() );
+
+    std::cout << "Please break connection to the database "
+                 "(stop the server, unplug the network cable, ...) "
+                 "and press Enter" << std::endl;
+    std::cin.get();
+
+    int id2;
+    sql << "select id from soci_test", into(id2);
+    CHECK( id2 == id );
+
+    CHECK( myCallback.did_reconnect() );
 }
 
 } // namespace test_cases

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -3331,6 +3331,8 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
         // empty session
         soci::session sql;
 
+        CHECK(!sql.is_connected());
+
         // idempotent:
         sql.close();
 
@@ -3347,10 +3349,13 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
 
         // open from empty session
         sql.open(backEndFactory_, connectString_);
+        CHECK(sql.is_connected());
         sql.close();
+        CHECK(!sql.is_connected());
 
         // reconnecting from closed session
         sql.reconnect();
+        CHECK(sql.is_connected());
 
         // opening already connected session
         try
@@ -3364,13 +3369,16 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
                "Cannot open already connected session.");
         }
 
+        CHECK(sql.is_connected());
         sql.close();
 
         // open from closed
         sql.open(backEndFactory_, connectString_);
+        CHECK(sql.is_connected());
 
         // reconnect from already connected session
         sql.reconnect();
+        CHECK(sql.is_connected());
     }
 
     {
@@ -4640,6 +4648,7 @@ TEST_CASE_METHOD(common_tests, "Reconnect", "[keep-alive][.]")
     sql << "insert into soci_test (id) values (:id)", use(id);
 
     REQUIRE_NOTHROW( sql.commit() );
+    CHECK( sql.is_connected() );
 
     std::cout << "Please break connection to the database "
                  "(stop the server, unplug the network cable, ...) "
@@ -4648,6 +4657,8 @@ TEST_CASE_METHOD(common_tests, "Reconnect", "[keep-alive][.]")
 
     try
     {
+        CHECK( !sql.is_connected() );
+
         int id2;
         sql << "select id from soci_test", into(id2);
 
@@ -4666,6 +4677,7 @@ TEST_CASE_METHOD(common_tests, "Reconnect", "[keep-alive][.]")
     std::cin.get();
 
     REQUIRE_NOTHROW( sql.reconnect() );
+    CHECK( sql.is_connected() );
 
     int id2 = 1234;
     sql << "select id from soci_test", into(id2);


### PR DESCRIPTION
Add `is_connected()` to allow checking if connection to the database still works.

Also fix a couple of bugs and add some disabled by default tests that can be used to test this functionality at least interactively.

Any comments very welcome!