### PR TITLE
Bug fix and many simplifications to odbc_statement_backend

### DIFF
--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -148,7 +148,6 @@ struct odbc_vector_into_type_backend : details::vector_into_type_backend,
     void rebind_row(std::size_t rowInd);
 
     std::vector<SQLLEN> indHolderVec_;
-    std::vector<indicator> inds_;
     void *data_;
     char *buf_;              // generic buffer
     details::exchange_type type_;
@@ -555,8 +554,6 @@ inline void odbc_standard_type_backend_base::set_sqllen_from_value(SQLLEN &targe
 
 inline SQLLEN odbc_vector_into_type_backend::get_sqllen_from_vector_at(std::size_t idx) const
 {
-    if (statement_.fetchVectorByRows_)
-        idx = 0;
     if (requires_noncompliant_32bit_sqllen())
     {
         return reinterpret_cast<const int*>(&indHolderVec_[0])[idx];

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -133,7 +133,7 @@ struct odbc_vector_into_type_backend : details::vector_into_type_backend,
     // (as part of the define_by_pos)
     void prepare_indicators(std::size_t size);
 
-    void exchange_rows(bool gotData, std::size_t beginInd, std::size_t endInd);
+    void exchange_rows(std::size_t beginInd, std::size_t endInd);
 
     // IBM DB2 driver is not compliant to ODBC spec for indicators in 64bit
     // SQLLEN is still defined 32bit (int) but spec requires 64bit (long)

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -46,12 +46,6 @@ namespace details
     }
 }
 
-enum buffer_type
-{
-    bt_standard,
-    bt_vector
-};
-
 // Option allowing to specify the "driver completion" parameter of
 // SQLDriverConnect(). Its possible values are the same as the allowed values
 // for this parameter in the official ODBC, i.e. one of SQL_DRIVER_XXX (in
@@ -283,8 +277,8 @@ struct odbc_statement_backend : details::statement_backend
     std::string query_;
     std::vector<std::string> names_; // list of names for named binds
 
-    buffer_type intoType_;
-
+    // This vector, containing non-owning non-null pointers, can be empty if
+    // we're not using any vector "intos".
     std::vector<odbc_vector_into_type_backend*> intos_;
 };
 

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -16,7 +16,6 @@
 # define SOCI_ODBC_DECL SOCI_DECL_IMPORT
 #endif
 
-#include "soci/soci-platform.h"
 #include <vector>
 #include <soci/soci-backend.h>
 #include <sstream>

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -285,7 +285,7 @@ struct odbc_statement_backend : details::statement_backend
     buffer_type intoType_;
 
     std::vector<std::vector<indicator> > inds_;
-    std::vector<void*> intos_;
+    std::vector<odbc_vector_into_type_backend*> intos_;
 };
 
 struct odbc_rowid_backend : details::rowid_backend

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -129,10 +129,6 @@ struct odbc_vector_into_type_backend : details::vector_into_type_backend,
 
     void clean_up() SOCI_OVERRIDE;
 
-    // helper function for preparing indicators
-    // (as part of the define_by_pos)
-    void prepare_indicators(std::size_t size);
-
     // Normally data retrieved from the database is handled in post_fetch(),
     // however we may need to call SQLFetch() multiple times, so we call this
     // function instead after each call to it to retrieve the given range of

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -280,6 +280,10 @@ struct odbc_statement_backend : details::statement_backend
     // This vector, containing non-owning non-null pointers, can be empty if
     // we're not using any vector "intos".
     std::vector<odbc_vector_into_type_backend*> intos_;
+
+private:
+    // fetch() helper wrapping SQLFetch() call for the given range of rows.
+    exec_fetch_result do_fetch(int beginRow, int endRow);
 };
 
 struct odbc_rowid_backend : details::rowid_backend

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -150,6 +150,7 @@ struct odbc_vector_into_type_backend : details::vector_into_type_backend,
     void rebind_row(std::size_t rowInd);
 
     std::vector<SQLLEN> indHolderVec_;
+    std::vector<indicator> inds_;
     void *data_;
     char *buf_;              // generic buffer
     details::exchange_type type_;
@@ -284,7 +285,6 @@ struct odbc_statement_backend : details::statement_backend
 
     buffer_type intoType_;
 
-    std::vector<std::vector<indicator> > inds_;
     std::vector<odbc_vector_into_type_backend*> intos_;
 };
 

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -133,7 +133,11 @@ struct odbc_vector_into_type_backend : details::vector_into_type_backend,
     // (as part of the define_by_pos)
     void prepare_indicators(std::size_t size);
 
