### PR TITLE
Fix oracle rowset statement ORA-01455 error

### DIFF
--- a/src/backends/oracle/statement.cpp
+++ b/src/backends/oracle/statement.cpp
@@ -287,7 +287,7 @@ void oracle_statement_backend::describe_column(int colNum, data_type &type,
                 type = dt_double;
             }
         }
-        else if (dbprec <= std::numeric_limits<int>::digits10)
+        else if (dbprec <= std::numeric_limits<int>::digits10 && dbprec != 0)
         {
             type = dt_integer;
         }


### PR DESCRIPTION
When we use sql 'select to_number(to_char(sysdate, 'YYYYMMDDHH24MISS'))'
with rowset that auto detect data_type will lead to 'ORA-01455:
converting column overflows integer datatype'