### PR TITLE
session and transaction objects are linked. Is possible known from session object the transaction associated and is it active. And from transaction object the session owner. 

### DIFF
--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -69,8 +69,8 @@ public:
     void allow_multiple_transaction( bool allow_multiple_transaction );
     bool allow_multiple_transaction() const;
 
-    transaction * current_transaction();
-    bool current_transaction_is_active();
+    transaction * current_transaction() const;
+    bool current_transaction_is_active() const;
 
     void begin();
     void commit();

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -38,14 +38,13 @@ class blob_backend;
 
 class connection_pool;
 class failover_callback;
+class transaction;
 
 class SOCI_DECL session
 {
 private:
 
     void set_query_transformation_(cxx_details::auto_ptr<details::query_transformation_function>& qtf);
-
-
 
 public:
     session();
@@ -66,6 +65,12 @@ public:
 
     // check if we have a working connection to the database
     bool is_connected() const SOCI_NOEXCEPT;
+
+    void allow_multiple_transaction( bool allow_multiple_transaction );
+    bool allow_multiple_transaction() const;
+
+    transaction * current_transaction();
+    bool current_transaction_is_active();
 
     void begin();
     void commit();
@@ -209,6 +214,11 @@ private:
     bool isFromPool_;
     std::size_t poolPosition_;
     connection_pool * pool_;
+
+    transaction * transaction_;
+    bool allow_multiple_transaction_;
+
+    friend class transaction;
 };
 
 } // namespace soci

--- a/include/soci/transaction.h
+++ b/include/soci/transaction.h
@@ -24,10 +24,10 @@ public:
     void commit();
     void rollback();
 
-    inline session* current_session();
+    inline session* current_session() const;
 
-    bool is_active();
-    bool by_session();
+    bool is_active() const;
+    bool by_session() const;
 
 private:
     //Private constructor use from session object in case not assigned transaction.

--- a/include/soci/transaction.h
+++ b/include/soci/transaction.h
@@ -24,9 +24,21 @@ public:
     void commit();
     void rollback();
 
+    inline session* current_session();
+
+    bool is_active();
+    bool by_session();
+
 private:
+    //Private constructor use from session object in case not assigned transaction.
+    //Used in src/core/session.cpp:343
+    transaction(session& sql, bool by_session);
+
     bool handled_;
     session& sql_;
+    bool by_session_;
+
+    friend class session;
 
     SOCI_NOT_COPYABLE(transaction)
 };

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -11,6 +11,7 @@
 #include "soci/connection-pool.h"
 #include "soci/soci-backend.h"
 #include "soci/query_transformation.h"
+#include "soci/transaction.h"
 
 using namespace soci;
 using namespace soci::details;
@@ -76,7 +77,8 @@ session::session()
     : once(this), prepare(this), query_transformation_(NULL),
       logger_(new standard_logger_impl),
       uppercaseColumnNames_(false), backEnd_(NULL),
-      isFromPool_(false), pool_(NULL)
+      isFromPool_(false), pool_(NULL),
+      transaction_(NULL), allow_multiple_transaction_(true)
 {
 }
 
@@ -85,7 +87,8 @@ session::session(connection_parameters const & parameters)
       logger_(new standard_logger_impl),
       lastConnectParameters_(parameters),
       uppercaseColumnNames_(false), backEnd_(NULL),
-      isFromPool_(false), pool_(NULL)
+      isFromPool_(false), pool_(NULL),
+      transaction_(NULL), allow_multiple_transaction_(true)
 {
     open(lastConnectParameters_);
 }
