### PR TITLE
Add support for vectors of XML and long string values to several backends

### DIFF
--- a/cmake/SociBackend.cmake
+++ b/cmake/SociBackend.cmake
@@ -354,7 +354,7 @@ macro(soci_backend_test)
 
       add_test(${TEST_TARGET}
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET}
-        ${${TEST_CONNSTR_VAR}})
+        ${${TEST_CONNSTR_VAR}} --invisibles)
 
       soci_backend_test_create_vcxproj_user(${TEST_TARGET} "\"${${TEST_CONNSTR_VAR}}\"")
 
@@ -376,7 +376,7 @@ macro(soci_backend_test)
 
       add_test(${TEST_TARGET_STATIC}
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_TARGET_STATIC}
-        ${${TEST_CONNSTR_VAR}})
+        ${${TEST_CONNSTR_VAR}} --invisibles)
 
       soci_backend_test_create_vcxproj_user(${TEST_TARGET_STATIC} "\"${${TEST_CONNSTR_VAR}}\"")
 

--- a/include/private/firebird/common.h
+++ b/include/private/firebird/common.h
@@ -40,6 +40,9 @@ void setTextParam(char const * s, std::size_t size, char * buf_,
 
 std::string getTextParam(XSQLVAR const *var);
 
+// Copy contents of a BLOB in buf into the given string.
+void copy_from_blob(firebird_statement_backend &st, char *buf, std::string &out);
+
 template <typename IntType>
 const char *str2dec(const char * s, IntType &out, short &scale)
 {

--- a/include/private/firebird/common.h
+++ b/include/private/firebird/common.h
@@ -253,20 +253,6 @@ T1 from_isc(XSQLVAR * var)
     GCC_WARNING_RESTORE(cast-align)
 }
 
-template <typename T>
-std::size_t getVectorSize(void *p)
-{
-    std::vector<T> *v = static_cast<std::vector<T> *>(p);
-    return v->size();
-}
-
-template <typename T>
-void resizeVector(void *p, std::size_t sz)
-{
-    std::vector<T> *v = static_cast<std::vector<T> *>(p);
-    v->resize(sz);
-}
-
 } // namespace firebird
 
 } // namespace details

--- a/include/private/soci-vector-helpers.h
+++ b/include/private/soci-vector-helpers.h
@@ -1,0 +1,133 @@
+//
+// Copyright (C) 2021 Sinitsyn Ilya
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_VECTOR_HELPERS_H_INCLUDED
+#define SOCI_VECTOR_HELPERS_H_INCLUDED
+
+#include "soci-exchange-cast.h"
+
+namespace soci
+{
+
+namespace details
+{
+
+// Helper functions to work with vectors.
+
+template <exchange_type e>
+std::vector<typename exchange_type_traits<e>::value_type>& exchange_vector_type_cast(void *data)
+{
+    return *static_cast<std::vector<typename exchange_type_traits<e>::value_type>*>(data);
+}
+
+// Get the size of the vector.
+inline std::size_t get_vector_size(exchange_type e, void *data)
+{
+    switch (e)
+    {
+        case x_char:
+            return exchange_vector_type_cast<x_char>(data).size();
+        case x_stdstring:
+            return exchange_vector_type_cast<x_stdstring>(data).size();
+        case x_short:
+            return exchange_vector_type_cast<x_short>(data).size();
+        case x_integer:
+            return exchange_vector_type_cast<x_integer>(data).size();
+        case x_long_long:
+            return exchange_vector_type_cast<x_long_long>(data).size();
+        case x_unsigned_long_long:
+            return exchange_vector_type_cast<x_unsigned_long_long>(data).size();
+        case x_double:
+            return exchange_vector_type_cast<x_double>(data).size();
+        case x_stdtm:
+            return exchange_vector_type_cast<x_stdtm>(data).size();
+        case x_xmltype:
+            return exchange_vector_type_cast<x_xmltype>(data).size();
+        case x_longstring:
+            return exchange_vector_type_cast<x_longstring>(data).size();
+        case x_statement:
+        case x_rowid:
+        case x_blob:
+            break;
+    }
+    throw soci_error("Failed to get the size of the vector of non-supported type.");
+}
+
+// Set the size of the vector.
+inline void resize_vector(exchange_type e, void *data, std::size_t newSize)
+{
+    switch (e)
+    {
+        case x_char:
+            exchange_vector_type_cast<x_char>(data).resize(newSize);
+            return;
+        case x_stdstring:
+            exchange_vector_type_cast<x_stdstring>(data).resize(newSize);
+            return;
+        case x_short:
+            exchange_vector_type_cast<x_short>(data).resize(newSize);
+            return;
+        case x_integer:
+            exchange_vector_type_cast<x_integer>(data).resize(newSize);
+            return;
+        case x_long_long:
+            exchange_vector_type_cast<x_long_long>(data).resize(newSize);
+            return;
+        case x_unsigned_long_long:
+            exchange_vector_type_cast<x_unsigned_long_long>(data).resize(newSize);
+            return;
+        case x_double:
+            exchange_vector_type_cast<x_double>(data).resize(newSize);
+            return;
+        case x_stdtm:
+            exchange_vector_type_cast<x_stdtm>(data).resize(newSize);
+            return;
+        case x_xmltype:
+            exchange_vector_type_cast<x_xmltype>(data).resize(newSize);
+            return;
+        case x_longstring:
+            exchange_vector_type_cast<x_longstring>(data).resize(newSize);
+            return;
+        case x_statement:
+        case x_rowid:
+        case x_blob:
+            break;
+    }
+    throw soci_error("Failed to get the size of the vector of non-supported type.");
+}
+
+// Get the string at the given index of the vector.
+inline std::string& vector_string_value(exchange_type e, void *data, std::size_t ind)
+{
+    switch (e)
+    {
+        case x_stdstring:
+            return exchange_vector_type_cast<x_stdstring>(data).at(ind);
+        case x_xmltype:
+            return exchange_vector_type_cast<x_xmltype>(data).at(ind).value;
+        case x_longstring:
+            return exchange_vector_type_cast<x_longstring>(data).at(ind).value;
+        case x_char:
+        case x_short:
+        case x_integer:
+        case x_long_long:
+        case x_unsigned_long_long:
+        case x_double:
+        case x_stdtm:
+        case x_statement:
+        case x_rowid:
+        case x_blob:
+            break;
+    }
+    throw soci_error("Can't get the string value from the vector of values with non-supported type.");
+}
+
+} // namespace details
+
+} // namespace soci
+
+#endif // SOCI_VECTOR_HELPERS_H_INCLUDED

