### PR TITLE
[sqlite3] Improve get_last_insert_id

### DIFF
--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -329,6 +329,7 @@ struct sqlite3_session_backend : details::session_backend
 
     }
     sqlite_api::sqlite3 *conn_;
+    bool sequenceTableExists_;
 };
 
 struct sqlite3_backend_factory : backend_factory

--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -52,9 +52,29 @@ void check_sqlite_err(sqlite_api::sqlite3* conn, int res, char const* const errM
 
 } // namespace anonymous
 
+static int CheckSequenceTableCallback(void* ctxt, int valueNum, char**, char**)
+{
+    bool* flag = (bool*)ctxt;
+    *flag = valueNum > 0;
+    return 0;
+}
+
+static bool SequenceTableExists(sqlite_api::sqlite3* conn)
+{
+    char *zErrMsg = 0;
+    bool sequenceTableExists = false;
+    std::string query = "select name from sqlite_master where type='table' and name='sqlite_sequence'";
+    int const res = sqlite3_exec(conn, query.c_str(), &CheckSequenceTableCallback,
+                                 &sequenceTableExists,
+                                 &zErrMsg);
+    check_sqlite_err(conn, res, "Failed checking if the sqlite_sequence table exists");
+
+    return sequenceTableExists;
+}
 
 sqlite3_session_backend::sqlite3_session_backend(
     connection_parameters const & parameters)
+    : sequenceTableExists_(false)
 {
     int timeout = 0;
     int connection_flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
@@ -133,13 +153,11 @@ sqlite3_session_backend::sqlite3_session_backend(
     if (!foreignKeys.empty())
     {
         std::string const query("pragma foreign_keys=" + foreignKeys);
-        std::string const errMsg("Executing query: " + query + " failed");
-        execude_hardcoded(conn_, query.c_str(), errMsg.c_str());
+        execude_hardcoded(conn_, query.c_str(), "Attempt to set foreign_keys pragma failed");
     }
 
     res = sqlite3_busy_timeout(conn_, timeout * 1000);
     check_sqlite_err(conn_, res, "Failed to set busy timeout for connection. ");
-
 }
 
 sqlite3_session_backend::~sqlite3_session_backend()
@@ -162,10 +180,56 @@ void sqlite3_session_backend::rollback()
     execude_hardcoded(conn_, "ROLLBACK", "Cannot rollback transaction.");
 }
 
-bool sqlite3_session_backend::get_last_insert_id(
-    session & /* s */, std::string const & /* table */, long long & value)
+struct SeqCtxt
 {
-    value = static_cast<long long>(sqlite3_last_insert_rowid(conn_));
+    long long value_;
+    bool filledIn_;
+};
+
+static int GetOneLong(void* ctxt, int valueNum, char** values, char**)
+{
+    SeqCtxt* seqCtxt = (SeqCtxt*)ctxt;
+    seqCtxt->value_ = 0;
+    seqCtxt->filledIn_ = true;
+    char* ptr = NULL;
+    if (valueNum == 1 && values[0])
+        seqCtxt->value_ = strtol(values[0], &ptr, 10);
+    return 0;
+}
+
+bool sqlite3_session_backend::get_last_insert_id(
+    session &, std::string const & table, long long & value)
+{
+    char *zErrMsg = NULL;
+    SeqCtxt seqCtxt = { 0 };
+    if (sequenceTableExists_ || SequenceTableExists(conn_))
+    {
+        // Once the sqlite_sequence table is created (because of a column marked AUTOINCREMENT)
+        // it can never be dropped, so don't search for it again.
+        sequenceTableExists_ = true;
+
+        std::string const query = "select seq from sqlite_sequence where name ='" + table + "'";
+        int const res = sqlite3_exec(conn_, query.c_str(), &GetOneLong, &seqCtxt, &zErrMsg);
+        check_sqlite_err(conn_, res, "Unable to get value in sqlite_sequence");
+
+        // The value will not be filled if the callback was never called.
+        // It may mean either that nothing was inserted yet into the table
+        // that has an AUTOINCREMENT column, or that the table does not have an AUTOINCREMENT
+        // column.
+        if (seqCtxt.filledIn_)
+        {
+            value = seqCtxt.value_;
+            return true;
+        }
+    }
+
+    // Fall-back just get the maximum rowid of what was already inserted in the
+    // table. This has the disadvantage that if rows were deleted, then ids may be re-used.
+    // But, if one cares about that, AUTOINCREMENT should be used anyway.
+    std::string const maxRowIdQuery = "select max(rowid) from " + table;
+    int const res = sqlite3_exec(conn_, maxRowIdQuery.c_str(), &GetOneLong, &seqCtxt, &zErrMsg);
+    check_sqlite_err(conn_, res, "Unable to get max rowid");
+    value = seqCtxt.value_;
 
     return true;
 }

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -114,6 +114,102 @@ TEST_CASE("SQLite foreign keys are enabled by foreign_keys option", "[sqlite][fo
                       "\"delete from parent where id = 1\".");
 }
 
