### PR TITLE
Fixes for MSVS warnings and a bug fix for SQLite doubles

### DIFF
--- a/cmake/SociConfig.cmake
+++ b/cmake/SociConfig.cmake
@@ -49,6 +49,10 @@ endif()
 # Force compilation flags and set desired warnings level
 #
 
+# This is used to set the -Werror compilation flag only when explicitly
+# requested, as e.g. in CI builds.
+set(SOCI_WERROR_OPTION "")
+
 if (MSVC)
   add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
@@ -61,17 +65,17 @@ if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /we4266")
   endif()
 
+  if (SOCI_ENABLE_WERROR)
+     set(SOCI_WERROR_OPTION "/WX")
+  endif (SOCI_ENABLE_WERROR)
 else()
 
-  # Set the -Werror compilation flag (where all the compilation warnings are
-  # considered as errors) only when building in Debug mode
-  set(SOCI_WERROR_OPTION "")
   if (SOCI_ENABLE_WERROR)
      set(SOCI_WERROR_OPTION "-Werror")
   endif (SOCI_ENABLE_WERROR)
 
   set(SOCI_GCC_CLANG_COMMON_FLAGS
-    "-pedantic ${SOCI_WERROR_OPTION} -Wno-error=parentheses -Wall -Wextra -Wpointer-arith -Wcast-align -Wcast-qual -Wfloat-equal -Woverloaded-virtual -Wredundant-decls -Wno-long-long")
+    "-pedantic -Wno-error=parentheses -Wall -Wextra -Wpointer-arith -Wcast-align -Wcast-qual -Wfloat-equal -Woverloaded-virtual -Wredundant-decls -Wno-long-long")
 
 
   if (SOCI_CXX11)
@@ -113,6 +117,8 @@ else()
   endif()
 
 endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SOCI_WERROR_OPTION}")
 
 # Set SOCI_HAVE_* variables for soci-config.h generator
 set(SOCI_HAVE_CXX11 ${SOCI_CXX11} CACHE INTERNAL "Enables C++11 support")

