### PR TITLE
Fix using vectors of custom types

### DIFF
--- a/include/soci/db2/soci-db2.h
+++ b/include/soci/db2/soci-db2.h
@@ -141,7 +141,7 @@ struct SOCI_DB2_DECL db2_standard_use_type_backend : details::standard_use_type_
 
     db2_statement_backend& statement_;
 
-    void *prepare_for_bind(void *data, SQLLEN &size, SQLSMALLINT &sqlType, SQLSMALLINT &cType);
+    void *prepare_for_bind(SQLLEN &size, SQLSMALLINT &sqlType, SQLSMALLINT &cType);
 
     void *data;
     details::exchange_type type;
@@ -168,7 +168,7 @@ struct SOCI_DB2_DECL db2_vector_use_type_backend : details::vector_use_type_back
     db2_statement_backend& statement_;
 
     void prepare_indicators(std::size_t size);
-    void *prepare_for_bind(void *data, SQLUINTEGER &size,SQLSMALLINT &sqlType, SQLSMALLINT &cType);
+    void *prepare_for_bind(SQLUINTEGER &size,SQLSMALLINT &sqlType, SQLSMALLINT &cType);
 
     std::vector<SQLLEN> indVec;
     void *data;

--- a/include/soci/db2/soci-db2.h
+++ b/include/soci/db2/soci-db2.h
@@ -168,14 +168,14 @@ struct SOCI_DB2_DECL db2_vector_use_type_backend : details::vector_use_type_back
     db2_statement_backend& statement_;
 
     void prepare_indicators(std::size_t size);
-    void prepare_for_bind(void *&data, SQLUINTEGER &size,SQLSMALLINT &sqlType, SQLSMALLINT &cType);
-    void bind_helper(int &position, void *data, details::exchange_type type);
+    void *prepare_for_bind(void *data, SQLUINTEGER &size,SQLSMALLINT &sqlType, SQLSMALLINT &cType);
 
     std::vector<SQLLEN> indVec;
     void *data;
     char *buf;
     details::exchange_type type;
     std::size_t colSize;
+    int position;
 };
 
 struct db2_session_backend;

--- a/include/soci/db2/soci-db2.h
+++ b/include/soci/db2/soci-db2.h
@@ -116,7 +116,6 @@ struct SOCI_DB2_DECL db2_vector_into_type_backend : details::vector_into_type_ba
 
     void prepare_indicators(std::size_t size);
 
-    SQLLEN *indptr;
     std::vector<SQLLEN> indVec;
     void *data;
     char *buf;
@@ -172,7 +171,6 @@ struct SOCI_DB2_DECL db2_vector_use_type_backend : details::vector_use_type_back
     void prepare_for_bind(void *&data, SQLUINTEGER &size,SQLSMALLINT &sqlType, SQLSMALLINT &cType);
     void bind_helper(int &position, void *data, details::exchange_type type);
 
