### PR TITLE
add namespace qualifiers to sessions to allow macOS builds

### DIFF
--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -994,9 +994,9 @@ TEST_CASE("Bulk iterators", "[postgresql][bulkiters]")
 // false_bind_variable_inside_identifier
 struct test_false_bind_variable_inside_identifier_table_creator : table_creator_base
 {
-    test_false_bind_variable_inside_identifier_table_creator(session & sql)
+    test_false_bind_variable_inside_identifier_table_creator(soci::session & sql)
         : table_creator_base(sql)
-        , msession(sql) 
+        , msession(sql)
     {
 
         try
@@ -1013,7 +1013,7 @@ struct test_false_bind_variable_inside_identifier_table_creator : table_creator_
         {
             drop();
         }
-        
+
     }
     ~test_false_bind_variable_inside_identifier_table_creator(){
         drop();
@@ -1028,7 +1028,7 @@ private:
         }
         catch (soci_error const& e){}
     }
-    session& msession;
+    soci::session& msession;
 };
 TEST_CASE("false_bind_variable_inside_identifier", "[postgresql][bind-variables]")
 {
@@ -1037,7 +1037,7 @@ TEST_CASE("false_bind_variable_inside_identifier", "[postgresql][bind-variables]
     std::string type_value;
 
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
         test_false_bind_variable_inside_identifier_table_creator tableCreator(sql);
 
         sql << "insert into soci_test(\"column_with:colon\") values(2020)";


### PR DESCRIPTION
Hello,

Due to the polluted global namespace of C++ headers on MacOS, SOCI could not be built with postgresql support on MacOS. I have attached a build log, the error is quite simple. The same problem has occurred before:
[https://github.com/SOCI/soci/issues/605](https://github.com/SOCI/soci/issues/605)
The fix is simply to add the namespace qualifier `soci::` to all session declarations.

[build_log.txt](https://github.com/SOCI/soci/files/5468277/build_log.txt)