--- a/include/soci/firebird/soci-firebird.h
+++ b/include/soci/firebird/soci-firebird.h
@@ -77,11 +77,6 @@ struct firebird_standard_into_type_backend : details::standard_into_type_backend
 
     char *buf_;
     short indISCHolder_;
-
-private:
-    // Copy contents of a BLOB (represented by its id) in buf_ into the given
-    // string.
-    void copy_from_blob(std::string& out);
 };
 
 struct firebird_vector_into_type_backend : details::vector_into_type_backend
@@ -151,7 +146,8 @@ private:
 struct firebird_vector_use_type_backend : details::vector_use_type_backend
 {
     firebird_vector_use_type_backend(firebird_statement_backend &st)
-        : statement_(st), data_(NULL), type_(), position_(0), buf_(NULL), indISCHolder_(0)
+        : statement_(st), data_(NULL), type_(), position_(0), buf_(NULL), indISCHolder_(0),
+          blob_(NULL)
     {}
 
     void bind_by_pos(int &position,
@@ -175,6 +171,14 @@ struct firebird_vector_use_type_backend : details::vector_use_type_backend
 
     char *buf_;
     short indISCHolder_;
+
+private:
+    // Allocate a temporary blob, fill it with the data from the provided
+    // string and copy its ID into buf_.
+    void copy_to_blob(const std::string &in);
+
+    // This is used for types mapping to CLOB.
+    firebird_blob_backend *blob_;
 };
 
 struct firebird_session_backend;

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -51,8 +51,6 @@ struct oracle_standard_into_type_backend : details::standard_into_type_backend
     void define_by_pos(int &position,
         void *data, details::exchange_type type) SOCI_OVERRIDE;
 
-    void read_from_lob(OCILobLocator * lobp, std::string & value);
-
     void pre_exec(int num) SOCI_OVERRIDE;
     void pre_fetch() SOCI_OVERRIDE;
     void post_fetch(bool gotData, bool calledFromFetch,

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -133,12 +133,6 @@ struct oracle_standard_use_type_backend : details::standard_use_type_backend
     // common part for bind_by_pos and bind_by_name
     void prepare_for_bind(void *&data, sb4 &size, ub2 &oracleType, bool readOnly);
 
-    // common helper for pre_use for LOB-directed wrapped types
-    void write_to_lob(OCILobLocator * lobp, const std::string & value);
-
-    // common lazy initialization of the temporary LOB object
-    void lazy_temp_lob_init();
-
     void pre_exec(int num) SOCI_OVERRIDE;
     void pre_use(indicator const *ind) SOCI_OVERRIDE;
     void post_use(bool gotData, indicator *ind) SOCI_OVERRIDE;

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -87,6 +87,7 @@ struct oracle_vector_into_type_backend : details::vector_into_type_backend
         int & position, void * data, details::exchange_type type,
         std::size_t begin, std::size_t * end) SOCI_OVERRIDE;
 
+    void pre_exec(int num) SOCI_OVERRIDE;
     void pre_fetch() SOCI_OVERRIDE;
     void post_fetch(bool gotData, indicator *ind) SOCI_OVERRIDE;
 

--- a/src/backends/firebird/blob.cpp
+++ b/src/backends/firebird/blob.cpp
@@ -179,6 +179,12 @@ void firebird_blob_backend::load()
         open();
     }
 
+    // The blob is empty.
+    if (data_.empty())
+    {
+        return;
+    }
+
     ISC_STATUS stat[20];
     unsigned short bytes;
     std::vector<char>::size_type total_bytes = 0;

--- a/src/backends/firebird/standard-into-type.cpp
+++ b/src/backends/firebird/standard-into-type.cpp
@@ -132,39 +132,22 @@ void firebird_standard_into_type_backend::exchangeData()
             break;
 
         case x_longstring:
-            copy_from_blob(exchange_type_cast<x_longstring>(data_).value);
+            {
+                std::string &tmp = exchange_type_cast<x_longstring>(data_).value;
+                copy_from_blob(statement_, buf_, tmp);
+            }
             break;
 
         case x_xmltype:
-            copy_from_blob(exchange_type_cast<x_xmltype>(data_).value);
+            {
+                std::string &tmp = exchange_type_cast<x_xmltype>(data_).value;
+                copy_from_blob(statement_, buf_, tmp);
+            }
             break;
 
         default:
             throw soci_error("Into element used with non-supported type.");
     } // switch
-}
-
-void firebird_standard_into_type_backend::copy_from_blob(std::string& out)
-{
-    firebird_blob_backend blob(statement_.session_);
-
-    GCC_WARNING_SUPPRESS(cast-align)
-
-    blob.assign(*reinterpret_cast<ISC_QUAD*>(buf_));
-
-    GCC_WARNING_RESTORE(cast-align)
-
-    std::size_t const len_total = blob.get_len();
-    out.resize(len_total);
-
-    std::size_t const len_read = blob.read(0, &out[0], len_total);
-    if (len_read != len_total)
-    {
-        std::ostringstream os;
-        os << "Read " << len_read << " bytes instead of expected "
-           << len_total << " from Firebird text blob object";
-        throw soci_error(os.str());
-    }
 }
 
 void firebird_standard_into_type_backend::clean_up()

--- a/src/backends/firebird/standard-into-type.cpp
+++ b/src/backends/firebird/standard-into-type.cpp
@@ -85,6 +85,10 @@ void firebird_standard_into_type_backend::exchangeData()
         case x_long_long:
             exchange_type_cast<x_long_long>(data_) = from_isc<long long>(var);
             break;
