### PR TITLE
Avoid -Wpedantic given for some versions of mysql.h

### DIFF
--- a/include/private/firebird/common.h
+++ b/include/private/firebird/common.h
@@ -235,7 +235,7 @@ T1 from_isc(XSQLVAR * var)
         }
     }
 
-    GCC_WARNING_SUPPRESS(cast-align)
+    SOCI_GCC_WARNING_SUPPRESS(cast-align)
 
     switch (var->sqltype & ~1)
     {
@@ -253,7 +253,7 @@ T1 from_isc(XSQLVAR * var)
         throw soci_error("Incorrect data type for numeric conversion");
     }
 
-    GCC_WARNING_RESTORE(cast-align)
+    SOCI_GCC_WARNING_RESTORE(cast-align)
 }
 
 } // namespace firebird

--- a/include/private/soci-compiler.h
+++ b/include/private/soci-compiler.h
@@ -10,14 +10,14 @@
 
 #include "soci-cpp.h"
 
-// CHECK_GCC(major,minor) evaluates to 1 when using g++ of at least this
+// SOCI_CHECK_GCC(major,minor) evaluates to 1 when using g++ of at least this
 // version or 0 when using g++ of lesser version or not using g++ at all.
 #if defined(__GNUC__) && defined(__GNUC_MINOR__)
-#   define CHECK_GCC(major, minor) \
+#   define SOCI_CHECK_GCC(major, minor) \
         ((__GNUC__ > (major)) \
             || (__GNUC__ == (major) && __GNUC_MINOR__ >= (minor)))
 #else
-#   define CHECK_GCC(major, minor) 0
+#   define SOCI_CHECK_GCC(major, minor) 0
 #endif
 
 // GCC_WARNING_{SUPPRESS,RESTORE} macros can be used to bracket the code
@@ -25,15 +25,15 @@
 //
 // They only work with g++ 4.6+ or clang, warnings are not disabled for earlier
 // g++ versions.
-#if defined(__clang__) || CHECK_GCC(4, 6)
-#   define GCC_WARNING_SUPPRESS(x) \
+#if defined(__clang__) || SOCI_CHECK_GCC(4, 6)
+#   define SOCI_GCC_WARNING_SUPPRESS(x) \
         _Pragma (SOCI_STRINGIZE(GCC diagnostic push)) \
         _Pragma (SOCI_STRINGIZE(GCC diagnostic ignored SOCI_STRINGIZE(SOCI_CONCAT(-W,x))))
-#   define GCC_WARNING_RESTORE(x) \
+#   define SOCI_GCC_WARNING_RESTORE(x) \
         _Pragma (SOCI_STRINGIZE(GCC diagnostic pop))
 #else /* gcc < 4.6 or not gcc and not clang at all */
-#   define GCC_WARNING_SUPPRESS(x)
-#   define GCC_WARNING_RESTORE(x)
+#   define SOCI_GCC_WARNING_SUPPRESS(x)
+#   define SOCI_GCC_WARNING_RESTORE(x)
 #endif
 
 #endif // SOCI_PRIVATE_SOCI_COMPILER_H_INCLUDED

--- a/include/soci/mysql/soci-mysql.h
+++ b/include/soci/mysql/soci-mysql.h
@@ -21,8 +21,26 @@
 #ifdef _WIN32
 #include <winsock.h> // SOCKET
 #endif // _WIN32
+
+// Some version of mysql.h contain trailing comma in an enum declaration that
+// trigger -Wpedantic, so suppress it as there is nothing to be done about it
+// using the macros defined in our private soci-compiler.h header, that we can
+// only include when building SOCI itself.
+#ifdef SOCI_MYSQL_SOURCE
+    #include "soci-compiler.h"
+#endif
+
+#ifdef SOCI_GCC_WARNING_SUPPRESS
+    SOCI_GCC_WARNING_SUPPRESS(pedantic)
+#endif
+
 #include <mysql.h> // MySQL Client
 #include <errmsg.h> // MySQL Error codes
+
+#ifdef SOCI_GCC_WARNING_RESTORE
+    SOCI_GCC_WARNING_RESTORE(pedantic)
+#endif
+
 #include <vector>
 
 

