### PR TITLE
Fixed MySQL backend not categorizing correctly connection errors to 'soci_error'

### DIFF
--- a/include/soci/mysql/soci-mysql.h
+++ b/include/soci/mysql/soci-mysql.h
@@ -32,7 +32,15 @@ class SOCI_MYSQL_DECL mysql_soci_error : public soci_error
 {
 public:
     mysql_soci_error(std::string const & msg, int errNum)
-        : soci_error(msg), err_num_(errNum) {}
+        : soci_error(msg), err_num_(errNum) {
+            if(errNum == CR_CONNECTION_ERROR ||
+               errNum == CR_CONN_HOST_ERROR ||
+               errNum == CR_SERVER_GONE_ERROR ||
+               errNum == CR_SERVER_LOST ||
+               errNum == 1927) { // Lost connection to backend server
+                cat_ = connection_error;
+            }
+        }
 
     unsigned int err_num_;
 };

--- a/include/soci/mysql/soci-mysql.h
+++ b/include/soci/mysql/soci-mysql.h
@@ -22,6 +22,7 @@
 #include <winsock.h> // SOCKET
 #endif // _WIN32
 #include <mysql.h> // MySQL Client
+#include <errmsg.h> // MySQL Error codes
 #include <vector>
 
 
@@ -32,7 +33,7 @@ class SOCI_MYSQL_DECL mysql_soci_error : public soci_error
 {
 public:
     mysql_soci_error(std::string const & msg, int errNum)
-        : soci_error(msg), err_num_(errNum) {
+        : soci_error(msg), err_num_(errNum), cat_(unknown) {
             if(errNum == CR_CONNECTION_ERROR ||
                errNum == CR_CONN_HOST_ERROR ||
                errNum == CR_SERVER_GONE_ERROR ||
@@ -42,7 +43,10 @@ public:
             }
         }
 
+    error_category get_error_category() const SOCI_OVERRIDE { return cat_; }
+
     unsigned int err_num_;
+    error_category cat_;
 };
 
 struct mysql_statement_backend;


### PR DESCRIPTION
During a connection error the MySQL backend was not checking the error category
and not propagating it as well. It could lead the user to improperly handle
such situations as they would be unaware of this bug.