### PR TITLE
Small fix to mute cmake warning deprecation 2.8 notice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 ###############################################################################
 # General settings
 ###############################################################################
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8...3.20 FATAL_ERROR)
 
 project(SOCI)
 


### PR DESCRIPTION
I noticed the compatibility to old versions is important to soci project.

But newer version of cmake >= 3.0. Show annoying message about 2.8 deprecation notice. With this patch is possible mute the warning message. With no effects in older cmake version like 2.8. The olders cmake version <= 3.0 ignore the ...3.20

I take the solution from:

https://discourse.cmake.org/t/how-to-fix-cmake-minimum-required-deprecation-warning/2487

Thanks in advance!!!!