@@ -96,7 +99,8 @@ session::session(backend_factory const & factory,
     logger_(new standard_logger_impl),
       lastConnectParameters_(factory, connectString),
       uppercaseColumnNames_(false), backEnd_(NULL),
-      isFromPool_(false), pool_(NULL)
+      isFromPool_(false), pool_(NULL),
+      transaction_(NULL), allow_multiple_transaction_(true)
 {
     open(lastConnectParameters_);
 }
@@ -107,7 +111,8 @@ session::session(std::string const & backendName,
       logger_(new standard_logger_impl),
       lastConnectParameters_(backendName, connectString),
       uppercaseColumnNames_(false), backEnd_(NULL),
-      isFromPool_(false), pool_(NULL)
+      isFromPool_(false), pool_(NULL),
+      transaction_(NULL), allow_multiple_transaction_(true)
 {
     open(lastConnectParameters_);
 }
@@ -117,7 +122,8 @@ session::session(std::string const & connectString)
       logger_(new standard_logger_impl),
       lastConnectParameters_(connectString),
       uppercaseColumnNames_(false), backEnd_(NULL),
-      isFromPool_(false), pool_(NULL)
+      isFromPool_(false), pool_(NULL),
+      transaction_(NULL), allow_multiple_transaction_(true)
 {
     open(lastConnectParameters_);
 }
@@ -125,7 +131,8 @@ session::session(std::string const & connectString)
 session::session(connection_pool & pool)
     : query_transformation_(NULL),
       logger_(new standard_logger_impl),
-      isFromPool_(true), pool_(&pool)
+      isFromPool_(true), pool_(&pool),
+      transaction_(NULL), allow_multiple_transaction_(true)
 {
     poolPosition_ = pool.lease();
     session & pooledSession = pool.at(poolPosition_);
@@ -137,6 +144,30 @@ session::session(connection_pool & pool)
 
 session::~session()
 {
+    transaction * transaction_local = this->transaction_; //Save the pointer
+
+    this->transaction_ = NULL; //Prevent callback in method transaction::destructor() -> session::rollback() from this object
+
+    if ( transaction_local != NULL )
+    {
+        if ( transaction_local->by_session() )  //Created by this session object?
+        {
+            transaction_local->handled_ = true; //Disable the transaction object. Prevent any operation in transaction object.
+
+            delete transaction_local;           //Yes is created. Delete transaction object. No rollback in transaction::destructor
+
+            backEnd_->rollback();
+        }
+        else if ( transaction_local->is_active() ) //Not created by session object. Still transaction active?
+        {
+            transaction_local->rollback();         //Yes is active. Only force rollback and disable the transaction object handled_ = true
+
+            transaction_local->handled_ = true;    //Stay absolute sure of disable the transaction object. We closed the session no way this transaction are valid anymore
+        }
+
+        transaction_local = NULL;                  //Clear reference to transaction object
+    }
+
     if (isFromPool_)
     {
         pool_->give_back(poolPosition_);
@@ -193,6 +224,30 @@ void session::open(std::string const & connectString)
 
 void session::close()
 {
+    transaction * transaction_local = this->transaction_; //Save the pointer
+
+    this->transaction_ = NULL; //Prevent callback in method transaction::destructor() -> session::rollback() from this object
+
+    if ( transaction_local != NULL )
+    {
+        if ( transaction_local->by_session() )  //Created by this session object?
+        {
+            transaction_local->handled_ = true; //Disable the transaction object. Prevent any operation in transaction object.
+
+            delete transaction_local;           //Yes is created. Delete transaction object. No rollback in destructor
+
+            backEnd_->rollback();               //Manual rollback
+        }
+        else if ( transaction_local->is_active() ) //Not created by session object. Still transaction active?
+        {
+            transaction_local->rollback();      //Yes is active. Only force rollback and disable the transaction object handled_ = true
+
+            transaction_local->handled_ = true;    //Stay absolute sure of disable the transaction object. We closed the session no way this transaction are valid anymore
+        }
+
+        transaction_local = NULL;            //Clear reference to transaction object
+    }
+
     if (isFromPool_)
     {
         pool_->at(poolPosition_).close();
@@ -251,9 +306,67 @@ bool session::is_connected() const SOCI_NOEXCEPT
     }
 }
 
+void session::allow_multiple_transaction( bool allow_multiple_transaction )
+{
+    this->allow_multiple_transaction_ = allow_multiple_transaction;
+}
+
+bool session::allow_multiple_transaction() const
+{
+    return this->allow_multiple_transaction_;
+}
+
+transaction * session::current_transaction()
+{
+    return this->transaction_;
+}
+
+bool session::current_transaction_is_active()
+{
+    return this->transaction_ != NULL ? transaction_->is_active(): false;
+}
+
 void session::begin()
 {
     ensureConnected(backEnd_);
+
+    transaction * transaction_local = this->transaction_; //Save the pointer
+
+    this->transaction_ = NULL; //Prevent callback in method transaction::destructor() -> session::rollback() from this object
+
+    if ( transaction_local )
+    {
+
+        if ( this->allow_multiple_transaction_ == false )
+        {
+            if ( transaction_local->by_session() )     //Created by this session object?
+            {
+                delete transaction_local;              //Yes is created. Delete transaction object. Force rollback in destructor. Here callback to session::rollback()
+            }
+            else if ( transaction_local->is_active() ) //Not created by session object. Still transaction active?
+            {
+                this->transaction_->rollback();        //Yes is active. Only force rollback and disable the transaction object put handled_ = true.
+            }
+        }
+        else if ( transaction_local->by_session() )  //Created by this session object?
+        {
+            delete transaction_local;                //Yes is created. Delete transaction object. Force rollback in destructor. Here callback to session::rollback()
+        }
+        else
+        {
+            this->transaction_ = transaction_local;  //Recover the transaction back
+        }
+
+        transaction_local = NULL;                 //Clear reference to transaction object
+    }
+
+    if ( this->transaction_ == NULL ) //No transaction object associated yet?
+    {
+        //Create transaction object because not associated yet
+        //Mark the by_session to true, to indicate is create inside of session object.
+        //by_session help to know when is need delete the pointer and prevent memory leak
+        this->transaction_ = new transaction( *this, true ); //No auto start transaction private constructor. Because we start the transaction in the next line
+    }
 
     backEnd_->begin();
 }
@@ -263,6 +376,24 @@ void session::commit()
     ensureConnected(backEnd_);
 
     backEnd_->commit();
+
+    if ( this->transaction_ != NULL )
+    {
+       bool old_handled_state = this->transaction_->handled_;
+
+       this->transaction_->handled_ = true;    //Disable the transaction object. Prevent any operation in transaction object.
+
+       if ( this->transaction_->by_session() ) //Created by this session object?
+       {
+           delete this->transaction_;          //Yes is created. Delete transaction object. No rollback in destructor
+       }
+       else if ( this->allow_multiple_transaction_ )
+       {
+           this->transaction_->handled_ = old_handled_state;    //Enable again the transaction object. To allow normal operation in transaction object.
+       }
+
+       this->transaction_ = NULL;           //Clear reference to transaction object
+    }
 }
 
 void session::rollback()
@@ -270,6 +401,24 @@ void session::rollback()
     ensureConnected(backEnd_);
 
     backEnd_->rollback();
+
+    if ( this->transaction_ )
+    {
+       bool old_handled_state = this->transaction_->handled_;
+
+       this->transaction_->handled_ = true;    //Disable the transaction object. Prevent any operation in transaction object.
+
+       if ( this->transaction_->by_session() ) //Created by this session object?
+       {
+           delete this->transaction_;          //Yes is created. Delete transaction object. No rollback in destructor
+       }
+       else if ( this->allow_multiple_transaction_ )
+       {
+           this->transaction_->handled_ = old_handled_state;    //Enable again the transaction object. To allow normal operation in transaction object.
+       }
+
+       this->transaction_ = NULL;           //Clear reference to transaction object
+    }
 }
 
 std::ostringstream & session::get_query_stream()

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -316,12 +316,12 @@ bool session::allow_multiple_transaction() const
     return this->allow_multiple_transaction_;
 }
 
-transaction * session::current_transaction()
+transaction * session::current_transaction() const
 {
     return this->transaction_;
 }
 
-bool session::current_transaction_is_active()
+bool session::current_transaction_is_active() const
 {
     return this->transaction_ != NULL ? transaction_->is_active(): false;
 }

--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -12,9 +12,43 @@
 using namespace soci;
 
 transaction::transaction(session& sql)
-    : handled_(false), sql_(sql)
+    : handled_(false), sql_(sql), by_session_(false)
 {
-    sql_.begin();
+    if (sql_.current_transaction() == NULL ||  //Session already in transaction?
+        sql_.allow_multiple_transaction())     //Session allow multiple transactions?
+    {
+        if (sql_.current_transaction() != NULL) //The session already with transaction?
+        {
+           if (sql_.current_transaction()->by_session()) //Yes already had. Is created by session object?
+           {
+               //Yes is created by session object.
+               bool old_handled_state = sql_.transaction_->handled_;
+
+               sql_.transaction_->handled_ = true; //Disable the transaction prevent call Transaction::Destructor -> Session::Rollback
+
+               delete sql_.transaction_;  //Prevent memory leak
+
+               if ( old_handled_state == false )
+               {
+                   sql_.rollback();           //Revert in session transaction
+               }
+           }
+        }
+
+        sql_.transaction_ = this; //Pass the reference back. This transaction is created outside of session object
+        sql_.begin();
+    }
+    else {
+        handled_ = true; //Yes. Session already in transaction and not allow mutiple transactions. Auto disable this transaction object
+    }
+}
+
+//Private constructor use from session object in case not assigned transaction.
+//Used in src/core/session.cpp:343
+transaction::transaction(session& sql, bool by_session)
+    : handled_(false), sql_(sql), by_session_(by_session)
+{
+    //This instance is created from inside of session object.
 }
 
 transaction::~transaction()
@@ -27,6 +61,11 @@ transaction::~transaction()
         }
         catch (...)
         {}
+    }
+
+    if (sql_.transaction_ == this)
+    {
+        sql_.transaction_ = NULL; //Clear my reference in the session object
     }
 }
 
