### PR TITLE
Fix simultaneous using of long strings vectors and vectors of trivial type values for ODBC

### DIFF
--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -145,8 +145,8 @@ struct odbc_vector_into_type_backend : details::vector_into_type_backend,
     // SQLLEN is still defined 32bit (int) but spec requires 64bit (long)
     inline SQLLEN get_sqllen_from_vector_at(std::size_t idx) const;
 
-    // Redefine the single vector value at the given index to the first row.
-    // Used when vector values fetched by a single row.
+    // Rebind the single vector value at the given index to the first row.
+    // Used when vector values are fetched by single row.
     void redefine_row(std::size_t rowInd);
 
     std::vector<SQLLEN> indHolderVec_;

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -145,6 +145,10 @@ struct odbc_vector_into_type_backend : details::vector_into_type_backend,
     // SQLLEN is still defined 32bit (int) but spec requires 64bit (long)
     inline SQLLEN get_sqllen_from_vector_at(std::size_t idx) const;
 
+    // Redefine the single vector value at the given index to the first row.
+    // Used when vector values fetched by a single row.
+    void redefine_row(std::size_t rowInd);
+
     std::vector<SQLLEN> indHolderVec_;
     void *data_;
     char *buf_;              // generic buffer

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -255,6 +255,25 @@ odbc_statement_backend::fetch(int number)
 
     for (std::size_t i = 0; i < fetchesCount; i += rowsPerFetch)
     {
+        if (fetchVectorByRows_) {
+            switch (intoType_)
+            {
+            case bt_standard:
+                // Standard intos processed in standard define_by_pos().
+                break;
+            case bt_vector:
+                // Unfortunately we ought to redefine all vector intos which
+                // binded directly as first elements of vectors.
+                for (std::size_t j = 0; j != intos_.size(); ++j)
+                {
+                    static_cast<odbc_vector_into_type_backend*>(intos_[j])->
+                        redefine_row(i);
+                }
+                break;
+            }
+
+        }
+
         SQLRETURN rc = SQLFetch(hstmt_);
 
         if (SQL_NO_DATA == rc)

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -255,15 +255,16 @@ odbc_statement_backend::fetch(int number)
 
     for (std::size_t i = 0; i < fetchesCount; i += rowsPerFetch)
     {
-        if (fetchVectorByRows_) {
+        if (fetchVectorByRows_)
+        {
             switch (intoType_)
             {
             case bt_standard:
                 // Standard intos processed in standard define_by_pos().
                 break;
             case bt_vector:
-                // Unfortunately we ought to redefine all vector intos which
-                // binded directly as first elements of vectors.
+                // Unfortunately we need to redefine all vector intos which
+                // were bound to the first element of the vector initially.
                 for (std::size_t j = 0; j != intos_.size(); ++j)
                 {
                     static_cast<odbc_vector_into_type_backend*>(intos_[j])->

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -215,6 +215,70 @@ void odbc_vector_into_type_backend::define_by_pos(
     }
 }
 
+void odbc_vector_into_type_backend::redefine_row(std::size_t rowInd)
+{
+    void* elementPtr = NULL;
+    SQLLEN size = 0;
+    switch (type_)
+    {
+    // simple cases
+    case x_short:
+        elementPtr = &exchange_vector_type_cast<x_short>(data_)[rowInd];
+        size = sizeof(short);
+        break;
+    case x_integer:
+        elementPtr = &exchange_vector_type_cast<x_integer>(data_)[rowInd];
+        size = sizeof(SQLINTEGER);
+        break;
+    case x_long_long:
+        if (!use_string_for_bigint())
+        {
+            elementPtr = &exchange_vector_type_cast<x_long_long>(data_)[rowInd];
+            size = sizeof(long long);
+        }
+        break;
+    case x_unsigned_long_long:
+        if (!use_string_for_bigint())
+        {
+            elementPtr = &exchange_vector_type_cast<x_unsigned_long_long>(data_)[rowInd];
+            size = sizeof(unsigned long long);
+        }
+        break;
+    case x_double:
+        elementPtr = &exchange_vector_type_cast<x_double>(data_)[rowInd];
+        size = sizeof(double);
+        break;
+
+    // cases that require adjustments and buffer management
+
+    case x_char:
+    case x_stdstring:
+    case x_xmltype:
+    case x_longstring:
+    case x_stdtm:
+        // Do nothing.
+        break;
+
+    default:
+        throw soci_error("Into element used with non-supported type.");
+    }
+
+    if (elementPtr != NULL)
+    {
+        const SQLUSMALLINT pos = static_cast<SQLUSMALLINT>(position_ + 1);
+        SQLRETURN rc
+            = SQLBindCol(statement_.hstmt_, pos, odbcType_,
+                static_cast<SQLPOINTER>(elementPtr), size, &indHolderVec_[rowInd]);
+        if (is_odbc_error(rc))
+        {
+            std::ostringstream ss;
+            ss << "binding output vector item at index " << rowInd
+               << " of column #" << pos;
+            throw odbc_soci_error(SQL_HANDLE_STMT, statement_.hstmt_, ss.str());
+        }
+    }
+}
+
 void odbc_vector_into_type_backend::pre_fetch()
 {
     // nothing to do for the supported types


### PR DESCRIPTION
9b4c5484faa4a753b6bdee19673f41912c5b5835 makes the error (sorry) when fetching a vector of trivial type values by a single row. Because vectors of trivial type values binded directly as a pointer to the first element (long string and other types converted in `odbc_vector_into_type_backend::exchange_rows()`).