--- a/src/backends/firebird/common.cpp
+++ b/src/backends/firebird/common.cpp
@@ -190,11 +190,11 @@ std::string getTextParam(XSQLVAR const *var)
 
     if ((var->sqltype & ~1) == SQL_VARYING)
     {
-        GCC_WARNING_SUPPRESS(cast-align)
+        SOCI_GCC_WARNING_SUPPRESS(cast-align)
 
         size = *reinterpret_cast<short*>(var->sqldata);
 
-        GCC_WARNING_RESTORE(cast-align)
+        SOCI_GCC_WARNING_RESTORE(cast-align)
 
         offset = sizeof(short);
     }
@@ -224,11 +224,11 @@ void copy_from_blob(firebird_statement_backend &st, char *buf, std::string &out)
 {
     firebird_blob_backend blob(st.session_);
 
-    GCC_WARNING_SUPPRESS(cast-align)
+    SOCI_GCC_WARNING_SUPPRESS(cast-align)
 
     blob.assign(*reinterpret_cast<ISC_QUAD*>(buf));
 
-    GCC_WARNING_RESTORE(cast-align)
+    SOCI_GCC_WARNING_RESTORE(cast-align)
 
     std::size_t const len_total = blob.get_len();
     out.resize(len_total);

--- a/src/backends/firebird/standard-into-type.cpp
+++ b/src/backends/firebird/standard-into-type.cpp
@@ -123,11 +123,11 @@ void firebird_standard_into_type_backend::exchangeData()
                     throw soci_error("Can't get Firebid BLOB BackEnd");
                 }
 
-                GCC_WARNING_SUPPRESS(cast-align)
+                SOCI_GCC_WARNING_SUPPRESS(cast-align)
 
                 blob->assign(*reinterpret_cast<ISC_QUAD*>(buf_));
 
-                GCC_WARNING_RESTORE(cast-align)
+                SOCI_GCC_WARNING_RESTORE(cast-align)
             }
             break;
 

--- a/src/backends/mysql/common.cpp
+++ b/src/backends/mysql/common.cpp
@@ -5,6 +5,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#define SOCI_MYSQL_SOURCE
 #include "common.h"
 #include <ciso646>
 #include <cstdlib>

--- a/src/backends/mysql/common.h
+++ b/src/backends/mysql/common.h
@@ -41,11 +41,11 @@ bool is_infinity_or_nan(T x)
     T y = x - x;
 
     // We really need exact floating point comparison here.
-    GCC_WARNING_SUPPRESS(float-equal)
+    SOCI_GCC_WARNING_SUPPRESS(float-equal)
 
     return (y != y);
 
-    GCC_WARNING_RESTORE(float-equal)
+    SOCI_GCC_WARNING_RESTORE(float-equal)
 }
 
 template <typename T>