-    void exchange_rows(std::size_t beginInd, std::size_t endInd);
+    // Normally data retrieved from the database is handled in post_fetch(),
+    // however we may need to call SQLFetch() multiple times, so we call this
+    // function instead after each call to it to retrieve the given range of
+    // rows.
+    void do_post_fetch_rows(std::size_t beginRow, std::size_t endRow);
 
     // IBM DB2 driver is not compliant to ODBC spec for indicators in 64bit
     // SQLLEN is still defined 32bit (int) but spec requires 64bit (long)

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -275,6 +275,10 @@ odbc_statement_backend::fetch(int number)
         {
             // Unfortunately we need to redefine all vector intos which
             // were bound to the first element of the vector initially.
+            //
+            // Note that we need to do it even for row == 0 as this might not
+            // be the first call to fetch() and so the current bindings might
+            // not be the same as initial ones.
             for (std::size_t j = 0; j != intos_.size(); ++j)
             {
                 intos_[j]->rebind_row(row);

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -267,8 +267,7 @@ odbc_statement_backend::fetch(int number)
                 // were bound to the first element of the vector initially.
                 for (std::size_t j = 0; j != intos_.size(); ++j)
                 {
-                    static_cast<odbc_vector_into_type_backend*>(intos_[j])->
-                        rebind_row(i);
+                    intos_[j]->rebind_row(i);
                 }
                 break;
             }
@@ -298,8 +297,7 @@ odbc_statement_backend::fetch(int number)
             case bt_vector:
                 for (std::size_t j = 0; j != intos_.size(); ++j)
                 {
-                    static_cast<odbc_vector_into_type_backend*>(intos_[j])->
-                        exchange_rows(true, i, i + rowsPerFetch);
+                    intos_[j]->exchange_rows(true, i, i + rowsPerFetch);
                 }
                 break;
         }

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -228,7 +228,7 @@ odbc_statement_backend::fetch(int number)
     {
         for (std::size_t i = 0; i != intos_.size(); ++i)
         {
-            intos_[i]->inds_.resize(number);
+            intos_[i]->resize(number);
         }
 
         // Usually we try to fetch the entire vector at once, but if some into

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -231,7 +231,7 @@ odbc_statement_backend::do_fetch(int beginRow, int endRow)
 
     for (std::size_t j = 0; j != intos_.size(); ++j)
     {
-        intos_[j]->exchange_rows(true, beginRow, endRow);
+        intos_[j]->exchange_rows(beginRow, endRow);
     }
 
     return ef_success;

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -249,7 +249,7 @@ odbc_statement_backend::fetch(int number)
 
     SQLSetStmtAttr(hstmt_, SQL_ATTR_ROW_BIND_TYPE, SQL_BIND_BY_COLUMN, 0);
 
-    statement_backend::exec_fetch_result res;
+    statement_backend::exec_fetch_result res = ef_success; // just for MSVC
 
     // Usually we try to fetch the entire vector at once, but if some into
     // string columns are bigger than 8KB (ODBC_MAX_COL_SIZE) then we use

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -132,11 +132,8 @@ void odbc_statement_backend::prepare(std::string const & query,
         throw odbc_soci_error(SQL_HANDLE_STMT, hstmt_, ss.str());
     }
 
-    // prepare buffers for indicators
-    inds_.clear();
-
-    // reset types of into buffers
-    intoType_ = bt_standard;
+    // reset any old into buffers, they will be added later if they're used
+    // with this query
     intos_.clear();
 }
 
@@ -229,10 +226,9 @@ odbc_statement_backend::fetch(int number)
 
     if (intoType_ == bt_vector)
     {
-        // inds_ used only by vector intos.
-        for (std::size_t i = 0; i != inds_.size(); ++i)
+        for (std::size_t i = 0; i != intos_.size(); ++i)
         {
-            inds_[i].resize(number);
+            intos_[i]->inds_.resize(number);
         }
 
         // Usually we try to fetch the entire vector at once, but if some into

--- a/src/backends/odbc/statement.cpp
+++ b/src/backends/odbc/statement.cpp
@@ -231,7 +231,7 @@ odbc_statement_backend::do_fetch(int beginRow, int endRow)
 
     for (std::size_t j = 0; j != intos_.size(); ++j)
     {
-        intos_[j]->exchange_rows(beginRow, endRow);
+        intos_[j]->do_post_fetch_rows(beginRow, endRow);
     }
 
     return ef_success;

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -283,8 +283,8 @@ void odbc_vector_into_type_backend::pre_fetch()
     // nothing to do for the supported types
 }
 