--- a/src/backends/mysql/session.cpp
+++ b/src/backends/mysql/session.cpp
@@ -284,22 +284,22 @@ void parse_connect_string(const string & connectString,
         {
             if (!valid_uint(val))
                 throw soci_error(err);
-            char *end;
-            *connect_timeout = std::strtoul(val.c_str(), &end, 10);
+            char *endp;
+            *connect_timeout = std::strtoul(val.c_str(), &endp, 10);
             *connect_timeout_p = true;
         } else if (par == "read_timeout" && !*read_timeout_p)
         {
             if (!valid_uint(val))
                 throw soci_error(err);
-            char *end;
-            *read_timeout = std::strtoul(val.c_str(), &end, 10);
+            char *endp;
+            *read_timeout = std::strtoul(val.c_str(), &endp, 10);
             *read_timeout_p = true;
         } else if (par == "write_timeout" && !*write_timeout_p)
         {
             if (!valid_uint(val))
                 throw soci_error(err);
-            char *end;
-            *write_timeout = std::strtoul(val.c_str(), &end, 10);
+            char *endp;
+            *write_timeout = std::strtoul(val.c_str(), &endp, 10);
             *write_timeout_p = true;
         }
         else

--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -26,7 +26,7 @@ namespace // unnamed
 #ifndef SOCI_POSTGRESQL_NOSINGLEROWMODE
 void wait_until_operation_complete(postgresql_session_backend & session)
 {
-    while (true)
+    for (;;)
     {
         PGresult * result = PQgetResult(session.conn_);
         if (result == NULL)

--- a/src/backends/postgresql/vector-into-type.cpp
+++ b/src/backends/postgresql/vector-into-type.cpp
@@ -79,7 +79,7 @@ void postgresql_vector_into_type_backend::post_fetch(bool gotData, indicator * i
 
         int const endRow = statement_.currentRow_ + statement_.rowsToConsume_;
 
-        for (int curRow = statement_.currentRow_, i = begin_;
+        for (int curRow = statement_.currentRow_, i = static_cast<int>(begin_);
              curRow != endRow; ++curRow, ++i)
         {
             // first, deal with indicators

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -19,6 +19,12 @@
 #pragma warning(disable:4355)
 #endif
 
+// This is used instead of tolower() just to avoid warnings about int to char
+// casts inside MSVS std::transform() implementation.
+char toLowerCh(char c) {
+    return static_cast<char>( std::tolower(c) );
+}
+
 using namespace soci;
 using namespace soci::details;
 using namespace sqlite_api;
@@ -510,7 +516,7 @@ void sqlite3_statement_backend::describe_column(int colNum, data_type & type,
         dt.resize(siter - dt.begin());
 
     // do all comparisons in lower case
-    std::transform(dt.begin(), dt.end(), dt.begin(), tolower);
+    std::transform(dt.begin(), dt.end(), dt.begin(), toLowerCh);
 
     sqlite3_data_type_map::const_iterator iter = dataTypeMap.find(dt);
     if (iter != dataTypeMap.end())

--- a/src/backends/sqlite3/vector-into-type.cpp
+++ b/src/backends/sqlite3/vector-into-type.cpp
@@ -47,12 +47,23 @@ void sqlite3_vector_into_type_backend::pre_fetch()
 namespace // anonymous
 {
 
+// MSVS 2015 (only) gives a bogus warning about unreachable code here, suppress
+// it to allow compilation with /WX in the CI builds.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4702) // unreachable code
+#endif
+
 template <typename T>
 void set_in_vector(void* p, int indx, T const& val)
 {
     std::vector<T> &v = *static_cast<std::vector<T>*>(p);
     v[indx] = val;
 }
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 template <typename T>
 T parse_number_from_string(const char* str)

--- a/src/backends/sqlite3/vector-into-type.cpp
+++ b/src/backends/sqlite3/vector-into-type.cpp
@@ -55,6 +55,22 @@ void set_in_vector(void* p, int indx, T const& val)
 }
 
 template <typename T>
+T parse_number_from_string(const char* str)
+{
+    T value;
+    if (!details::cstring_to_integer(value, str))
+        throw soci_error("Cannot convert data");
+
+    return value;
+}
+
+template <>
+double parse_number_from_string(const char* str)
+{
+    return details::cstring_to_double(str);
+}
+
+template <typename T>
 void set_number_in_vector(void *p, int idx, const sqlite3_column &col)
 {
     using namespace details;
@@ -65,13 +81,10 @@ void set_number_in_vector(void *p, int idx, const sqlite3_column &col)
         case dt_date:
         case dt_string:
         case dt_blob:
-            {
-                T value;
-                if (!details::cstring_to_integer(value, col.buffer_.size_ > 0 ? col.buffer_.constData_ : ""))
-                    throw soci_error("Cannot convert data");
-
-                set_in_vector(p, idx, value);
-            }
+            set_in_vector(p, idx,
+                          parse_number_from_string<T>(col.buffer_.size_ > 0
+                                                        ? col.buffer_.constData_
+                                                        : ""));
             break;
 
         case dt_double:

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -43,6 +43,14 @@ void logger_impl::set_stream(std::ostream *)
     throw_not_supported();
 }
 
+// Disable the warning given by MSVC after throw_not_supported(): we can't just
+// remove the return because this results in warnings about missing return from
+// the other compilers.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4702) // unreachable code
+#endif
+
 std::ostream * logger_impl::get_stream() const
 {
     throw_not_supported();
@@ -57,6 +65,9 @@ std::string logger_impl::get_last_query() const
     return std::string();
 }
 
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 
 logger::logger(logger_impl * impl)

--- a/tests/mysql/test-mysql.cpp
+++ b/tests/mysql/test-mysql.cpp
@@ -62,9 +62,6 @@ TEST_CASE("MySQL stored procedures", "[mysql][stored-procedure]")
 
     // explicit procedure syntax
     {
-        std::string in("my message2");
-        std::string out;
-
         procedure proc = (sql.prepare <<
             "myecho(:input)",
             into(out), use(in, "input"));

--- a/tests/odbc/test-odbc-access.cpp
+++ b/tests/odbc/test-odbc-access.cpp
@@ -70,8 +70,8 @@ class test_context : public test_context_base
 {
 public:
 
-test_context(backend_factory const &backEnd, std::string const &connectString)
-        : test_context_base(backEnd, connectString) {}
+    test_context(backend_factory const &backend, std::string const &connstr)
+        : test_context_base(backend, connstr) {}
 
     table_creator_base * table_creator_1(soci::session& s) const
     {

--- a/tests/odbc/test-odbc-mssql.cpp
+++ b/tests/odbc/test-odbc-mssql.cpp
@@ -143,9 +143,9 @@ struct table_creator_for_xml : table_creator_base
 class test_context : public test_context_base
 {
 public:
-    test_context(backend_factory const &backEnd,
-                std::string const &connectString)
-        : test_context_base(backEnd, connectString) {}
+    test_context(backend_factory const &backend,
+                std::string const &connstr)
+        : test_context_base(backend, connstr) {}
 
     table_creator_base* table_creator_1(soci::session& s) const SOCI_OVERRIDE
     {

--- a/tests/odbc/test-odbc-postgresql.cpp
+++ b/tests/odbc/test-odbc-postgresql.cpp
@@ -153,9 +153,9 @@ struct table_creator_for_clob : table_creator_base
 class test_context : public test_context_base
 {
 public:
-    test_context(backend_factory const &backEnd,
-                std::string const &connectString)
-        : test_context_base(backEnd, connectString),
+    test_context(backend_factory const &backend,
+                std::string const &connstr)
+        : test_context_base(backend, connstr),
           m_verDriver(get_driver_version())
     {
         std::cout << "Using ODBC driver version " << m_verDriver << "\n";

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -1026,7 +1026,7 @@ private:
             msession << "DROP FUNCTION IF EXISTS \"function_with:colon\"();";
             msession << "DROP TYPE IF EXISTS \"type_with:colon\" ;";
         }
-        catch (soci_error const& e){}
+        catch (soci_error const&){}
     }
     soci::session& msession;
 };

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -119,9 +119,6 @@ TEST_CASE("PostgreSQL function call", "[postgresql][function]")
 
     // explicit procedure syntax
     {
-        std::string in("my message2");
-        std::string out;
-
         procedure proc = (sql.prepare <<
             "soci_test(:input)",
             into(out), use(in, "input"));
@@ -1150,8 +1147,8 @@ struct table_creator_for_clob : table_creator_base
 class test_context : public test_context_base
 {
 public:
-    test_context(backend_factory const &backEnd, std::string const &connectString)
-        : test_context_base(backEnd, connectString)
+    test_context(backend_factory const &backend, std::string const &connstr)
+        : test_context_base(backend, connstr)
     {}
 
     table_creator_base* table_creator_1(soci::session& s) const SOCI_OVERRIDE

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -394,9 +394,9 @@ struct table_creator_for_get_affected_rows : table_creator_base
 class test_context : public test_context_base
 {
 public:
-    test_context(backend_factory const &backEnd,
-                std::string const &connectString)
-        : test_context_base(backEnd, connectString) {}
+    test_context(backend_factory const &backend,
+                std::string const &connstr)
+        : test_context_base(backend, connstr) {}
 
     table_creator_base* table_creator_1(soci::session& s) const SOCI_OVERRIDE
     {


### PR DESCRIPTION
The goal here is to enable `/WX` for MSVS to be able to see when new warnings appear, but as a side effect this PR also contains a fix for SQLite.