### PR TITLE
[MySQL] my_bool has been replaced by bool

### DIFF
--- a/src/backends/mysql/session.cpp
+++ b/src/backends/mysql/session.cpp
@@ -356,7 +356,7 @@ mysql_session_backend::mysql_session_backend(
     if (reconnect_p)
     {
         #if MYSQL_VERSION_ID < 8
-            my_bool reconnect = 1;
+            bool reconnect = 1;
         #else
             bool reconnect = 1;
         #endif


### PR DESCRIPTION
`my_bool` has been replaced by `bool` in newer versions of MySQL. For instance, https://github.com/r-dbi/RMariaDB/pull/107