+class SetupAutoIncrementTable
+{
+public:
+    SetupAutoIncrementTable(soci::session& sql)
+        : m_sql(sql)
+    {
+        m_sql <<
+        "create table t("
+        "    id integer primary key autoincrement,"
+        "    name text"
+        ")";
+    }
+
+    ~SetupAutoIncrementTable()
+    {
+        m_sql << "drop table t";
+    }
+
+private:
+    SetupAutoIncrementTable(const SetupAutoIncrementTable&);
+    SetupAutoIncrementTable& operator=(const SetupAutoIncrementTable&);
+
+    soci::session& m_sql;
+};
+
+TEST_CASE("SQLite get_last_insert_id works with AUTOINCREMENT",
+          "[sqlite][rowid]")
+{
+    soci::session sql(backEnd, connectString);
+    SetupAutoIncrementTable createTable(sql);
+
+    sql << "insert into t(name) values('x')";
+    sql << "insert into t(name) values('y')";
+
+    long long val;
+    sql.get_last_insert_id("t", val);
+    CHECK(val == 2);
+}
+
+TEST_CASE("SQLite get_last_insert_id with AUTOINCREMENT does not reuse IDs when rows deleted",
+          "[sqlite][rowid]")
+{
+    soci::session sql(backEnd, connectString);
+    SetupAutoIncrementTable createTable(sql);
+
+    sql << "insert into t(name) values('x')";
+    sql << "insert into t(name) values('y')";
+
+    sql << "delete from t where id = 2";
+
+    long long val;
+    sql.get_last_insert_id("t", val);
+    CHECK(val == 2);
+}
+
+class SetupNoAutoIncrementTable
+{
+public:
+    SetupNoAutoIncrementTable(soci::session& sql)
+        : m_sql(sql)
+    {
+        m_sql <<
+        "create table t("
+        "    id integer primary key,"
+        "    name text"
+        ")";
+    }
+
+    ~SetupNoAutoIncrementTable()
+    {
+        m_sql << "drop table t";
+    }
+
+private:
+    SetupNoAutoIncrementTable(const SetupAutoIncrementTable&);
+    SetupNoAutoIncrementTable& operator=(const SetupAutoIncrementTable&);
+
+    soci::session& m_sql;
+};
+
+TEST_CASE("SQLite get_last_insert_id without AUTOINCREMENT reuses IDs when rows deleted",
+          "[sqlite][rowid]")
+{
+    soci::session sql(backEnd, connectString);
+    SetupNoAutoIncrementTable createTable(sql);
+
+    sql << "insert into t(name) values('x')";
+    sql << "insert into t(name) values('y')";
+
+    sql << "delete from t where id = 2";
+
+    long long val;
+    sql.get_last_insert_id("t", val);
+    CHECK(val == 1);
+}
+
 // BLOB test
 struct blob_table_creator : public table_creator_base
 {


### PR DESCRIPTION
Take the value from the specified table as argument.
If table column was marked AUTOINCREMENT use that by checking the internal sqlite_sequence table. If the AUTOINCREMENT is not present or nothing was inserted into a table, just take the max(rowid) of that table. This has the disadvantage that ids are recycled when rows are deleted (as test shows). However, if this is in anyway important to the caller then the columns will be marked as AUTOINCREMENT given this is the solution the documentation specifies.

The previous version was of reduced utility, it was a simple wrapper around the sqlite3_last_insert_rowid which would return a *global* last insert rowid across the whole database connection. Presumably this was not the original purpose of the API given that the table name parameter is present.