### PR TITLE
Change my_bool > bool

### DIFF
--- a/src/backends/mysql/session.cpp
+++ b/src/backends/mysql/session.cpp
@@ -355,7 +355,11 @@ mysql_session_backend::mysql_session_backend(
     }
     if (reconnect_p)
     {
-        my_bool reconnect = 1;
+        #if MYSQL_VERSION_ID < 8
+            my_bool reconnect = 1;
+        #else
+            bool reconnect = 1;
+        #endif
         if (0 != mysql_options(conn_, MYSQL_OPT_RECONNECT, &reconnect))
         {
             clean_up();


### PR DESCRIPTION
Hello,

Something changed upstream in the library you're importing for the `mysql` port.
The current release version of SOCI doesn't compile if you enable `mysql`, this PR fixes it.

Maybe we should check this on the CI and build and run all of the backends.

Cheers!