+        case x_unsigned_long_long:
+            exchange_type_cast<x_unsigned_long_long>(data_) =
+                from_isc<unsigned long long>(var);
+            break;
         case x_double:
             exchange_type_cast<x_double>(data_) = from_isc<double>(var);
             break;

--- a/src/backends/firebird/standard-use-type.cpp
+++ b/src/backends/firebird/standard-use-type.cpp
@@ -116,6 +116,9 @@ void firebird_standard_use_type_backend::exchangeData()
         case x_long_long:
             to_isc<long long>(data_, var);
             break;
+        case x_unsigned_long_long:
+            to_isc<unsigned long long>(data_, var);
+            break;
         case x_double:
             to_isc<double>(data_, var);
             break;

--- a/src/backends/firebird/vector-into-type.cpp
+++ b/src/backends/firebird/vector-into-type.cpp
@@ -80,6 +80,12 @@ void firebird_vector_into_type_backend::exchangeData(std::size_t row)
             setIntoVector(data_, row, tmp);
         }
         break;
+    case x_unsigned_long_long:
+        {
+            unsigned long long tmp = from_isc<unsigned long long>(var);
+            setIntoVector(data_, row, tmp);
+        }
+    break;
     case x_double:
         {
             double tmp = from_isc<double>(var);

--- a/src/backends/firebird/vector-into-type.cpp
+++ b/src/backends/firebird/vector-into-type.cpp
@@ -8,6 +8,7 @@
 #define SOCI_FIREBIRD_SOURCE
 #include "soci/firebird/soci-firebird.h"
 #include "firebird/common.h"
+#include "soci-vector-helpers.h"
 
 using namespace soci;
 using namespace soci::details;
@@ -136,68 +137,12 @@ void firebird_vector_into_type_backend::post_fetch(
 
 void firebird_vector_into_type_backend::resize(std::size_t sz)
 {
-    switch (type_)
-    {
-    case x_char:
-        resizeVector<char> (data_, sz);
-        break;
-    case x_short:
-        resizeVector<short> (data_, sz);
-        break;
-    case x_integer:
-        resizeVector<int> (data_, sz);
-        break;
-    case x_long_long:
-        resizeVector<long long> (data_, sz);
-        break;
-    case x_double:
-        resizeVector<double> (data_, sz);
-        break;
-    case x_stdstring:
-        resizeVector<std::string> (data_, sz);
-        break;
-    case x_stdtm:
-        resizeVector<std::tm> (data_, sz);
-        break;
-
-    default:
-        throw soci_error("Into vector element used with non-supported type.");
-    }
+    resize_vector(type_, data_, sz);
 }
 
 std::size_t firebird_vector_into_type_backend::size()
 {
-    std::size_t sz = 0; // dummy initialization to please the compiler
-    switch (type_)
-    {
-        // simple cases
-    case x_char:
-        sz = getVectorSize<char> (data_);
-        break;
-    case x_short:
-        sz = getVectorSize<short> (data_);
-        break;
-    case x_integer:
-        sz = getVectorSize<int> (data_);
-        break;
-    case x_long_long:
-        sz = getVectorSize<long long> (data_);
-        break;
-    case x_double:
-        sz = getVectorSize<double> (data_);
-        break;
-    case x_stdstring:
-        sz = getVectorSize<std::string> (data_);
-        break;
-    case x_stdtm:
-        sz = getVectorSize<std::tm> (data_);
-        break;
-
-    default:
-        throw soci_error("Into vector element used with non-supported type.");
-    }
-
-    return sz;
+    return get_vector_size(type_, data_);
 }
 
 void firebird_vector_into_type_backend::clean_up()

--- a/src/backends/firebird/vector-into-type.cpp
+++ b/src/backends/firebird/vector-into-type.cpp
@@ -106,6 +106,20 @@ void firebird_vector_into_type_backend::exchangeData(std::size_t row)
         }
         break;
 
+    case x_longstring:
+        {
+            std::string &tmp = exchange_vector_type_cast<x_longstring>(data_)[row].value;
+            copy_from_blob(statement_, buf_, tmp);
+        }
+        break;
+
+    case x_xmltype:
+        {
+            std::string &tmp = exchange_vector_type_cast<x_xmltype>(data_)[row].value;
+            copy_from_blob(statement_, buf_, tmp);
+        }
+        break;
+
     default:
         throw soci_error("Into vector element used with non-supported type.");
     } // switch

--- a/src/backends/firebird/vector-use-type.cpp
+++ b/src/backends/firebird/vector-use-type.cpp
@@ -8,6 +8,7 @@
 #define SOCI_FIREBIRD_SOURCE
 #include "soci/firebird/soci-firebird.h"
 #include "firebird/common.h"
+#include "soci-vector-helpers.h"
 
 using namespace soci;
 using namespace soci::details;
@@ -165,37 +166,7 @@ void firebird_vector_use_type_backend::exchangeData(std::size_t row)
 
 std::size_t firebird_vector_use_type_backend::size()
 {
-    std::size_t sz = 0; // dummy initialization to please the compiler
-    switch (type_)
-    {
-        // simple cases
-    case x_char:
-        sz = getVectorSize<char> (data_);
-        break;
-    case x_short:
-        sz = getVectorSize<short> (data_);
-        break;
-    case x_integer:
-        sz = getVectorSize<int> (data_);
-        break;
-    case x_long_long:
-        sz = getVectorSize<long long> (data_);
-        break;
-    case x_double:
-        sz = getVectorSize<double> (data_);
-        break;
-    case x_stdstring:
-        sz = getVectorSize<std::string> (data_);
-        break;
-    case x_stdtm:
-        sz = getVectorSize<std::tm> (data_);
-        break;
-
-    default:
-        throw soci_error("Use vector element used with non-supported type.");
-    }
-
-    return sz;
+    return get_vector_size(type_, data_);
 }
 
 void firebird_vector_use_type_backend::clean_up()

--- a/src/backends/firebird/vector-use-type.cpp
+++ b/src/backends/firebird/vector-use-type.cpp
@@ -133,6 +133,11 @@ void firebird_vector_use_type_backend::exchangeData(std::size_t row)
             static_cast<void*>(getUseVectorValue<long long>(data_, row)),
             var);
         break;
