### PR TITLE
search_paths() not defined in dynamic_backends namespace

### DIFF
--- a/src/core/backend-loader.cpp
+++ b/src/core/backend-loader.cpp
@@ -281,7 +281,7 @@ backend_factory const& dynamic_backends::get(std::string const& name)
     return *(i->second.factory_);
 }
 
-SOCI_DECL std::vector<std::string>& search_paths()
+SOCI_DECL std::vector<std::string>& dynamic_backends::search_paths()
 {
     return search_paths_;
 }


### PR DESCRIPTION
dynamic_backends::search_paths() is declared in backend-loader.h,
but in backend-loader.cpp, search_paths() is not defined in namespace properly.

The problem cause link error if try to use dynamic_backends::search_paths().