### PR TITLE
Use fully qualified type for `session`

### DIFF
--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -1068,7 +1068,7 @@ TEST_CASE("colon_in_double_quotes_in_single_quotes",
     std::string return_value;
 
     {
-        session sql(backEnd, connectString);
+        soci::session sql(backEnd, connectString);
         table_creator_colon_in_double_quotes_in_single_quotes
             tableCreator(sql);
 


### PR DESCRIPTION
Hi!
I'm creating a SOCI package for conda(https://github.com/conda-forge/staged-recipes/pull/13388) and it'd be super nice to have a release with these `soci::` fixes. It's currently causing my [builds to fail](https://dev.azure.com/conda-forge/84710dde-1620-425b-80d0-4cf5baca359d/_apis/build/builds/248209/logs/35) on osx.
Please lemme know if I can help somehow.
Cheers.