### PR TITLE
Suppress interactive dialogs during reconnect when using ODBC backend

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,3 @@
-# Auto detect text files and perform LF normalization
-* text=auto
-
 *.bash eol=lf
 *.env eol=lf
 *.sh eol=lf

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -145,7 +145,9 @@ public:
     explicit connection_parameters(std::string const & fullConnectString);
 
     void set_option(const char * name, std::string const & value);
-    bool get_option(const char * name, std::string & value) const
+    bool get_option(const char * name, std::string & value) const;
+
+    bool is_option_on(const char * name) const;
 };
 ```
 
@@ -154,6 +156,7 @@ The methods of this class are:
 * Default constructor is rarely used as it creates an uninitialized object and the only way to initialize it later is to assign another, valid, connection_parameters object to this one.
 * The other constructors correspond to the similar constructors of the `session` class and specify both the backend, either as a pointer to it or by name, and the connection string.
 * `set_option` can be used to set the value of an option with the given name. Currently all option values are strings, so if you need to set a numeric option you need to convert it to a string first. If an option with the given name had been already set before, its old value is overwritten.
+* `get_option` can be used to query the value of an option and returns `false` if there is no such option, while `is_option_on` simply checks if the option is specified with the value `soci::option_true` (which is a symbolic constant standing for the string `"1"`).
 
 ## class connection_pool
 

--- a/include/soci/connection-parameters.h
+++ b/include/soci/connection-parameters.h
@@ -16,6 +16,10 @@
 namespace soci
 {
 
+// Names of some predefined options and their values.
+extern SOCI_DECL char const * option_reconnect;
+extern SOCI_DECL char const * option_true;
+
 class backend_factory;
 
 // Simple container for the information used when opening a session.
@@ -52,6 +56,14 @@ public:
         value = it->second;
 
         return true;
+    }
+
+    // Return true if the option with the given name was found with option_true
+    // value.
+    bool is_option_on(const char * name) const
+    {
+      std::string value;
+      return get_option(name, value) && value == option_true;
     }
 
 private:

--- a/src/core/connection-parameters.cpp
+++ b/src/core/connection-parameters.cpp
@@ -12,6 +12,10 @@
 
 using namespace soci;
 
+char const * soci::option_reconnect = "reconnect";
+
+char const * soci::option_true = "1";
+
 namespace // anonymous
 {
 

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -223,7 +223,14 @@ void session::reconnect()
             close();
         }
 
-        backEnd_ = lastFactory->make_session(lastConnectParameters_);
+        // Indicate that we're reconnecting using a special parameter which can
+        // be used by some backends (currently only ODBC) that interactive
+        // prompts should be suppressed, as they would be unexpected during
+        // reconnection, which may happen automatically and not in the result
+        // of a user action.
+        connection_parameters reconnectParameters(lastConnectParameters_);
+        reconnectParameters.set_option(option_reconnect, option_true);
+        backEnd_ = lastFactory->make_session(reconnectParameters);
     }
 }
 


### PR DESCRIPTION
This was unexpected and there was no way to suppress them (while to get them, it's always possible to just call `close(); open()` instead of `reconnect()`).