### PR TITLE
soci::session disabmigue on macos in test-postgresql.cpp

### DIFF
--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -1052,7 +1052,7 @@ TEST_CASE("false_bind_variable_inside_identifier", "[postgresql][bind-variables]
 struct table_creator_colon_in_double_quotes_in_single_quotes :
     table_creator_base
 {
-    table_creator_colon_in_double_quotes_in_single_quotes(session & sql)
+    table_creator_colon_in_double_quotes_in_single_quotes(soci::session & sql)
         : table_creator_base(sql)
     {
        sql << "CREATE TABLE soci_test( \"column_with:colon\" text)";


### PR DESCRIPTION
Signed-off-by: kuvaldini <ivan@kuvaldini.pro>

Error message:
```
[ 83%] Building CXX object src/backends/sqlite3/CMakeFiles/soci_sqlite3.dir/standard-into-type.cpp.o
/devel/soci/tests/postgresql/test-postgresql.cpp:1055:59: error: reference to 'session' is ambiguous
    table_creator_colon_in_double_quotes_in_single_quotes(session & sql)
                                                          ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/include/sys/proc.h:84:8: note: candidate found by name lookup is
      'session'
struct session;
       ^
/devel/soci/include/soci/callbacks.h:14:7: note: candidate found by name lookup is 'soci::session'
class session;
      ^
 ```