### PR TITLE
Fix possible segfault and missing FAIL(...) call in unit test "Insert error"

### DIFF
--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4660,6 +4660,8 @@ TEST_CASE_METHOD(common_tests, "Insert error", "[core][insert][exception]")
                 age = *a;
                 st.execute(true);
             }
+
+            FAIL("exception expected on unique constraint violation with prepared statement not thrown");
         }
         catch (soci_error const &e)
         {

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4654,7 +4654,7 @@ TEST_CASE_METHOD(common_tests, "Insert error", "[core][insert][exception]")
         try
         {
             int const *a = ages;
-            for (char const* const* n = names; n; ++n, ++a)
+            for (char const* const* n = names; *n; ++n, ++a)
             {
                 name = *n;
                 age = *a;


### PR DESCRIPTION
The unit test "Insert error" contains an incorrect break condition in the for loop. Checking for the validity of the pointer address always results in a truthy value, possibly walking the whole `names` array. When trying to assign the referenced NULL value to a std::string, this could result in a segfault.

Also, a call to FAIL(...) was missing in case the expected exception did not occur in the test.