### PR TITLE
Rename postgresql_result::free() to clear() to avoid conflicts

### DIFF
--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -63,7 +63,7 @@ public:
     // given one.
     void reset(PGresult* result = NULL)
     {
-        free();
+        clear();
         init(result);
     }
 
@@ -95,7 +95,7 @@ public:
     PGresult* get_result() const { return result_; }
 
     // Dtor frees the result.
-    ~postgresql_result() { free(); }
+    ~postgresql_result() { clear(); }
 
 private:
     void init(PGresult* result)
@@ -103,7 +103,7 @@ private:
         result_ = result;
     }
 
-    void free()
+    void clear()
     {
         // Notice that it is safe to call PQclear() with NULL pointer, it
         // simply does nothing in this case.


### PR DESCRIPTION
Some memory checking tools re-#define "free" as a macro, resulting in
compilation failures in this header, even when it's included from
outside SOCI.

Just rename the function to a name less likely to result in a conflict.