### PR TITLE
Fix CMake warnings

### DIFF
--- a/cmake/dependencies/Oracle.cmake
+++ b/cmake/dependencies/Oracle.cmake
@@ -1,4 +1,4 @@
-set(ORACLE_FIND_QUIETLY TRUE)
+set(Oracle_FIND_QUIETLY TRUE)
 
 find_package(Oracle)
 

--- a/cmake/dependencies/SQLite3.cmake
+++ b/cmake/dependencies/SQLite3.cmake
@@ -1,4 +1,4 @@
-set(SQLITE3_FIND_QUIETLY TRUE)
+set(SQLite3_FIND_QUIETLY TRUE)
 
 find_package(SQLite3)
 

--- a/cmake/modules/FindOracle.cmake
+++ b/cmake/modules/FindOracle.cmake
@@ -81,7 +81,7 @@ set(ORACLE_LIBRARIES ${ORACLE_LIBRARY})
 # Handle the QUIETLY and REQUIRED arguments and set ORACLE_FOUND to TRUE
 # if all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(ORACLE DEFAULT_MSG ORACLE_LIBRARY ORACLE_INCLUDE_DIR)
+find_package_handle_standard_args(Oracle DEFAULT_MSG ORACLE_LIBRARY ORACLE_INCLUDE_DIR)
 
 if(NOT ORACLE_FOUND)
 	message(STATUS "None of the supported Oracle versions (${ORACLE_VERSIONS}) could be found, consider updating ORACLE_VERSIONS if the version you use is not among them.")

--- a/cmake/modules/FindSQLite3.cmake
+++ b/cmake/modules/FindSQLite3.cmake
@@ -54,7 +54,7 @@ set(SQLITE3_LIBRARIES
 # Handle the QUIETLY and REQUIRED arguments and set SQLITE3_FOUND to TRUE
 # if all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(SQLITE3
+find_package_handle_standard_args(SQLite3
   DEFAULT_MSG
   SQLITE3_LIBRARIES
   SQLITE3_INCLUDE_DIR)


### PR DESCRIPTION
The find_package() calls of Oracle and SQLite3 emitted warnings because
their respective _FOUND variables were only set in their uppercase
variants. Letting find_package_handle_standard_args() handle the mixed
case variable and setting the uppercase variable manually gets rid of
those warnings.

Fixes #932 