+    case x_unsigned_long_long:
+        to_isc<unsigned long long>(
+            static_cast<void*>(getUseVectorValue<unsigned long long>(data_, row)),
+            var);
+        break;
     case x_double:
         to_isc<double>(
             static_cast<void*>(getUseVectorValue<double>(data_, row)),

--- a/src/backends/firebird/vector-use-type.cpp
+++ b/src/backends/firebird/vector-use-type.cpp
@@ -156,12 +156,27 @@ void firebird_vector_use_type_backend::exchangeData(std::size_t row)
         tmEncode(var->sqltype,
             getUseVectorValue<std::tm>(data_, row), buf_);
         break;
+        // types which internally use blobs
+    case x_xmltype:
+    case x_longstring:
+        copy_to_blob(vector_string_value(type_, data_, row));
+        break;
         //  Not supported
         //  case x_cstring:
         //  case x_blob:
     default:
         throw soci_error("Use element used with non-supported type.");
     } // switch
+}
+
+void firebird_vector_use_type_backend::copy_to_blob(const std::string &in)
+{
+    delete blob_;
+
+    blob_ = new firebird_blob_backend(statement_.session_);
+    blob_->append(in.c_str(), in.length());
+    blob_->save();
+    memcpy(buf_, &blob_->bid_, sizeof(blob_->bid_));
 }
 
 std::size_t firebird_vector_use_type_backend::size()
@@ -175,6 +190,11 @@ void firebird_vector_use_type_backend::clean_up()
     {
         delete [] buf_;
         buf_ = NULL;
+    }
+    if (blob_ != NULL)
+    {
+        delete blob_;
+        blob_ = NULL;
     }
     std::vector<void*>::iterator it =
         std::find(statement_.uses_.begin(), statement_.uses_.end(), this);

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -148,7 +148,12 @@ void odbc_vector_into_type_backend::define_by_pos(
         {
             odbcType_ = SQL_C_CHAR;
             const size_t vectorSize = get_vector_size(type, data);
-            colSize_ = get_sqllen_from_value(statement_.column_size(position)) + 1;
+
+            // Column size for text data type can be too large for buffer allocation.
+            colSize_ = static_cast<size_t>(get_sqllen_from_value(statement_.column_size(position)));
+            colSize_ = (colSize_ > odbc_max_buffer_length || colSize_ == 0) ? odbc_max_buffer_length : colSize_;
+            colSize_++;
+
             std::size_t bufSize = colSize_ * vectorSize;
             buf_ = new char[bufSize];
 

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -8,6 +8,7 @@
 #define SOCI_ODBC_SOURCE
 #include "soci/soci-platform.h"
 #include "soci/odbc/soci-odbc.h"
+#include "soci/type-wrappers.h"
 #include "soci-compiler.h"
 #include "soci-cstrtoi.h"
 #include "soci-mktime.h"
@@ -142,6 +143,8 @@ void odbc_vector_into_type_backend::define_by_pos(
         }
         break;
     case x_stdstring:
+    case x_xmltype:
+    case x_longstring:
         {
             odbcType_ = SQL_C_CHAR;
             const size_t vectorSize = get_vector_size(type, data);
@@ -214,7 +217,7 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator *ind)
                 pos += colSize_;
             }
         }
