### PR TITLE
sqlite3: support the pragma foreign_keys for enforcing foreign keys

### DIFF
--- a/docs/backends/sqlite3.md
+++ b/docs/backends/sqlite3.md
@@ -53,6 +53,7 @@ The set of parameters used in the connection string for SQLite is:
 * `synchronous` - set the pragma synchronous flag ([link](http://www.sqlite.org/pragma.html#pragma_synchronous))
 * `shared_cache` - should be `true` ([link](http://www.sqlite.org/c3ref/enable_shared_cache.html))
 * `vfs` - set the SQLite VFS used to as OS interface. The VFS should be registered before opening the connection, see [the documenation](https://www.sqlite.org/vfs.html)
+* `foreign_keys` - set the pragma foreign_keys flag ([link](https://www.sqlite.org/pragma.html#pragma_foreign_keys)). Possible values are "on"/"off"
 
 Once you have created a `session` object as shown above, you can use it to access the database, for example:
 

--- a/docs/backends/sqlite3.md
+++ b/docs/backends/sqlite3.md
@@ -53,7 +53,7 @@ The set of parameters used in the connection string for SQLite is:
 * `synchronous` - set the pragma synchronous flag ([link](http://www.sqlite.org/pragma.html#pragma_synchronous))
 * `shared_cache` - should be `true` ([link](http://www.sqlite.org/c3ref/enable_shared_cache.html))
 * `vfs` - set the SQLite VFS used to as OS interface. The VFS should be registered before opening the connection, see [the documenation](https://www.sqlite.org/vfs.html)
-* `foreign_keys` - set the pragma foreign_keys flag ([link](https://www.sqlite.org/pragma.html#pragma_foreign_keys)). Possible values are "on"/"off"
+* `foreign_keys` - set the pragma foreign_keys flag ([link](https://www.sqlite.org/pragma.html#pragma_foreign_keys)).
 
 Once you have created a `session` object as shown above, you can use it to access the database, for example:
 

--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -133,7 +133,8 @@ sqlite3_session_backend::sqlite3_session_backend(
     if (!foreignKeys.empty())
     {
         std::string const query("pragma foreign_keys=" + foreignKeys);
-        execude_hardcoded(conn_, query.c_str(), "Attempt to set foreign_keys pragma failed");
+        std::string const errMsg("Executing query: " + query + " failed");
+        execude_hardcoded(conn_, query.c_str(), errMsg.c_str());
     }
 
     res = sqlite3_busy_timeout(conn_, timeout * 1000);

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -59,20 +59,20 @@ public:
     SetupForeignKeys(soci::session& sql)
         : m_sql(sql)
     {
-        sql <<
+        m_sql <<
         "create table parent ("
         "    id integer primary key"
         ")";
 
-        sql <<
+        m_sql <<
         "create table child ("
         "    id integer primary key,"
         "    parent integer,"
         "    foreign key(parent) references parent(id)"
         ")";
 
-        sql << "insert into parent(id) values(1)";
-        sql << "insert into child(id, parent) values(100, 1)";
+        m_sql << "insert into parent(id) values(1)";
+        m_sql << "insert into child(id, parent) values(100, 1)";
     }
 
     ~SetupForeignKeys()
@@ -81,10 +81,10 @@ public:
         m_sql << "drop table parent";
     }
 
-    SetupForeignKeys(const SetupForeignKeys&) = delete;
-    SetupForeignKeys& operator=(const SetupForeignKeys&) = delete;
-
 private:
+    SetupForeignKeys(const SetupForeignKeys&);
+    SetupForeignKeys& operator=(const SetupForeignKeys&);
+
     soci::session& m_sql;
 };
 
@@ -108,7 +108,10 @@ TEST_CASE("SQLite foreign keys are enabled by foreign_keys option", "[sqlite][fo
 
     SetupForeignKeys setupForeignKeys(sql);
 
-    CHECK_THROWS_AS(sql << "delete from parent where id = 1", soci::soci_error);
+    CHECK_THROWS_WITH(sql << "delete from parent where id = 1",
+                      "sqlite3_statement_backend::loadOne: FOREIGN KEY "
+                      "constraint failed while executing "
+                      "\"delete from parent where id = 1\".");
 }
 
 // BLOB test

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -99,7 +99,7 @@ TEST_CASE("SQLite foreign keys are enabled by foreign_keys option", "[sqlite][fo
     {
         sql << "delete from parent where id = 1";
     }
-    catch ( const soci::soci_error& err )
+    catch (const soci::soci_error&)
     {
         thrown = true;
     }


### PR DESCRIPTION
By default sqlite3 will not enforce foreign key (added a test for that).
It's opt-in functionality that must be enabled at each connection open.

Added connection parameter foreign_keys for the sqlite3 backend.

For reference:
https://www.sqlite.org/foreignkeys.html