### PR TITLE
Fix compile issue wrt SIGSTKSZ no longer being a constant

### DIFF
--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -6489,7 +6489,7 @@ namespace Catch {
         static bool isSet;
         static struct sigaction oldSigActions [sizeof(signalDefs)/sizeof(SignalDefs)];
         static stack_t oldSigStack;
-        static char altStackMem[SIGSTKSZ];
+        static char altStackMem[8192];
 
         static void handleSignal( int sig ) {
             std::string name = "<unknown signal>";
@@ -6540,7 +6540,7 @@ namespace Catch {
     bool FatalConditionHandler::isSet = false;
     struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs)/sizeof(SignalDefs)] = {};
     stack_t FatalConditionHandler::oldSigStack = {};
-    char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
+    char FatalConditionHandler::altStackMem[8192] = {};
 
 } // namespace Catch
 


### PR DESCRIPTION
* On recent Fedora distributions, there is a compilation error in the test part similar to https://github.com/onqtam/doctest/issues/473
* I have applied a patch similar to https://github.com/onqtam/doctest/pull/474, which is admittedly very (too?) simple.
* A more elaborate patch could be derived from https://github.com/onqtam/doctest/commit/8ee91f37ba27397ef5eeedd2e542a4aaaa33ddc1 . If anyone would give it a try for a longer term patch, that would be welcome. In the meantime, this pull request allows to compile without error.

