### PR TITLE
Map dt_date to datetime in SQLite3's DDL API

### DIFF
--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -317,6 +317,12 @@ struct sqlite3_session_backend : details::session_backend
             case dt_double:
                 return "real";
             case dt_date:
+                // The type `datetime` doesn't exist in SQLite3. Instead,
+                // the storage class of date and time data types is either
+                // one of TEXT, REAL or INTEGER. However, when using the
+                // soci::row API, we want to be able to map the column back 
+                // to a dt_date, so that we can query its value as a std::tm.
+                return "datetime";
             case dt_integer:
             case dt_long_long:
             case dt_unsigned_long_long:


### PR DESCRIPTION
As the datetime data type doesn't exist in SQLite3, the DDL
method create_column_type() mapped dt_date to an integer type. This was
possible because SQLite3 internally handles datetime values as text,
real or integer. When using the soci::row API however, we want to be
able to query datetime columns as std::tm instead of integers.
To do this, create_column_type() must assign dt_date to a type that
gets mapped back to dt_date in get_data_type_map() in
sqlite3/statement.cpp. The most generic one in this case is datetime.

Fixes #969 