-        if (type_ == x_stdstring)
+        if (type_ == x_stdstring || type_ == x_xmltype || type_ == x_longstring)
         {
             const char *pos = buf_;
             std::size_t const vsize = get_vector_size(type_, data_);;

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -151,7 +151,7 @@ void odbc_vector_into_type_backend::define_by_pos(
 
             // Column size for text data type can be too large for buffer allocation.
             colSize_ = static_cast<size_t>(get_sqllen_from_value(statement_.column_size(position)));
-            colSize_ = (colSize_ > odbc_max_buffer_length || colSize_ == 0) ? odbc_max_buffer_length : colSize_;
+            colSize_ = (colSize_ >= ODBC_MAX_COL_SIZE || colSize_ == 0) ? odbc_max_buffer_length : colSize_;
             colSize_++;
 
             std::size_t bufSize = colSize_ * vectorSize;

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -154,6 +154,8 @@ void* odbc_vector_use_type_backend::prepare_for_bind(SQLUINTEGER &size,
         }
         break;
     case x_stdstring:
+    case x_xmltype:
+    case x_longstring:
         {
             sqlType = SQL_CHAR;
             cType = SQL_C_CHAR;
@@ -289,6 +291,8 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
 
         case x_char:
         case x_stdstring:
+        case x_xmltype:
+        case x_longstring:
             non_null_indicator = SQL_NTS;
             break;
 
@@ -365,8 +369,6 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
         case x_statement:
         case x_rowid:
         case x_blob:
-        case x_xmltype:
-        case x_longstring:
             // Those are unreachable, we would have thrown from
             // prepare_for_bind() if we we were using one of them, only handle
             // them here to avoid compiler warnings about unhandled enum
@@ -386,7 +388,7 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
             else
             {
                 // for strings we have already set the values
-                if (type_ != x_stdstring)
+                if (type_ != x_stdstring && type_ != x_xmltype && type_ != x_longstring)
                 {
                     set_sqllen_from_vector_at(i, non_null_indicator);
                 }
@@ -399,7 +401,7 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
         for (std::size_t i = 0; i != indHolderVec_.size(); ++i)
         {
             // for strings we have already set the values
-            if (type_ != x_stdstring)
+            if (type_ != x_stdstring && type_ != x_xmltype && type_ != x_longstring)
             {
                 set_sqllen_from_vector_at(i, non_null_indicator);
             }

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -157,9 +157,6 @@ void* odbc_vector_use_type_backend::prepare_for_bind(SQLUINTEGER &size,
     case x_xmltype:
     case x_longstring:
         {
-            sqlType = SQL_CHAR;
-            cType = SQL_C_CHAR;
-
             std::size_t maxSize = 0;
             std::size_t const vecSize = get_vector_size(type_, data_);
             prepare_indicators(vecSize);
@@ -185,6 +182,9 @@ void* odbc_vector_use_type_backend::prepare_for_bind(SQLUINTEGER &size,
 
             data = buf_;
             size = static_cast<SQLINTEGER>(maxSize);
+
+            sqlType = size >= ODBC_MAX_COL_SIZE ? SQL_LONGVARCHAR : SQL_VARCHAR;
+            cType = SQL_C_CHAR;
         }
         break;
     case x_stdtm:

--- a/src/backends/oracle/clob.h
+++ b/src/backends/oracle/clob.h
@@ -10,8 +10,9 @@
 
 #include "soci/oracle/soci-oracle.h"
 
-// Note that the functions in this file are currently implemented in
-// standard-use-type.cpp.
+// Note that mopst functions in this file are currently implemented in
+// standard-use-type.cpp except for read_from_lob() which is found in
+// standard-into-type.cpp.
 
 namespace soci
 {
@@ -28,6 +29,10 @@ OCILobLocator * create_temp_lob(oracle_session_backend& session);
 // Writes the given value to the LOB. Throws on error.
 void write_to_lob(oracle_session_backend& session,
     OCILobLocator * lobp, const std::string & value);
+
+// Reads the value from the lob into the given string. Throws on error.
+void read_from_lob(oracle_session_backend& session,
+    OCILobLocator * lobp, std::string & value);
 
 // Frees a temporary LOB object. Doesn't throw.
 void free_temp_lob(oracle_session_backend& session, OCILobLocator * lobp);

--- a/src/backends/oracle/clob.h
+++ b/src/backends/oracle/clob.h
@@ -29,6 +29,9 @@ OCILobLocator * create_temp_lob(oracle_session_backend& session);
 void write_to_lob(oracle_session_backend& session,
     OCILobLocator * lobp, const std::string & value);
 
+// Frees a temporary LOB object. Doesn't throw.
+void free_temp_lob(oracle_session_backend& session, OCILobLocator * lobp);
+
 } // namespace oracle
 
 } // namespace details

--- a/src/backends/oracle/clob.h
+++ b/src/backends/oracle/clob.h
@@ -1,0 +1,38 @@
+//
+// Copyright (C) 2021 Vadim Zeitlin
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_ORACLE_CLOB_H_INCLUDED
+#define SOCI_ORACLE_CLOB_H_INCLUDED
+
+#include "soci/oracle/soci-oracle.h"
+
+// Note that the functions in this file are currently implemented in
+// standard-use-type.cpp.
+
+namespace soci
+{
+
+namespace details
+{
+
+namespace oracle
+{
+
+// Creates and returns a temporary LOB object. Throws on error.
+OCILobLocator * create_temp_lob(oracle_session_backend& session);
+
+// Writes the given value to the LOB. Throws on error.
+void write_to_lob(oracle_session_backend& session,
+    OCILobLocator * lobp, const std::string & value);
+
+} // namespace oracle
+
+} // namespace details
+
+} // namespace soci
+
+#endif // SOCI_ORACLE_CLOB_H_INCLUDED

--- a/src/backends/oracle/standard-into-type.cpp
+++ b/src/backends/oracle/standard-into-type.cpp
@@ -8,6 +8,7 @@
 #define SOCI_ORACLE_SOURCE
 #include "soci/oracle/soci-oracle.h"
 #include "soci/blob.h"
+#include "clob.h"
 #include "error.h"
 #include "soci/rowid.h"
 #include "soci/statement.h"
@@ -178,25 +179,7 @@ void oracle_standard_into_type_backend::pre_exec(int /* num */)
     if (type_ == x_xmltype || type_ == x_longstring)
     {
         // lazy initialization of the temporary LOB object
-        
-        OCILobLocator * lobp;
-        sword res = OCIDescriptorAlloc(statement_.session_.envhp_,
-            reinterpret_cast<dvoid**>(&lobp), OCI_DTYPE_LOB, 0, 0);
-        if (res != OCI_SUCCESS)
-        {
-            throw_oracle_soci_error(res, statement_.session_.errhp_);
-        }
-        
-        res = OCILobCreateTemporary(statement_.session_.svchp_,
-            statement_.session_.errhp_,
-            lobp, 0, SQLCS_IMPLICIT,
-            OCI_TEMP_CLOB, OCI_ATTR_NOCACHE, OCI_DURATION_SESSION);
-        if (res != OCI_SUCCESS)
-        {
-            throw_oracle_soci_error(res, statement_.session_.errhp_);
-        }
-
-        ociData_ = lobp;
+        ociData_ = create_temp_lob(statement_.session_);
     }
 }
 

--- a/src/backends/oracle/standard-into-type.cpp
+++ b/src/backends/oracle/standard-into-type.cpp
@@ -346,11 +346,8 @@ void oracle_standard_into_type_backend::clean_up()
 {
     if (type_ == x_xmltype || type_ == x_longstring)
     {
-        OCILobLocator * lobp = static_cast<OCILobLocator *>(ociData_);
-
-        // ignore errors from this call
-        (void) OCILobFreeTemporary(statement_.session_.svchp_, statement_.session_.errhp_,
-            lobp);
+        free_temp_lob(statement_.session_, static_cast<OCILobLocator *>(ociData_));
+        ociData_ = NULL;
     }
     
     if (defnp_ != NULL)

--- a/src/backends/oracle/standard-into-type.cpp
+++ b/src/backends/oracle/standard-into-type.cpp
@@ -218,7 +218,7 @@ void oracle::read_from_lob(oracle_session_backend& session,
                 lobp, &lenChunk,
                 offset,
                 reinterpret_cast<dvoid*>(&buf[offset - 1]),
-                len - offset + 1, 0, 0, 0, 0);
+                len, 0, 0, 0, 0);
             if (res == OCI_NEED_DATA)
             {
                 offset += lenChunk;

--- a/src/backends/oracle/standard-use-type.cpp
+++ b/src/backends/oracle/standard-use-type.cpp
@@ -281,6 +281,16 @@ OCILobLocator * oracle::create_temp_lob(oracle_session_backend& session)
     return lobp;
 }
 
+void oracle::free_temp_lob(oracle_session_backend& session,
+    OCILobLocator * lobp)
+{
+    // ignore errors from this call
+    (void) OCILobFreeTemporary(session.svchp_, session.errhp_, lobp);
+
+    // free LOB Locator
+    OCIDescriptorFree(lobp, OCI_DTYPE_LOB);
+}
+
 void oracle_standard_use_type_backend::pre_exec(int /* num */)
 {
     switch (type_)
@@ -582,14 +592,7 @@ void oracle_standard_use_type_backend::clean_up()
 {
     if (type_ == x_xmltype || type_ == x_longstring)
     {
-        OCILobLocator * lobp = static_cast<OCILobLocator *>(ociData_);
-
-        // ignore errors from this call
-        (void) OCILobFreeTemporary(statement_.session_.svchp_, statement_.session_.errhp_,
-            lobp);
-
-        // free LOB Locator
-        OCIDescriptorFree(lobp, OCI_DTYPE_LOB);
+        free_temp_lob(statement_.session_, static_cast<OCILobLocator *>(ociData_));
         ociData_ = NULL;
     }
     

--- a/src/backends/oracle/vector-into-type.cpp
+++ b/src/backends/oracle/vector-into-type.cpp
@@ -326,69 +326,7 @@ void oracle_vector_into_type_backend::resize(std::size_t sz)
     }
     else
     {
-        switch (type_)
-        {
-            // simple cases
-        case x_char:
-            {
-                std::vector<char> *v = static_cast<std::vector<char> *>(data_);
-                v->resize(sz);
-            }
-            break;
-        case x_short:
-            {
-                std::vector<short> *v = static_cast<std::vector<short> *>(data_);
-                v->resize(sz);
-            }
-            break;
-        case x_integer:
-            {
-                std::vector<int> *v = static_cast<std::vector<int> *>(data_);
-                v->resize(sz);
-            }
-            break;
-        case x_long_long:
-            {
-                std::vector<long long> *v
-                    = static_cast<std::vector<long long> *>(data_);
-                v->resize(sz);
-            }
-            break;
-        case x_unsigned_long_long:
-            {
-                std::vector<unsigned long long> *v
-                    = static_cast<std::vector<unsigned long long> *>(data_);
-                v->resize(sz);
-            }
-            break;
-        case x_double:
-            {
-                std::vector<double> *v
-                    = static_cast<std::vector<double> *>(data_);
-                v->resize(sz);
-            }
-            break;
-        case x_stdstring:
-            {
-                std::vector<std::string> *v
-                    = static_cast<std::vector<std::string> *>(data_);
-                v->resize(sz);
-            }
-            break;
-        case x_stdtm:
-            {
-                std::vector<std::tm> *v
-                    = static_cast<std::vector<std::tm> *>(data_);
-                v->resize(sz);
-            }
-            break;
-
-        case x_xmltype:    break; // not supported
-        case x_longstring: break; // not supported
-        case x_statement:  break; // not supported
-        case x_rowid:      break; // not supported
-        case x_blob:       break; // not supported
-        }
+        resize_vector(type_, data_, sz);
 
         end_var_ = sz;
     }

--- a/src/backends/oracle/vector-into-type.cpp
+++ b/src/backends/oracle/vector-into-type.cpp
@@ -11,6 +11,7 @@
 #include "error.h"
 #include "soci/soci-platform.h"
 #include "soci-mktime.h"
+#include "soci-vector-helpers.h"
 #include <cctype>
 #include <cstdio>
 #include <cstring>
@@ -419,72 +420,7 @@ std::size_t oracle_vector_into_type_backend::size()
 
 std::size_t oracle_vector_into_type_backend::full_size()
 {
-    std::size_t sz = 0; // dummy initialization to please the compiler
-    switch (type_)
-    {
-    // simple cases
-    case x_char:
-        {
-            std::vector<char> *v = static_cast<std::vector<char> *>(data_);
-            sz = v->size();
-        }
-        break;
-    case x_short:
-        {
-            std::vector<short> *v = static_cast<std::vector<short> *>(data_);
-            sz = v->size();
-        }
-        break;
-    case x_integer:
-        {
-            std::vector<int> *v = static_cast<std::vector<int> *>(data_);
-            sz = v->size();
-        }
-        break;
-    case x_long_long:
-        {
-            std::vector<long long> *v
-                = static_cast<std::vector<long long> *>(data_);
-            sz = v->size();
-        }
-        break;
-    case x_unsigned_long_long:
-        {
-            std::vector<unsigned long long> *v
-                = static_cast<std::vector<unsigned long long> *>(data_);
-            sz = v->size();
-        }
-        break;
-    case x_double:
-        {
-            std::vector<double> *v
-                = static_cast<std::vector<double> *>(data_);
-            sz = v->size();
-        }
-        break;
-    case x_stdstring:
-        {
-            std::vector<std::string> *v
-                = static_cast<std::vector<std::string> *>(data_);
-            sz = v->size();
-        }
-        break;
-    case x_stdtm:
-        {
-            std::vector<std::tm> *v
-                = static_cast<std::vector<std::tm> *>(data_);
-            sz = v->size();
-        }
-        break;
-
-    case x_xmltype:    break; // not supported
-    case x_longstring: break; // not supported
-    case x_statement:  break; // not supported
-    case x_rowid:      break; // not supported
-    case x_blob:       break; // not supported
-    }
-
-    return sz;
+    return get_vector_size(type_, data_);
 }
 
 void oracle_vector_into_type_backend::clean_up()

--- a/src/backends/oracle/vector-use-type.cpp
+++ b/src/backends/oracle/vector-use-type.cpp
@@ -154,11 +154,12 @@ void oracle_vector_use_type_backend::prepare_for_bind(
         }
         break;
 
-    case x_xmltype:    break; // not supported
-    case x_longstring: break; // not supported
-    case x_statement:  break; // not supported
-    case x_rowid:      break; // not supported
-    case x_blob:       break; // not supported
+    case x_xmltype:
+    case x_longstring:
+    case x_statement:
+    case x_rowid:
+    case x_blob:
+        throw soci_error("Unsupported type for vector use parameter");
     }
 }
 

--- a/src/backends/oracle/vector-use-type.cpp
+++ b/src/backends/oracle/vector-use-type.cpp
@@ -9,6 +9,7 @@
 #include "soci/oracle/soci-oracle.h"
 #include "error.h"
 #include "soci/soci-platform.h"
+#include "soci-vector-helpers.h"
 #include <cctype>
 #include <cstdio>
 #include <cstring>
@@ -335,72 +336,7 @@ std::size_t oracle_vector_use_type_backend::size()
 
 std::size_t oracle_vector_use_type_backend::full_size()
 {
-    std::size_t sz = 0; // dummy initialization to please the compiler
-    switch (type_)
-    {
-    // simple cases
-    case x_char:
-        {
-            std::vector<char> *vp = static_cast<std::vector<char> *>(data_);
-            sz = vp->size();
-        }
-        break;
-    case x_short:
-        {
-            std::vector<short> *vp = static_cast<std::vector<short> *>(data_);
-            sz = vp->size();
-        }
-        break;
-    case x_integer:
-        {
-            std::vector<int> *vp = static_cast<std::vector<int> *>(data_);
-            sz = vp->size();
-        }
-        break;
-    case x_long_long:
-        {
-            std::vector<long long> *vp
-                = static_cast<std::vector<long long> *>(data_);
-            sz = vp->size();
-        }
-        break;
-    case x_unsigned_long_long:
-        {
-            std::vector<unsigned long long> *vp
-                = static_cast<std::vector<unsigned long long> *>(data_);
-            sz = vp->size();
-        }
-        break;
-    case x_double:
-        {
-            std::vector<double> *vp
-                = static_cast<std::vector<double> *>(data_);
-            sz = vp->size();
-        }
-        break;
-    case x_stdstring:
-        {
-            std::vector<std::string> *vp
-                = static_cast<std::vector<std::string> *>(data_);
-            sz = vp->size();
-        }
-        break;
-    case x_stdtm:
-        {
-            std::vector<std::tm> *vp
-                = static_cast<std::vector<std::tm> *>(data_);
-            sz = vp->size();
-        }
-        break;
-
-    case x_xmltype:    break; // not supported
-    case x_longstring: break; // not supported
-    case x_statement:  break; // not supported
-    case x_rowid:      break; // not supported
-    case x_blob:       break; // not supported
-    }
-
-    return sz;
+    return get_vector_size(type_, data_);
 }
 
 void oracle_vector_use_type_backend::clean_up()

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -8890,7 +8890,13 @@ std::string toString( std::string const& value ) {
             switch( s[i] ) {
             case '\n': subs = "\\n"; break;
             case '\t': subs = "\\t"; break;
-            default: break;
+            default:
+                char const c = s[i];
+                if ( c < 0x20 || c == 0x7f ) {
+                    subs = "\\x";
+                    subs += '0' + c / 0x10;
+                    subs += "0123456789ABCDEF"[c % 0x10];
+                }
             }
             if( !subs.empty() ) {
                 s = s.substr( 0, i ) + subs + s.substr( i+1 );

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4791,14 +4791,6 @@ TEST_CASE_METHOD(common_tests, "CLOB vector", "[core][clob][vector]")
 {
     soci::session sql(backEndFactory_, connectString_);
 
-    if (sql.get_backend_name() != "firebird" &&
-        sql.get_backend_name() != "odbc" &&
-        sql.get_backend_name() != "postgresql")
-    {
-        WARN("Vector of long strings not supported by the database, skipping the test.");
-        return;
-    }
-
     auto_table_creator tableCreator(tc_.table_creator_clob(sql));
     if (!tableCreator.get())
     {
@@ -4892,14 +4884,6 @@ TEST_CASE_METHOD(common_tests, "XML vector", "[core][xml][vector]")
 {
     soci::session sql(backEndFactory_, connectString_);
 
-    if (sql.get_backend_name() != "firebird" &&
-        sql.get_backend_name() != "odbc" &&
-        sql.get_backend_name() != "postgresql")
-    {
-        WARN("Vector of XML types not supported by the database, skipping the test.");
-        return;
-    }
-
     auto_table_creator tableCreator(tc_.table_creator_xml(sql));
     if (!tableCreator.get())
     {
@@ -4945,14 +4929,6 @@ TEST_CASE_METHOD(common_tests, "XML vector", "[core][xml][vector]")
 TEST_CASE_METHOD(common_tests, "Into XML vector with several fetches", "[core][xml][into][vector][statement]")
 {
     soci::session sql(backEndFactory_, connectString_);
-
-    if (sql.get_backend_name() != "firebird" &&
-        sql.get_backend_name() != "odbc" &&
-        sql.get_backend_name() != "postgresql")
-    {
-        WARN("Vector of XML types not supported by the database, skipping the test.");
-        return;
-    }
 
     auto_table_creator tableCreator(tc_.table_creator_xml(sql));
     if (!tableCreator.get())

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4647,14 +4647,19 @@ TEST_CASE_METHOD(common_tests, "String length", "[core][string][length]")
     CHECK(vout[2].length() == 20);
 }
 
-// Helper function used in two tests below.
-static std::string make_long_xml_string()
+// Helper function used in some tests below. Generates an XML sample about
+// approximateSize bytes long.
+static std::string make_long_xml_string(int approximateSize = 5000)
 {
+    const int tagsSize = 6 + 7;
+    const int patternSize = 26;
+    const int patternsCount = approximateSize / patternSize + 1;
+
     std::string s;
-    s.reserve(6 + 200*26 + 7);
+    s.reserve(tagsSize + patternsCount * patternSize);
 
     s += "<file>";
-    for (int i = 0; i != 200; ++i)
+    for (int i = 0; i != patternsCount; ++i)
     {
         s += "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     }
@@ -4779,7 +4784,8 @@ TEST_CASE_METHOD(common_tests, "XML vector", "[core][xml][vector]")
     id[1] = 1; // Use the same ID to select both objects by ID.
     std::vector<xml_type> xml(2);
     xml[0].value = make_long_xml_string();
-    xml[1].value = make_long_xml_string();
+    // Check long strings handling.
+    xml[1].value = make_long_xml_string(10000);
 
     sql << "insert into soci_test (id, x) values (:1, "
         << tc_.to_xml(":2")

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4777,6 +4777,12 @@ TEST_CASE_METHOD(common_tests, "CLOB", "[core][clob]")
     sql << "select s from soci_test where id = 1", into(s2);
 
     CHECK(s2.value == s1.value);
+
+    // Check that trailing new lines are preserved.
+    s1.value = "multi\nline\nstring\n\n";
+    sql << "update soci_test set s = :s where id = 1", use(s1);
+    sql << "select s from soci_test where id = 1", into(s2);
+    CHECK(s2.value == s1.value);
 }
 
 TEST_CASE_METHOD(common_tests, "CLOB vector", "[core][clob][vector]")

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4742,12 +4742,14 @@ static std::string make_long_xml_string(int approximateSize = 5000)
 // string, only structurally equal as XML. In particular, extra whitespace
 // can be added and this does happen with Oracle, for example, which adds
 // an extra new line, so remove it if it's present.
-static void remove_trailing_nl(std::string& str)
+static std::string remove_trailing_nl(std::string str)
 {
     if (!str.empty() && *str.rbegin() == '\n')
     {
         str.resize(str.length() - 1);
     }
+
+    return str;
 }
 
 TEST_CASE_METHOD(common_tests, "CLOB", "[core][clob]")
@@ -4858,9 +4860,7 @@ TEST_CASE_METHOD(common_tests, "XML", "[core][xml]")
         << " from soci_test where id = :1",
         into(xml2), use(id);
 
-    remove_trailing_nl(xml2.value);
-
-    CHECK(xml.value == xml2.value);
+    CHECK(xml.value == remove_trailing_nl(xml2.value));
 
     sql << "update soci_test set x = null where id = :1", use(id);
 
@@ -4927,13 +4927,8 @@ TEST_CASE_METHOD(common_tests, "XML vector", "[core][xml][vector]")
         << " from soci_test where id = :1",
         into(xml2), use(id.at(0));
 
-    for (int i = 0; i < 2; ++i)
-    {
-        remove_trailing_nl(xml2.at(i).value);
-    }
-
-    CHECK(xml.at(0).value == xml2.at(0).value);
-    CHECK(xml.at(1).value == xml2.at(1).value);
+    CHECK(xml.at(0).value == remove_trailing_nl(xml2.at(0).value));
+    CHECK(xml.at(1).value == remove_trailing_nl(xml2.at(1).value));
 
     sql << "update soci_test set x = null where id = :1", use(id.at(0));
 

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4784,7 +4784,8 @@ TEST_CASE_METHOD(common_tests, "CLOB vector", "[core][clob][vector]")
     soci::session sql(backEndFactory_, connectString_);
 
     if (sql.get_backend_name() != "firebird" &&
-        sql.get_backend_name() != "odbc")
+        sql.get_backend_name() != "odbc" &&
+        sql.get_backend_name() != "postgresql")
     {
         WARN("Vector of long strings not supported by the database, skipping the test.");
         return;
@@ -4886,7 +4887,8 @@ TEST_CASE_METHOD(common_tests, "XML vector", "[core][xml][vector]")
     soci::session sql(backEndFactory_, connectString_);
 
     if (sql.get_backend_name() != "firebird" &&
-        sql.get_backend_name() != "odbc")
+        sql.get_backend_name() != "odbc" &&
+        sql.get_backend_name() != "postgresql")
     {
         WARN("Vector of XML types not supported by the database, skipping the test.");
         return;
@@ -4944,7 +4946,8 @@ TEST_CASE_METHOD(common_tests, "Into XML vector with several fetches", "[core][x
     soci::session sql(backEndFactory_, connectString_);
 
     if (sql.get_backend_name() != "firebird" &&
-        sql.get_backend_name() != "odbc")
+        sql.get_backend_name() != "odbc" &&
+        sql.get_backend_name() != "postgresql")
     {
         WARN("Vector of XML types not supported by the database, skipping the test.");
         return;

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4987,14 +4987,14 @@ TEST_CASE_METHOD(common_tests, "Into XML vector with several fetches", "[core][x
 
     st.execute(true);
     REQUIRE(result.size() == 3);
-    CHECK(result[0].value == values[0].value);
-    CHECK(result[1].value == values[1].value);
-    CHECK(result[2].value == values[2].value);
+    CHECK(remove_trailing_nl(result[0].value) == values[0].value);
+    CHECK(remove_trailing_nl(result[1].value) == values[1].value);
+    CHECK(remove_trailing_nl(result[2].value) == values[2].value);
 
     REQUIRE(st.fetch());
     REQUIRE(result.size() == 2);
-    CHECK(result[0].value == values[3].value);
-    CHECK(result[1].value == values[4].value);
+    CHECK(remove_trailing_nl(result[0].value) == values[3].value);
+    CHECK(remove_trailing_nl(result[1].value) == values[4].value);
 
     REQUIRE(!st.fetch());
 }

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -435,6 +435,10 @@ public:
     // *exactly* the same value.
     virtual bool has_fp_bug() const { return false; }
 
+    // Override this if the backend wrongly returns CR LF when reading a string
+    // with just LFs from the database to strip the unwanted CRs.
+    virtual std::string fix_crlf_if_necessary(std::string const& s) const { return s; }
+
     // Override this if the backend doesn't handle multiple active select
     // statements at the same time, i.e. a result set must be entirely consumed
     // before creating a new one (this is the case of MS SQL without MARS).
@@ -4784,7 +4788,7 @@ TEST_CASE_METHOD(common_tests, "CLOB", "[core][clob]")
     s1.value = "multi\nline\nstring\n\n";
     sql << "update soci_test set s = :s where id = 1", use(s1);
     sql << "select s from soci_test where id = 1", into(s2);
-    CHECK(s2.value == s1.value);
+    CHECK(tc_.fix_crlf_if_necessary(s2.value) == s1.value);
 }
 
 TEST_CASE_METHOD(common_tests, "CLOB vector", "[core][clob][vector]")


### PR DESCRIPTION
This previously didn't work for any backend and now works for Firebird, ODBC, Oracle and PostgreSQL, which is not everything but is still much better than nothing.