### PR TITLE
proper implementation of the get_table_names for MySQL

### DIFF
--- a/include/soci/mysql/soci-mysql.h
+++ b/include/soci/mysql/soci-mysql.h
@@ -260,6 +260,11 @@ struct mysql_session_backend : details::session_backend
     mysql_rowid_backend * make_rowid_backend() SOCI_OVERRIDE;
     mysql_blob_backend * make_blob_backend() SOCI_OVERRIDE;
 
+    std::string get_table_names_query() const SOCI_OVERRIDE
+    {
+        return "SELECT table_name AS 'TABLE_NAME' FROM information_schema.tables WHERE table_schema = DATABASE()";
+    }
+
     MYSQL *conn_;
 };
 


### PR DESCRIPTION
Currently, the default implementation of the get_table_names method returns nothing as it seems to use a Postgres-specific query. I have added a MySQL-specific query that returns a list of table names for the selected database.