--- a/src/backends/odbc/standard-into-type.cpp
+++ b/src/backends/odbc/standard-into-type.cpp
@@ -181,11 +181,11 @@ void odbc_standard_into_type_backend::post_fetch(
             // Our pointer should, in fact, be sufficiently aligned, as we
             // allocate it on the heap, but gcc on ARMv7hl warns about this not
             // being the case, so just suppress this warning explicitly here.
-            GCC_WARNING_SUPPRESS(cast-align)
+            SOCI_GCC_WARNING_SUPPRESS(cast-align)
 
             TIMESTAMP_STRUCT * ts = reinterpret_cast<TIMESTAMP_STRUCT*>(buf_);
 
-            GCC_WARNING_RESTORE(cast-align)
+            SOCI_GCC_WARNING_RESTORE(cast-align)
 
             details::mktime_from_ymdhms(t,
                                         ts->year, ts->month, ts->day,

--- a/src/backends/odbc/standard-use-type.cpp
+++ b/src/backends/odbc/standard-use-type.cpp
@@ -103,11 +103,11 @@ void* odbc_standard_use_type_backend::prepare_for_bind(
                    // yyyy-mm-dd hh:mm:ss
 
         // See comment for the use of this macro in standard-into-type.cpp.
-        GCC_WARNING_SUPPRESS(cast-align)
+        SOCI_GCC_WARNING_SUPPRESS(cast-align)
 
         TIMESTAMP_STRUCT * ts = reinterpret_cast<TIMESTAMP_STRUCT*>(buf_);
 
-        GCC_WARNING_RESTORE(cast-align)
+        SOCI_GCC_WARNING_RESTORE(cast-align)
 
         ts->year = static_cast<SQLSMALLINT>(t.tm_year + 1900);
         ts->month = static_cast<SQLUSMALLINT>(t.tm_mon + 1);

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -269,11 +269,11 @@ void odbc_vector_into_type_backend::do_post_fetch_rows(
         for (std::size_t i = beginRow; i != endRow; ++i)
         {
             // See comment for the use of this macro in standard-into-type.cpp.
-            GCC_WARNING_SUPPRESS(cast-align)
+            SOCI_GCC_WARNING_SUPPRESS(cast-align)
 
             TIMESTAMP_STRUCT * ts = reinterpret_cast<TIMESTAMP_STRUCT*>(pos);
 
-            GCC_WARNING_RESTORE(cast-align)
+            SOCI_GCC_WARNING_RESTORE(cast-align)
 
             details::mktime_from_ymdhms(v[i],
                                         ts->year, ts->month, ts->day,

--- a/src/backends/odbc/vector-use-type.cpp
+++ b/src/backends/odbc/vector-use-type.cpp
@@ -310,11 +310,11 @@ void odbc_vector_use_type_backend::pre_use(indicator const *ind)
                     std::tm t = v[i];
 
                     // See comment for the use of this macro in standard-into-type.cpp.
-                    GCC_WARNING_SUPPRESS(cast-align)
+                    SOCI_GCC_WARNING_SUPPRESS(cast-align)
 
                     TIMESTAMP_STRUCT * ts = reinterpret_cast<TIMESTAMP_STRUCT*>(pos);
 
-                    GCC_WARNING_RESTORE(cast-align)
+                    SOCI_GCC_WARNING_RESTORE(cast-align)
 
                     ts->year = static_cast<SQLSMALLINT>(t.tm_year + 1900);
                     ts->month = static_cast<SQLUSMALLINT>(t.tm_mon + 1);

--- a/src/backends/oracle/standard-use-type.cpp
+++ b/src/backends/oracle/standard-use-type.cpp
@@ -498,14 +498,14 @@ void oracle_standard_use_type_backend::post_use(bool gotData, indicator *ind)
 
                 // Exact comparison is fine here, they are really supposed to
                 // be exactly the same.
-                GCC_WARNING_SUPPRESS(float-equal)
+                SOCI_GCC_WARNING_SUPPRESS(float-equal)
 
                 if (original != bound)
                 {
                     throw soci_error("Attempted modification of const use element");
                 }
 
-                GCC_WARNING_RESTORE(float-equal)
+                SOCI_GCC_WARNING_RESTORE(float-equal)
             }
             break;
         case x_stdstring:

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -535,11 +535,11 @@ inline bool
 are_doubles_exactly_equal(double a, double b)
 {
     // Avoid g++ warnings: we do really want the exact equality here.
-    GCC_WARNING_SUPPRESS(float-equal)
+    SOCI_GCC_WARNING_SUPPRESS(float-equal)
 
     return a == b;
 
-    GCC_WARNING_RESTORE(float-equal)
+    SOCI_GCC_WARNING_RESTORE(float-equal)
 }
 
 #define ASSERT_EQUAL_EXACT(a, b) \

--- a/tests/mysql/test-mysql.cpp
+++ b/tests/mysql/test-mysql.cpp
@@ -7,6 +7,8 @@
 //
 
 #include "soci/soci.h"
+
+#include "soci-compiler.h"
 #include "soci/mysql/soci-mysql.h"
 #include "mysql/test-mysql.h"
 #include <string.h>


### PR DESCRIPTION
This warning, given due to a trailing comma in mysql.h, breaks a CI
build under Ubuntu 20.04.4.

Just suppress it, as it's harmless and we can't do anything about it
anyhow.