-    SQLLEN *indptr;
     std::vector<SQLLEN> indVec;
     void *data;
     char *buf;

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -115,7 +115,7 @@ struct odbc_vector_into_type_backend : details::vector_into_type_backend,
                                        private odbc_standard_type_backend_base
 {
     odbc_vector_into_type_backend(odbc_statement_backend &st)
-        : odbc_standard_type_backend_base(st), indHolders_(NULL),
+        : odbc_standard_type_backend_base(st),
           data_(NULL), buf_(NULL) {}
 
     void define_by_pos(int &position,
@@ -137,7 +137,6 @@ struct odbc_vector_into_type_backend : details::vector_into_type_backend,
     // SQLLEN is still defined 32bit (int) but spec requires 64bit (long)
     inline SQLLEN get_sqllen_from_vector_at(std::size_t idx) const;
 
-    SQLLEN *indHolders_;
     std::vector<SQLLEN> indHolderVec_;
     void *data_;
     char *buf_;              // generic buffer
@@ -191,7 +190,7 @@ struct odbc_vector_use_type_backend : details::vector_use_type_backend,
                                       private odbc_standard_type_backend_base
 {
     odbc_vector_use_type_backend(odbc_statement_backend &st)
-        : odbc_standard_type_backend_base(st), indHolders_(NULL),
+        : odbc_standard_type_backend_base(st),
           data_(NULL), buf_(NULL) {}
 
     // helper function for preparing indicators
@@ -218,7 +217,6 @@ struct odbc_vector_use_type_backend : details::vector_use_type_backend,
     // SQLLEN is still defined 32bit (int) but spec requires 64bit (long)
     inline void set_sqllen_from_vector_at(const std::size_t idx, const SQLLEN val);
 
-    SQLLEN *indHolders_;
     std::vector<SQLLEN> indHolderVec_;
     void *data_;
     details::exchange_type type_;

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -197,10 +197,8 @@ struct odbc_vector_use_type_backend : details::vector_use_type_backend,
     // (as part of the define_by_pos)
     void prepare_indicators(std::size_t size);
 
-    // common part for bind_by_pos and bind_by_name
-    void prepare_for_bind(void *&data, SQLUINTEGER &size, SQLSMALLINT &sqlType, SQLSMALLINT &cType);
-    void bind_helper(int &position,
-        void *data, details::exchange_type type);
+    // helper of pre_use(), return the pointer to the data to be used by ODBC.
+    void* prepare_for_bind(SQLUINTEGER &size, SQLSMALLINT &sqlType, SQLSMALLINT &cType);
 
     void bind_by_pos(int &position,
         void *data, details::exchange_type type) SOCI_OVERRIDE;
@@ -220,6 +218,7 @@ struct odbc_vector_use_type_backend : details::vector_use_type_backend,
     std::vector<SQLLEN> indHolderVec_;
     void *data_;
     details::exchange_type type_;
+    int position_;
     char *buf_;              // generic buffer
     std::size_t colSize_;    // size of the string column (used for strings)
     // used for strings only

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -75,7 +75,7 @@ struct oracle_standard_into_type_backend : details::standard_into_type_backend
 struct oracle_vector_into_type_backend : details::vector_into_type_backend
 {
     oracle_vector_into_type_backend(oracle_statement_backend &st)
-        : statement_(st), defnp_(NULL), indOCIHolders_(NULL),
+        : statement_(st), defnp_(NULL),
         data_(NULL), buf_(NULL), user_ranges_(true) {}
 
     void define_by_pos(int &position,
@@ -105,7 +105,6 @@ struct oracle_vector_into_type_backend : details::vector_into_type_backend
     oracle_statement_backend &statement_;
 
     OCIDefine *defnp_;
-    sb2 *indOCIHolders_;
     std::vector<sb2> indOCIHolderVec_;
     void *data_;
     char *buf_;              // generic buffer
@@ -160,7 +159,7 @@ struct oracle_standard_use_type_backend : details::standard_use_type_backend
 struct oracle_vector_use_type_backend : details::vector_use_type_backend
 {
     oracle_vector_use_type_backend(oracle_statement_backend &st)
-        : statement_(st), bindp_(NULL), indOCIHolders_(NULL),
+        : statement_(st), bindp_(NULL),
           data_(NULL), buf_(NULL) {}
 
     void bind_by_pos(int & position,
@@ -201,7 +200,6 @@ struct oracle_vector_use_type_backend : details::vector_use_type_backend
 
     OCIBind *bindp_;
     std::vector<sb2> indOCIHolderVec_;
-    sb2 *indOCIHolders_;
     void *data_;
     char *buf_;        // generic buffer
     details::exchange_type type_;

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -160,7 +160,7 @@ struct oracle_vector_use_type_backend : details::vector_use_type_backend
 {
     oracle_vector_use_type_backend(oracle_statement_backend &st)
         : statement_(st), bindp_(NULL),
-          data_(NULL), buf_(NULL) {}
+          data_(NULL), buf_(NULL), bind_position_(0) {}
 
     void bind_by_pos(int & position,
         void * data, details::exchange_type type) SOCI_OVERRIDE
@@ -182,7 +182,7 @@ struct oracle_vector_use_type_backend : details::vector_use_type_backend
         void *data, details::exchange_type type,
         std::size_t begin, std::size_t * end) SOCI_OVERRIDE;
 
-    // common part for bind_by_pos and bind_by_name
+    // pre_use() helper
     void prepare_for_bind(void *&data, sb4 &size, ub2 &oracleType);
 
     // helper function for preparing indicators and sizes_ vectors
@@ -210,6 +210,10 @@ struct oracle_vector_use_type_backend : details::vector_use_type_backend
     // used for strings only
     std::vector<ub2> sizes_;
     std::size_t maxSize_;
+
+    // name is used if non-empty, otherwise position
+    std::string bind_name_;
+    int bind_position_;
 };
 
 struct oracle_session_backend;

--- a/src/backends/db2/standard-use-type.cpp
+++ b/src/backends/db2/standard-use-type.cpp
@@ -19,7 +19,7 @@ using namespace soci;
 using namespace soci::details;
 
 void *db2_standard_use_type_backend::prepare_for_bind(
-    void *data, SQLLEN &size, SQLSMALLINT &sqlType, SQLSMALLINT &cType)
+    SQLLEN &size, SQLSMALLINT &sqlType, SQLSMALLINT &cType)
 {
     switch (type)
     {
@@ -170,7 +170,7 @@ void db2_standard_use_type_backend::pre_use(indicator const *ind_ptr)
     SQLSMALLINT cType;
     SQLLEN size;
 
-    void *sqlData = prepare_for_bind(data, size, sqlType, cType);
+    void* const sqlData = prepare_for_bind(size, sqlType, cType);
 
     SQLRETURN cliRC = SQLBindParameter(statement_.hStmt,
                                     static_cast<SQLUSMALLINT>(position),

--- a/src/backends/db2/vector-into-type.cpp
+++ b/src/backends/db2/vector-into-type.cpp
@@ -26,7 +26,6 @@ void db2_vector_into_type_backend::prepare_indicators(std::size_t size)
     }
 
     indVec.resize(size);
-    indptr = &indVec[0];
 }
 
 void db2_vector_into_type_backend::define_by_pos(
@@ -155,7 +154,7 @@ void db2_vector_into_type_backend::define_by_pos(
     }
 
     SQLRETURN cliRC = SQLBindCol(statement_.hStmt, static_cast<SQLUSMALLINT>(position++),
-                              cType, data, size, indptr);
+                              cType, data, size, &indVec[0]);
     if (cliRC != SQL_SUCCESS)
     {
         throw db2_soci_error("Error while pre-fetching into vector",cliRC);

--- a/src/backends/db2/vector-into-type.cpp
+++ b/src/backends/db2/vector-into-type.cpp
@@ -244,17 +244,13 @@ void db2_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             std::size_t const indSize = statement_.get_number_of_rows();
             for (std::size_t i = 0; i != indSize; ++i)
             {
-                if (indVec[i] > 0)
-                {
-                    ind[i] = i_ok;
-                }
-                else if (indVec[i] == SQL_NULL_DATA)
+                if (indVec[i] == SQL_NULL_DATA)
                 {
                     ind[i] = i_null;
                 }
                 else
                 {
-                    ind[i] = i_truncated;
+                    ind[i] = i_ok;
                 }
             }
         }

--- a/src/backends/db2/vector-use-type.cpp
+++ b/src/backends/db2/vector-use-type.cpp
@@ -34,7 +34,6 @@ void db2_vector_use_type_backend::prepare_indicators(std::size_t size)
     }
 
     indVec.resize(size);
-    indptr = &indVec[0];
 }
 
 void db2_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &size,
@@ -204,7 +203,7 @@ void db2_vector_use_type_backend::bind_helper(int &position, void *data, details
 
     SQLRETURN cliRC = SQLBindParameter(statement_.hStmt, static_cast<SQLUSMALLINT>(position++),
                                     SQL_PARAM_INPUT, cType, sqlType, size, 0,
-                                    static_cast<SQLPOINTER>(data), size, indptr);
+                                    static_cast<SQLPOINTER>(data), size, &indVec[0]);
 
     if ( cliRC != SQL_SUCCESS )
     {

--- a/src/backends/db2/vector-use-type.cpp
+++ b/src/backends/db2/vector-use-type.cpp
@@ -36,7 +36,7 @@ void db2_vector_use_type_backend::prepare_indicators(std::size_t size)
     indVec.resize(size);
 }
 
-void *db2_vector_use_type_backend::prepare_for_bind(void *data, SQLUINTEGER &size,
+void *db2_vector_use_type_backend::prepare_for_bind(SQLUINTEGER &size,
     SQLSMALLINT &sqlType, SQLSMALLINT &cType)
 {
     void* sqlData = NULL;
@@ -245,7 +245,7 @@ void db2_vector_use_type_backend::pre_use(indicator const *ind)
     SQLSMALLINT cType;
     SQLUINTEGER size;
 
-    void* const sqlData = prepare_for_bind(data, size, sqlType, cType);
+    void* const sqlData = prepare_for_bind(size, sqlType, cType);
 
     // first deal with data
     if (type == x_stdtm)

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -29,7 +29,6 @@ void odbc_vector_into_type_backend::prepare_indicators(std::size_t size)
     }
 
     indHolderVec_.resize(size);
-    indHolders_ = &indHolderVec_[0];
 }
 
 void odbc_vector_into_type_backend::define_by_pos(
@@ -180,7 +179,7 @@ void odbc_vector_into_type_backend::define_by_pos(
 
     SQLRETURN rc
         = SQLBindCol(statement_.hstmt_, static_cast<SQLUSMALLINT>(position++),
-                odbcType_, static_cast<SQLPOINTER>(data), size, indHolders_);
+                odbcType_, static_cast<SQLPOINTER>(data), size, &indHolderVec_[0]);
     if (is_odbc_error(rc))
     {
         std::ostringstream ss;

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -322,17 +322,13 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
             for (std::size_t i = 0; i != indSize; ++i)
             {
                 SQLLEN const val = get_sqllen_from_vector_at(i);
-                if (val > 0)
-                {
-                    ind[i] = i_ok;
-                }
-                else if (val == SQL_NULL_DATA)
+                if (val == SQL_NULL_DATA)
                 {
                     ind[i] = i_null;
                 }
                 else
                 {
-                    ind[i] = i_truncated;
+                    ind[i] = i_ok;
                 }
             }
         }

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -316,32 +316,26 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
         }
 
         // then - deal with indicators
-        if (ind != NULL)
+        std::size_t const indSize = statement_.get_number_of_rows();
+        for (std::size_t i = 0; i != indSize; ++i)
         {
-            std::size_t const indSize = statement_.get_number_of_rows();
-            for (std::size_t i = 0; i != indSize; ++i)
+            SQLLEN const val = get_sqllen_from_vector_at(i);
+            if (val == SQL_NULL_DATA)
             {
-                SQLLEN const val = get_sqllen_from_vector_at(i);
-                if (val == SQL_NULL_DATA)
-                {
-                    ind[i] = i_null;
-                }
-                else
-                {
-                    ind[i] = i_ok;
-                }
-            }
-        }
-        else
-        {
-            std::size_t const indSize = statement_.get_number_of_rows();
-            for (std::size_t i = 0; i != indSize; ++i)
-            {
-                if (get_sqllen_from_vector_at(i) == SQL_NULL_DATA)
+                if (ind == NULL)
                 {
                     // fetched null and no indicator - programming error!
                     throw soci_error(
                         "Null value fetched and no indicator defined.");
+                }
+
+                ind[i] = i_null;
+            }
+            else
+            {
+                if (ind != NULL)
+                {
+                    ind[i] = i_ok;
                 }
             }
         }

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -36,9 +36,10 @@ void odbc_vector_use_type_backend::prepare_indicators(std::size_t size)
     indHolderVec_.resize(size);
 }
 
-void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &size,
+void* odbc_vector_use_type_backend::prepare_for_bind(SQLUINTEGER &size,
     SQLSMALLINT &sqlType, SQLSMALLINT &cType)
 {
+    void* data = NULL;
     switch (type_)
     {    // simple cases
     case x_short:
@@ -46,7 +47,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
             sqlType = SQL_SMALLINT;
             cType = SQL_C_SSHORT;
             size = sizeof(short);
-            std::vector<short> *vp = static_cast<std::vector<short> *>(data);
+            std::vector<short> *vp = static_cast<std::vector<short> *>(data_);
             std::vector<short> &v(*vp);
             prepare_indicators(v.size());
             data = &v[0];
@@ -58,7 +59,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
             cType = SQL_C_SLONG;
             size = sizeof(SQLINTEGER);
             SOCI_STATIC_ASSERT(sizeof(SQLINTEGER) == sizeof(int));
-            std::vector<int> *vp = static_cast<std::vector<int> *>(data);
+            std::vector<int> *vp = static_cast<std::vector<int> *>(data_);
             std::vector<int> &v(*vp);
             prepare_indicators(v.size());
             data = &v[0];
@@ -67,7 +68,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
     case x_long_long:
         {
             std::vector<long long> *vp =
-                static_cast<std::vector<long long> *>(data);
+                static_cast<std::vector<long long> *>(data_);
             std::vector<long long> &v(*vp);
             std::size_t const vsize = v.size();
             prepare_indicators(vsize);
@@ -92,7 +93,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
     case x_unsigned_long_long:
         {
             std::vector<unsigned long long> *vp =
-                static_cast<std::vector<unsigned long long> *>(data);
+                static_cast<std::vector<unsigned long long> *>(data_);
             std::vector<unsigned long long> &v(*vp);
             std::size_t const vsize = v.size();
             prepare_indicators(vsize);
@@ -119,7 +120,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
             sqlType = SQL_DOUBLE;
             cType = SQL_C_DOUBLE;
             size = sizeof(double);
-            std::vector<double> *vp = static_cast<std::vector<double> *>(data);
+            std::vector<double> *vp = static_cast<std::vector<double> *>(data_);
             std::vector<double> &v(*vp);
             prepare_indicators(v.size());
             data = &v[0];
@@ -130,7 +131,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
     case x_char:
         {
             std::vector<char> *vp
-                = static_cast<std::vector<char> *>(data);
+                = static_cast<std::vector<char> *>(data_);
             std::size_t const vsize = vp->size();
 
             prepare_indicators(vsize);
@@ -157,7 +158,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
             cType = SQL_C_CHAR;
 
             std::vector<std::string> *vp
-                = static_cast<std::vector<std::string> *>(data);
+                = static_cast<std::vector<std::string> *>(data_);
             std::vector<std::string> &v(*vp);
 
             std::size_t maxSize = 0;
@@ -189,7 +190,7 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
     case x_stdtm:
         {
             std::vector<std::tm> *vp
-                = static_cast<std::vector<std::tm> *>(data);
+                = static_cast<std::vector<std::tm> *>(data_);
 
             prepare_indicators(vp->size());
 
@@ -210,32 +211,8 @@ void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &si
     }
 
     colSize_ = size;
-}
 
-void odbc_vector_use_type_backend::bind_helper(int &position, void *data, exchange_type type)
-{
-    data_ = data; // for future reference
-    type_ = type; // for future reference
-
-    SQLSMALLINT sqlType(0);
-    SQLSMALLINT cType(0);
-    SQLUINTEGER size(0);
-
-    prepare_for_bind(data, size, sqlType, cType);
-
-    SQLULEN const arraySize = static_cast<SQLULEN>(indHolderVec_.size());
-    SQLSetStmtAttr(statement_.hstmt_, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)arraySize, 0);
-
-    SQLRETURN rc = SQLBindParameter(statement_.hstmt_, static_cast<SQLUSMALLINT>(position++),
-                                    SQL_PARAM_INPUT, cType, sqlType, size, 0,
-                                    static_cast<SQLPOINTER>(data), size, &indHolderVec_[0]);
-
-    if (is_odbc_error(rc))
-    {
-        std::ostringstream ss;
-        ss << "binding input vector parameter #" << position;
-        throw odbc_soci_error(SQL_HANDLE_STMT, statement_.hstmt_, ss.str());
-    }
+    return data;
 }
 
 void odbc_vector_use_type_backend::bind_by_pos(int &position,
@@ -247,7 +224,9 @@ void odbc_vector_use_type_backend::bind_by_pos(int &position,
          "Binding for use elements must be either by position or by name.");
     }
 
-    bind_helper(position, data, type);
+    position_ = position++;
+    data_ = data;
+    type_ = type;
 
     statement_.boundByPos_ = true;
 }
@@ -275,22 +254,31 @@ void odbc_vector_use_type_backend::bind_by_name(
         count++;
     }
 
-    if (position != -1)
-    {
-        bind_helper(position, data, type);
-    }
-    else
+    if (position == -1)
     {
         std::ostringstream ss;
         ss << "Unable to find name '" << name << "' to bind to";
         throw soci_error(ss.str().c_str());
     }
 
+    position_ = position;
+    data_ = data;
+    type_ = type;
+
     statement_.boundByName_ = true;
 }
 
 void odbc_vector_use_type_backend::pre_use(indicator const *ind)
 {
+    SQLSMALLINT sqlType(0);
+    SQLSMALLINT cType(0);
+    SQLUINTEGER size(0);
+
+    // Note that data_ is a pointer to C++ data while data returned by
+    // prepare_for_bind() is the data to be used by ODBC and doesn't always
+    // have the same format.
+    void* const data = prepare_for_bind(size, sqlType, cType);
+
     // first deal with data
     SQLLEN non_null_indicator = 0;
     switch (type_)
@@ -391,8 +379,7 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
     // then handle indicators
     if (ind != NULL)
     {
-        std::size_t const vsize = size();
-        for (std::size_t i = 0; i != vsize; ++i, ++ind)
+        for (std::size_t i = 0; i != indHolderVec_.size(); ++i, ++ind)
         {
             if (*ind == i_null)
             {
@@ -411,8 +398,7 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
     else
     {
         // no indicators - treat all fields as OK
-        std::size_t const vsize = size();
-        for (std::size_t i = 0; i != vsize; ++i)
+        for (std::size_t i = 0; i != indHolderVec_.size(); ++i)
         {
             // for strings we have already set the values
             if (type_ != x_stdstring)
@@ -420,6 +406,21 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
                 set_sqllen_from_vector_at(i, non_null_indicator);
             }
         }
+    }
+
+
+    SQLULEN const arraySize = static_cast<SQLULEN>(indHolderVec_.size());
+    SQLSetStmtAttr(statement_.hstmt_, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)arraySize, 0);
+
+    SQLRETURN rc = SQLBindParameter(statement_.hstmt_, static_cast<SQLUSMALLINT>(position_),
+                                    SQL_PARAM_INPUT, cType, sqlType, size, 0,
+                                    static_cast<SQLPOINTER>(data), size, &indHolderVec_[0]);
+
+    if (is_odbc_error(rc))
+    {
+        std::ostringstream ss;
+        ss << "binding input vector parameter #" << position_;
+        throw odbc_soci_error(SQL_HANDLE_STMT, statement_.hstmt_, ss.str());
     }
 }
 

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -34,7 +34,6 @@ void odbc_vector_use_type_backend::prepare_indicators(std::size_t size)
     }
 
     indHolderVec_.resize(size);
-    indHolders_ = &indHolderVec_[0];
 }
 
 void odbc_vector_use_type_backend::prepare_for_bind(void *&data, SQLUINTEGER &size,
@@ -229,7 +228,7 @@ void odbc_vector_use_type_backend::bind_helper(int &position, void *data, exchan
 
     SQLRETURN rc = SQLBindParameter(statement_.hstmt_, static_cast<SQLUSMALLINT>(position++),
                                     SQL_PARAM_INPUT, cType, sqlType, size, 0,
-                                    static_cast<SQLPOINTER>(data), size, indHolders_);
+                                    static_cast<SQLPOINTER>(data), size, &indHolderVec_[0]);
 
     if (is_odbc_error(rc))
     {

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -413,7 +413,7 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
     {
         // no indicators - treat all fields as OK
         std::size_t const vsize = size();
-        for (std::size_t i = 0; i != vsize; ++i, ++ind)
+        for (std::size_t i = 0; i != vsize; ++i)
         {
             // for strings we have already set the values
             if (type_ != x_stdstring)

--- a/src/backends/oracle/vector-into-type.cpp
+++ b/src/backends/oracle/vector-into-type.cpp
@@ -34,7 +34,6 @@ void oracle_vector_into_type_backend::prepare_indicators(std::size_t size)
     }
 
     indOCIHolderVec_.resize(size);
-    indOCIHolders_ = &indOCIHolderVec_[0];
 
     sizes_.resize(size);
     rCodes_.resize(size);
@@ -169,7 +168,7 @@ void oracle_vector_into_type_backend::define_by_pos_bulk(
     sword res = OCIDefineByPos(statement_.stmtp_, &defnp_,
         statement_.session_.errhp_,
         position++, dataBuf, elementSize, oracleType,
-        indOCIHolders_, &sizes_[0], &rCodes_[0], OCI_DEFAULT);
+        &indOCIHolderVec_[0], &sizes_[0], &rCodes_[0], OCI_DEFAULT);
     if (res != OCI_SUCCESS)
     {
         throw_oracle_soci_error(res, statement_.session_.errhp_);

--- a/src/backends/oracle/vector-use-type.cpp
+++ b/src/backends/oracle/vector-use-type.cpp
@@ -32,7 +32,6 @@ void oracle_vector_use_type_backend::prepare_indicators(std::size_t size)
     }
 
     indOCIHolderVec_.resize(size);
-    indOCIHolders_ = &indOCIHolderVec_[0];
 }
 
 void oracle_vector_use_type_backend::prepare_for_bind(
@@ -189,7 +188,7 @@ void oracle_vector_use_type_backend::bind_by_pos_bulk(int & position,
     sword res = OCIBindByPos(statement_.stmtp_, &bindp_,
         statement_.session_.errhp_,
         position++, dataBuf, elementSize, oracleType,
-        indOCIHolders_, sizesP, 0, 0, 0, OCI_DEFAULT);
+        &indOCIHolderVec_[0], sizesP, 0, 0, 0, OCI_DEFAULT);
     if (res != OCI_SUCCESS)
     {
         throw_oracle_soci_error(res, statement_.session_.errhp_);
@@ -224,7 +223,7 @@ void oracle_vector_use_type_backend::bind_by_name_bulk(
         reinterpret_cast<text*>(const_cast<char*>(name.c_str())),
         static_cast<sb4>(name.size()),
         dataBuf, elementSize, oracleType,
-        indOCIHolders_, sizesP, 0, 0, 0, OCI_DEFAULT);
+        &indOCIHolderVec_[0], sizesP, 0, 0, 0, OCI_DEFAULT);
     if (res != OCI_SUCCESS)
     {
         throw_oracle_soci_error(res, statement_.session_.errhp_);

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -376,6 +376,10 @@ public:
     // to fit by default.
     virtual bool has_silent_truncate_bug(session&) const { return false; }
 
+    // Override this if the backend doesn't distinguish between empty and null
+    // strings (Oracle does this).
+    virtual bool treats_empty_strings_as_null() const { return false; }
+
     // Override this to call commit() if it's necessary for the DDL statements
     // to be taken into account (currently this is only the case for Firebird).
     virtual void on_after_ddl(session&) const { }

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -125,6 +125,46 @@ private:
     int i_;
 };
 
+// user-defined object for the "vector of custom type objects" tests.
+class MyOptionalString
+{
+public:
+    MyOptionalString() : valid_(false) {}
+    MyOptionalString(const std::string& str) : valid_(true), str_(str) {}
+    void set(const std::string& str) { valid_ = true; str_ = str; }
+    void reset() { valid_ = false; str_.clear(); }
+    bool is_valid() const { return valid_; }
+    const std::string &get() const { return str_; }
+private:
+    bool valid_;
+    std::string str_;
+};
+
+std::ostream& operator<<(std::ostream& ostr, const MyOptionalString& optstr)
+{
+  ostr << (optstr.is_valid() ? "\"" + optstr.get() + "\"" : std::string("(null)"));
+
+  return ostr;
+}
+
+std::ostream& operator<<(std::ostream& ostr, const std::vector<MyOptionalString>& vec)
+{
+    if ( vec.empty() )
+    {
+        ostr << "Empty vector";
+    }
+    else
+    {
+        ostr << "Vector of size " << vec.size() << " containing\n";
+        for ( size_t n = 0; n < vec.size(); ++n )
+        {
+            ostr << "\t [" << std::setw(3) << n << "] = " << vec[n] << "\n";
+        }
+    }
+
+    return ostr;
+}
+
 namespace soci
 {
 
@@ -145,6 +185,37 @@ template<> struct type_conversion<MyInt>
     {
         i = mi.get();
         ind = i_ok;
+    }
+};
+
+// basic type conversion for string based user-defined type which can be null
+template<> struct type_conversion<MyOptionalString>
+{
+    typedef std::string base_type;
+
+    static void from_base(const base_type& in, indicator ind, MyOptionalString& out)
+    {
+        if (ind == i_null)
+        {
+            out.reset();
+        }
+        else
+        {
+            out.set(in);
+        }
+    }
+
+    static void to_base(const MyOptionalString& in, base_type& out, indicator& ind)
+    {
+        if (in.is_valid())
+        {
+            out = in.get();
+            ind = i_ok;
+        }
+        else
+        {
+            ind = i_null;
+        }
     }
 };
 
@@ -1784,6 +1855,88 @@ TEST_CASE_METHOD(common_tests, "Use vector", "[core][use][vector]")
         CHECK(v2[1] == 0);
         CHECK(v2[2] == 1);
         CHECK(v2[3] == 2000000000);
+    }
+}
+
+// use vector elements with type convertion
+TEST_CASE_METHOD(common_tests, "Use vector of custom type objects", "[core][use][vector][type_conversion]")
+{
+    soci::session sql(backEndFactory_, connectString_);
+
+    auto_table_creator tableCreator(tc_.table_creator_1(sql));
+
+    // Unfortunately there is no portable way to indicate whether nulls should
+    // appear at the beginning or the end (SQL 2003 "NULLS LAST" is still not
+    // supported by MS SQL in 2021...), so use this column just to order by it.
+    std::vector<int> i;
+    i.push_back(0);
+    i.push_back(1);
+    i.push_back(2);
+
+    std::vector<MyOptionalString> v;
+    v.push_back(MyOptionalString("string")); // A not empty valid string.
+    v.push_back(MyOptionalString());         // Invalid string mapped to null.
+    v.push_back(MyOptionalString(""));       // An empty but still valid string.
+
+    sql << "insert into soci_test(id, str) values(:i, :v)", use(i), use(v);
+
+    std::vector<std::string> values(3);
+    std::vector<indicator> inds(3);
+    sql << "select str from soci_test order by id", into(values, inds);
+
+    REQUIRE(values.size() == 3);
+    REQUIRE(inds.size() == 3);
+
+    CHECK(inds[0] == soci::i_ok);
+    CHECK(values[0] == "string");
+
+    CHECK(inds[1] == soci::i_null);
+
+    if ( !tc_.treats_empty_strings_as_null() )
+    {
+        CHECK(inds[2] == soci::i_ok);
+        CHECK(values[2] == "");
+    }
+}
+
+TEST_CASE_METHOD(common_tests, "Into vector of custom type objects", "[core][into][vector][type_conversion]")
+{
+    soci::session sql(backEndFactory_, connectString_);
+
+    auto_table_creator tableCreator(tc_.table_creator_1(sql));
+
+    // Column used for sorting only, see above.
+    std::vector<int> i;
+    i.push_back(0);
+    i.push_back(1);
+    i.push_back(2);
+
+    std::vector<std::string> values(3);
+    values[0] = "string";
+
+    std::vector<indicator> inds;
+    inds.push_back(i_ok);
+    inds.push_back(i_null);
+    inds.push_back(i_ok);
+
+    sql << "insert into soci_test(id, str) values(:i, :v)", use(i), use(values, inds);
+
+    std::vector<MyOptionalString> v2(4);
+
+    sql << "select str from soci_test order by id", into(v2);
+
+    INFO("Got back " << v2);
+    REQUIRE(v2.size() == 3);
+
+    CHECK(v2[0].is_valid());
+    CHECK(v2[0].get() == "string");
+
+    CHECK(!v2[1].is_valid());
+
+    if ( !tc_.treats_empty_strings_as_null() )
+    {
+        CHECK(v2[2].is_valid());
+        CHECK(v2[2].get().empty());
     }
 }
 

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -1538,6 +1538,11 @@ public:
         return true;
     }
 
+    bool treats_empty_strings_as_null() const SOCI_OVERRIDE
+    {
+        return true;
+    }
+
     std::string to_date_time(std::string const &datdt_string) const SOCI_OVERRIDE
     {
         return "to_date('" + datdt_string + "', 'YYYY-MM-DD HH24:MI:SS')";


### PR DESCRIPTION
The problem is that we can't really bind the parameters before we have the actual data and when using custom types this actual data only becomes available after calling `convert_to_base()` from `vector_use_type::pre_use()` in the core. So the backends that bound parameters before (ODBC and Oracle) didn't use the correct data and so the simple test added in the last commit here failed.

I'm still not sure what's going to happen when `execute()` (and hence `pre_use()`) is called multiple times and whether rebinding the parameters every time is a good idea. Perhaps we should only do it in the first call?