### PR TITLE
change source dir from where cmake will copy the "soci-config.h" file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ set(INCLUDEDIR "include" CACHE PATH "The directory to install includes into.")
 ###############################################################################
 # Configuration files
 ###############################################################################
-set(CONFIG_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
+set(CONFIG_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 install(DIRECTORY ${CONFIG_INCLUDE_DIR}/soci DESTINATION ${INCLUDEDIR})
 set(CONFIG_FILE_IN "include/soci/soci-config.h.in")
 set(CONFIG_FILE_OUT "${CONFIG_INCLUDE_DIR}/soci/soci-config.h")


### PR DESCRIPTION
- When configuring cmake, trying to run install(), the binary dir might not have been created yet
- Fixes issue: `soci` not found when adding as subproject #762

Notes:
- The travis jobs will not pass since I don't have permissions from this forked repo.
- The file "soci-config.h" is required to test the creation of the conan package from the original repo, not from my forked.