-void odbc_vector_into_type_backend::exchange_rows(
-    std::size_t beginInd, std::size_t endInd)
+void odbc_vector_into_type_backend::do_post_fetch_rows(
+    std::size_t beginRow, std::size_t endRow)
 {
     // first, deal with data
 
@@ -296,7 +296,7 @@ void odbc_vector_into_type_backend::exchange_rows(
 
         std::vector<char> &v(*vp);
         char *pos = buf_;
-        for (std::size_t i = beginInd; i != endInd; ++i)
+        for (std::size_t i = beginRow; i != endRow; ++i)
         {
             v[i] = *pos;
             pos += colSize_;
@@ -305,7 +305,7 @@ void odbc_vector_into_type_backend::exchange_rows(
     if (type_ == x_stdstring || type_ == x_xmltype || type_ == x_longstring)
     {
         const char *pos = buf_;
-        for (std::size_t i = beginInd; i != endInd; ++i, pos += colSize_)
+        for (std::size_t i = beginRow; i != endRow; ++i, pos += colSize_)
         {
             SQLLEN const len = get_sqllen_from_vector_at(i);
 
@@ -349,7 +349,7 @@ void odbc_vector_into_type_backend::exchange_rows(
 
         std::vector<std::tm> &v(*vp);
         char *pos = buf_;
-        for (std::size_t i = beginInd; i != endInd; ++i)
+        for (std::size_t i = beginRow; i != endRow; ++i)
         {
             // See comment for the use of this macro in standard-into-type.cpp.
             GCC_WARNING_SUPPRESS(cast-align)
@@ -370,7 +370,7 @@ void odbc_vector_into_type_backend::exchange_rows(
             = static_cast<std::vector<long long> *>(data_);
         std::vector<long long> &v(*vp);
         char *pos = buf_;
-        for (std::size_t i = beginInd; i != endInd; ++i)
+        for (std::size_t i = beginRow; i != endRow; ++i)
         {
             if (!cstring_to_integer(v[i], pos))
             {
@@ -385,7 +385,7 @@ void odbc_vector_into_type_backend::exchange_rows(
             = static_cast<std::vector<unsigned long long> *>(data_);
         std::vector<unsigned long long> &v(*vp);
         char *pos = buf_;
-        for (std::size_t i = beginInd; i != endInd; ++i)
+        for (std::size_t i = beginRow; i != endRow; ++i)
         {
             if (!cstring_to_unsigned(v[i], pos))
             {
@@ -397,7 +397,7 @@ void odbc_vector_into_type_backend::exchange_rows(
 
     // then - deal with indicators
 
-    for (std::size_t i = beginInd; i != endInd; ++i)
+    for (std::size_t i = beginRow; i != endRow; ++i)
     {
         SQLLEN const val = get_sqllen_from_vector_at(i);
         if (val == SQL_NULL_DATA)

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -202,15 +202,9 @@ void odbc_vector_into_type_backend::define_by_pos(
         throw soci_error("Into element used with non-supported type.");
     }
 
-    SQLRETURN rc
-        = SQLBindCol(statement_.hstmt_, static_cast<SQLUSMALLINT>(position++),
-                odbcType_, static_cast<SQLPOINTER>(data), size, &indHolderVec_[0]);
-    if (is_odbc_error(rc))
-    {
-        std::ostringstream ss;
-        ss << "binding output vector column #" << position;
-        throw odbc_soci_error(SQL_HANDLE_STMT, statement_.hstmt_, ss.str());
-    }
+    position++;
+
+    rebind_row(0);
 }
 
 void odbc_vector_into_type_backend::rebind_row(std::size_t rowInd)

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -43,7 +43,6 @@ void odbc_vector_into_type_backend::define_by_pos(
 
     statement_.intoType_ = bt_vector;
     statement_.intos_.push_back(this);
-    statement_.inds_.push_back(std::vector<indicator>());
 
     SQLLEN size = 0;       // also dummy
 
@@ -405,11 +404,11 @@ void odbc_vector_into_type_backend::exchange_rows(bool gotData,
             SQLLEN const val = get_sqllen_from_vector_at(i);
             if (val == SQL_NULL_DATA)
             {
-                statement_.inds_[position_][i] = i_null;
+                inds_[i] = i_null;
             }
             else
             {
-                statement_.inds_[position_][i] = i_ok;
+                inds_[i] = i_ok;
             }
         }
     }
@@ -429,13 +428,13 @@ void odbc_vector_into_type_backend::post_fetch(bool gotData, indicator* ind)
 
         for (std::size_t i = 0; i < rows; ++i)
         {
-            if (statement_.inds_[position_][i] == i_null && (ind == NULL))
+            if (inds_[i] == i_null && (ind == NULL))
             {
                 throw soci_error("Null value fetched and no indicator defined.");
             }
             else if (ind != NULL)
             {
-                ind[i] = statement_.inds_[position_][i];
+                ind[i] = inds_[i];
             }
         }
     }

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -42,7 +42,7 @@ void odbc_vector_into_type_backend::define_by_pos(
     position_ = position - 1;
 
     statement_.intoType_ = bt_vector;
-    statement_.intos_.push_back(static_cast<void*>(this));
+    statement_.intos_.push_back(this);
     statement_.inds_.push_back(std::vector<indicator>());
 
     SQLLEN size = 0;       // also dummy
@@ -460,7 +460,7 @@ void odbc_vector_into_type_backend::clean_up()
         delete [] buf_;
         buf_ = NULL;
     }
-    std::vector<void*>::iterator it
+    std::vector<odbc_vector_into_type_backend*>::iterator it
         = std::find(statement_.intos_.begin(), statement_.intos_.end(), this);
     if (it != statement_.intos_.end())
         statement_.intos_.erase(it);

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -42,7 +42,6 @@ void odbc_vector_into_type_backend::define_by_pos(
     type_ = type; // for future reference
     position_ = position - 1;
 
-    statement_.intoType_ = bt_vector;
     statement_.intos_.push_back(this);
 
     SQLLEN size = 0;       // also dummy

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -32,6 +32,7 @@ void odbc_vector_into_type_backend::prepare_indicators(std::size_t size)
     }
 
     indHolderVec_.resize(size);
+    inds_.resize(size);
 }
 
 void odbc_vector_into_type_backend::define_by_pos(
@@ -444,6 +445,7 @@ void odbc_vector_into_type_backend::resize(std::size_t sz)
 {
     // stays 64bit but gets but casted, see: get_sqllen_from_vector_at(...)
     indHolderVec_.resize(sz);
+    inds_.resize(sz);
     resize_vector(type_, data_, sz);
 }
 

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -43,30 +43,24 @@ void odbc_vector_into_type_backend::define_by_pos(
 
     statement_.intos_.push_back(this);
 
-    SQLLEN size = 0;       // also dummy
-
     switch (type)
     {
     // simple cases
     case x_short:
         {
             odbcType_ = SQL_C_SSHORT;
-            size = sizeof(short);
             std::vector<short> *vp = static_cast<std::vector<short> *>(data);
             std::vector<short> &v(*vp);
             prepare_indicators(v.size());
-            data = &v[0];
         }
         break;
     case x_integer:
         {
             odbcType_ = SQL_C_SLONG;
-            size = sizeof(SQLINTEGER);
             SOCI_STATIC_ASSERT(sizeof(SQLINTEGER) == sizeof(int));
             std::vector<int> *vp = static_cast<std::vector<int> *>(data);
             std::vector<int> &v(*vp);
             prepare_indicators(v.size());
-            data = &v[0];
         }
         break;
     case x_long_long:
@@ -78,17 +72,13 @@ void odbc_vector_into_type_backend::define_by_pos(
             if (use_string_for_bigint())
             {
                 odbcType_ = SQL_C_CHAR;
-                size = max_bigint_length;
-                std::size_t bufSize = size * v.size();
-                colSize_ = size;
+                colSize_ = max_bigint_length;
+                std::size_t bufSize = colSize_ * v.size();
                 buf_ = new char[bufSize];
-                data = buf_;
             }
             else // Normal case, use ODBC support.
             {
                 odbcType_ = SQL_C_SBIGINT;
-                size = sizeof(long long);
-                data = &v[0];
             }
         }
         break;
@@ -101,28 +91,22 @@ void odbc_vector_into_type_backend::define_by_pos(
             if (use_string_for_bigint())
             {
                 odbcType_ = SQL_C_CHAR;
-                size = max_bigint_length;
-                std::size_t bufSize = size * v.size();
-                colSize_ = size;
+                colSize_ = max_bigint_length;
+                std::size_t bufSize = colSize_ * v.size();
                 buf_ = new char[bufSize];
-                data = buf_;
             }
             else // Normal case, use ODBC support.
             {
                 odbcType_ = SQL_C_UBIGINT;
-                size = sizeof(unsigned long long);
-                data = &v[0];
             }
         }
         break;
     case x_double:
         {
             odbcType_ = SQL_C_DOUBLE;
-            size = sizeof(double);
             std::vector<double> *vp = static_cast<std::vector<double> *>(data);
             std::vector<double> &v(*vp);
             prepare_indicators(v.size());
-            data = &v[0];
         }
         break;
 
@@ -137,13 +121,10 @@ void odbc_vector_into_type_backend::define_by_pos(
 
             prepare_indicators(v->size());
 
-            size = sizeof(char) * 2;
-            std::size_t bufSize = size * v->size();
-
-            colSize_ = size;
+            colSize_ = sizeof(char) * 2;
+            std::size_t bufSize = colSize_ * v->size();
 
             buf_ = new char[bufSize];
-            data = buf_;
         }
         break;
     case x_stdstring:
@@ -175,9 +156,6 @@ void odbc_vector_into_type_backend::define_by_pos(
             buf_ = new char[bufSize];
 
             prepare_indicators(vectorSize);
-
-            size = static_cast<SQLINTEGER>(colSize_);
-            data = buf_;
         }
         break;
     case x_stdtm:
@@ -188,13 +166,11 @@ void odbc_vector_into_type_backend::define_by_pos(
 
             prepare_indicators(v->size());
 
-            size = sizeof(TIMESTAMP_STRUCT);
-            colSize_ = size;
+            colSize_ = sizeof(TIMESTAMP_STRUCT);
 
-            std::size_t bufSize = size * v->size();
+            std::size_t bufSize = colSize_ * v->size();
 
             buf_ = new char[bufSize];
-            data = buf_;
         }
         break;
 

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4880,14 +4880,15 @@ static std::string make_long_xml_string(int approximateSize = 5000)
     std::string s;
     s.reserve(tagsSize + patternsCount * patternSize);
 
-    s += "<file>";
+    std::ostringstream ss;
+    ss << "<test size=\"" << approximateSize << "\">";
     for (int i = 0; i != patternsCount; ++i)
     {
-        s += "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+       ss << "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     }
-    s += "</file>";
+    ss << "</test>";
 
-    return s;
+    return ss.str();
 }
 
 // The helper function to remove trailing \n from a given string.

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -5152,6 +5152,10 @@ TEST_CASE_METHOD(common_tests, "Into XML vector with several fetches", "[core][x
         stringSize = 10000;
     }
 
+    // Skip the rest when not executing the current section.
+    if (!stringSize)
+        return;
+
     int const count = 5;
     std::vector<xml_type> values(count);
     for (int i = 0; i != count; ++i)

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -5133,15 +5133,6 @@ TEST_CASE_METHOD(common_tests, "XML and int vectors", "[core][xml][vector]")
 
 TEST_CASE_METHOD(common_tests, "Into XML vector with several fetches", "[core][xml][into][vector][statement]")
 {
-    soci::session sql(backEndFactory_, connectString_);
-
-    auto_table_creator tableCreator(tc_.table_creator_xml(sql));
-    if (!tableCreator.get())
-    {
-        WARN("XML type not supported by the database, skipping the test.");
-        return;
-    }
-
     int stringSize = 0;
     SECTION("short string")
     {
@@ -5155,6 +5146,15 @@ TEST_CASE_METHOD(common_tests, "Into XML vector with several fetches", "[core][x
     // Skip the rest when not executing the current section.
     if (!stringSize)
         return;
+
+    soci::session sql(backEndFactory_, connectString_);
+
+    auto_table_creator tableCreator(tc_.table_creator_xml(sql));
+    if (!tableCreator.get())
+    {
+        WARN("XML type not supported by the database, skipping the test.");
+        return;
+    }
 
     int const count = 5;
     std::vector<xml_type> values(count);

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -5115,7 +5115,7 @@ TEST_CASE_METHOD(common_tests, "XML and int vectors", "[core][xml][vector]")
 
     sql << "select id, "
         << tc_.from_xml("x")
-        << " from soci_test where id in (0, 1, 2)",
+        << " from soci_test order by id",
         into(id2), into(xml2, ind2);
 
     CHECK(id.at(0) == id2.at(0));


### PR DESCRIPTION
For some reason this vector, added recently in 9b4c5484 (Fetch vectors
by a single row for huge strings in ODBC backend, 2021-03-24), used
"void*" for its elements instead of "odbc_vector_into_type_backend*",
requiring casts in several places.

Do use the actual type now, as there doesn't seem to be any problems
with doing this and it simplifies the code and makes it safer.