### PR TITLE
Fix working with default Oracle NUMBER using rowset API

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Backend-specific changes:
 
 - Oracle
  - Implement session::get_next_sequence_value().
+ - Fix using default NUMBER type with rowset API (#872).
  - Handle reading from CLOBs that can't be read all at once.
  - Fix another memory leak in CLOB handling code.
 

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -1068,6 +1068,22 @@ struct longlong_table_creator : table_creator_base
     }
 };
 
+// test using the result of to_number() which uses the default NUMBER type,
+// with precision == scale == 0, with rowset
+TEST_CASE("Oracle to_number with rowset", "[oracle][rowset][to_number]")
+{
+    soci::session sql(backEnd, connectString);
+
+    soci::rowset<soci::row>
+        rs = (sql.prepare << "select to_number('123456789012345') from dual");
+    double d = rs.begin()->get<double>(0);
+    ASSERT_EQUAL_EXACT(d, 123456789012345);
+
+    rs = (sql.prepare << "select to_number(:t) from dual", use(3.14));
+    d = rs.begin()->get<double>(0);
+    ASSERT_EQUAL_EXACT(d, 3.14);
+}
+
 // long long test
 TEST_CASE("Oracle long long", "[oracle][longlong]")
 {


### PR DESCRIPTION
Using rowset API with the result of to_number(), which returned a NUMBER
with both precision and scale of 0 (indicating that it's the default
NUMBER type, i.e. NUMBER(38, 10)), previously resulted in 'ORA-01455:
converting column overflows integer datatype' error because we
incorrectly handled such numbers as integers rather than doubles that
they really are.

Closes #872.

See #874, #875.

Co-Authored-By: Vadim Zeitlin <vz-soci@zeitlins.org>