### PR TITLE
Initialize indicator to i_null even when there is no data at all

### DIFF
--- a/docs/indicators.md
+++ b/docs/indicators.md
@@ -45,7 +45,10 @@ if (sql.got_data())
 }
 else
 {
-    // no such person in the database
+    // no such person in the database: notice that indicator will have the
+    // value i_null in this branch because often enough missing value can
+    // be handled in the same way as a null one, but you may also distinguish
+    // between the two cases if necessary, as done here by using got_data()
 }
 ```
 

--- a/include/soci/into-type.h
+++ b/include/soci/into-type.h
@@ -55,7 +55,13 @@ public:
     standard_into_type(void * data, exchange_type type)
         : data_(data), type_(type), ind_(NULL), backEnd_(NULL) {}
     standard_into_type(void * data, exchange_type type, indicator & ind)
-        : data_(data), type_(type), ind_(&ind), backEnd_(NULL) {}
+        : data_(data), type_(type), ind_(&ind), backEnd_(NULL)
+    {
+        // Backends won't initialize the indicator if no data is retrieved, so
+        // do it here, like this we can be sure it has a defined value even if
+        // an exception is thrown before anything else happens.
+        *ind_ = i_null;
+    }
 
     ~standard_into_type() SOCI_OVERRIDE;
 

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -700,6 +700,12 @@ TEST_CASE_METHOD(common_tests, "Use and into", "[core][into]")
         sql << "select tm from soci_test", into(t, ind);
         CHECK(ind == i_null);
 
+        // indicator should be initialized even when nothing is found
+        ind = i_ok;
+        sql << "select id from soci_test where str='NO SUCH ROW'",
+                into(i, ind);
+        CHECK(ind == i_null);
+
         try
         {
             // expect error


### PR DESCRIPTION
It is unexpected and error-prone to leave the indicator uninitialized if
a query doesn't retrieve any data, as it's too easy to forget to check
for got_data() and have the code working unpredictably depending on the
initial value of the uninitialized variable.

So always initialize the indicator value to i_null, this can't do any
harm, avoids bugs due to not checking got_data() and makes the code
simpler in the common case when absence of data is the same as having
NULL value in the database.

See #28.

---

This was supposed to be fixed 7.5 years ago, but somehow still isn't. I'd like to fix this because I just don't see any justification for the current behaviour, it's unnecessarily error-prone and doesn't seem to provide any advantages.

@mloskot If you're not too busy with the vacation, I'd appreciate your opinion about this, just in case I'm missing something fundamental here. TIA! 