@@ -50,4 +89,19 @@ void transaction::rollback()
 
     sql_.rollback();
     handled_ = true;
+}
+
+inline session* transaction::current_session()
+{
+    return &sql_;
+}
+
+bool transaction::is_active()
+{
+    return this->handled_ == false;
+}
+
+bool transaction::by_session() //This transaction is auto created inside of the object session? src/core/session.cpp:291
+{
+    return this->by_session_;
 }

--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -91,17 +91,17 @@ void transaction::rollback()
     handled_ = true;
 }
 
-inline session* transaction::current_session()
+inline session* transaction::current_session() const
 {
     return &sql_;
 }
 
-bool transaction::is_active()
+bool transaction::is_active() const
 {
     return this->handled_ == false;
 }
 
-bool transaction::by_session() //This transaction is auto created inside of the object session? src/core/session.cpp:291
+bool transaction::by_session() const //This transaction is auto created inside of the object session? src/core/session.cpp:291
 {
     return this->by_session_;
 }


### PR DESCRIPTION
session and transaction objects are linked. Is possible known from session object the transaction associated and is it active. And from transaction object the session owner. 

Constant correctness. 

Methods: In transaction::is_active, transaction::by_session, transaction::current_session, session::current_transaction, session::current_transaction_is_active.

Fix 3.