### PR TITLE
Fix pkg name for works fine of new version cmake

### DIFF
--- a/cmake/modules/FindOracle.cmake
+++ b/cmake/modules/FindOracle.cmake
@@ -81,7 +81,7 @@ set(ORACLE_LIBRARIES ${ORACLE_LIBRARY})
 # Handle the QUIETLY and REQUIRED arguments and set ORACLE_FOUND to TRUE
 # if all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(ORACLE DEFAULT_MSG ORACLE_LIBRARY ORACLE_INCLUDE_DIR)
+find_package_handle_standard_args(Oracle DEFAULT_MSG ORACLE_LIBRARY ORACLE_INCLUDE_DIR)
 
 if(NOT ORACLE_FOUND)
 	message(STATUS "None of the supported Oracle versions (${ORACLE_VERSIONS}) could be found, consider updating ORACLE_VERSIONS if the version you use is not among them.")

--- a/cmake/modules/FindSQLite3.cmake
+++ b/cmake/modules/FindSQLite3.cmake
@@ -54,7 +54,7 @@ set(SQLITE3_LIBRARIES
 # Handle the QUIETLY and REQUIRED arguments and set SQLITE3_FOUND to TRUE
 # if all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(SQLITE3
+find_package_handle_standard_args(SQLite3
   DEFAULT_MSG
   SQLITE3_LIBRARIES
   SQLITE3_INCLUDE_DIR)


### PR DESCRIPTION
The new version of cmake probably broke the compatibility of find_package_handle_standard_args.

It went wrong on my machine.
```
CMake Warning (dev) at /usr/share/cmake-3.21/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (SQLITE3)
  does not match the name of the calling package (SQLite3).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/modules/FindSQLite3.cmake:57 (find_package_handle_standard_args)
  src/backends/CMakeLists.txt:17 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
