### PR TITLE
Fix having both "use" and "into" in a vector object of a custom type.

### DIFF
--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -311,7 +311,7 @@ sqlite3_statement_backend::bind_and_execute(int number)
 
         // Handle the case where there are both into and use elements
         // in the same query and one of the into binds to a vector object.
-        if (1 == rows /* && number != rows */)
+        if (1 == rows && number != rows)
         {
             return load_rowset(number);
         }

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -311,7 +311,7 @@ sqlite3_statement_backend::bind_and_execute(int number)
 
         // Handle the case where there are both into and use elements
         // in the same query and one of the into binds to a vector object.
-        if (1 == rows && number != rows)
+        if (1 == rows /* && number != rows */)
         {
             return load_rowset(number);
         }

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -139,11 +139,11 @@ private:
     soci::session& m_sql;
 };
 
-enum class CustomType
+enum CustomType
 {
-    Val1,
-    Val2,
-    NotSet
+    CustomType_Val1,
+    CustomType_Val2,
+    CustomType_NotSet
 };
 
 namespace soci {
@@ -156,7 +156,7 @@ struct type_conversion<CustomType>
     {
         if ( ind == i_null )
         {
-            t = CustomType::NotSet;
+            t = CustomType_NotSet;
 
             return;
         }
@@ -164,13 +164,13 @@ struct type_conversion<CustomType>
         switch ( index )
         {
             case 0:
-                t = CustomType::Val1;
+                t = CustomType_Val1;
                 break;
             case 1:
-                t = CustomType::Val2;
+                t = CustomType_Val2;
                 break;
             default:
-                t = CustomType::NotSet;
+                t = CustomType_NotSet;
         }
     }
 
@@ -178,10 +178,10 @@ struct type_conversion<CustomType>
     {
         switch ( t )
         {
-            case CustomType::Val1:
+            case CustomType_Val1:
                 index = 0;
                 break;
-            case CustomType::Val2:
+            case CustomType_Val2:
                 index = 1;
                 break;
             default:
@@ -199,12 +199,12 @@ TEST_CASE("Can select custom type", "[sqlite][customtype]")
     soci::session sql(backEnd, connectString);
     SetupTableWithTimestampColumn table(sql);
 
-    CustomType v1 = CustomType::Val1;
+    CustomType v1 = CustomType_Val1;
     sql << "insert into t(ct) values(:ct)", use(v1);
 
     CustomType ct;
     sql << "select ct from t", into(ct);
-    CHECK(ct == CustomType::Val1);
+    CHECK(ct == CustomType_Val1);
 }
 
 TEST_CASE("Can select custom type row in vector", "[sqlite][customtype][vector]")
@@ -212,16 +212,16 @@ TEST_CASE("Can select custom type row in vector", "[sqlite][customtype][vector]"
     soci::session sql(backEnd, connectString);
     SetupTableWithTimestampColumn table(sql);
 
-    CustomType v1 = CustomType::Val1;
+    CustomType v1 = CustomType_Val1;
     sql << "insert into t(ct) values(:ct)", use(v1);
-    CustomType v2 = CustomType::Val2;
+    CustomType v2 = CustomType_Val2;
     sql << "insert into t(ct) values(:ct)", use(v2);
 
     std::vector<CustomType> v;
     v.resize(2);
     sql << "select ct from t", into(v);
     CHECK(v.size() == 2);
-    CHECK(v[0] == CustomType::Val1);
+    CHECK(v[0] == CustomType_Val1);
 }
 
 class SetupAutoIncrementTable

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -148,7 +148,7 @@ namespace soci {
 template <>
 struct type_conversion<Timestamp>
 {
-    using base_type = std::tm;
+    typedef std::tm base_type;
 
     static void from_base(const std::tm& tm, indicator ind, Timestamp& time)
     {

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -199,7 +199,8 @@ TEST_CASE("Can select custom type", "[sqlite][customtype]")
     soci::session sql(backEnd, connectString);
     SetupTableWithTimestampColumn table(sql);
 
-    sql << "insert into t(ct) values(:ct)", use(CustomType::Val1);
+    CustomType v1 = CustomType::Val1;
+    sql << "insert into t(ct) values(:ct)", use(v1);
 
     CustomType ct;
     sql << "select ct from t", into(ct);
@@ -211,8 +212,10 @@ TEST_CASE("Can select custom type row in vector", "[sqlite][customtype][vector]"
     soci::session sql(backEnd, connectString);
     SetupTableWithTimestampColumn table(sql);
 
-    sql << "insert into t(ct) values(:ct)", use(CustomType::Val1);
-    sql << "insert into t(ct) values(:ct)", use(CustomType::Val2);
+    CustomType v1 = CustomType::Val1;
+    sql << "insert into t(ct) values(:ct)", use(v1);
+    CustomType v2 = CustomType::Val2;
+    sql << "insert into t(ct) values(:ct)", use(v2);
 
     std::vector<CustomType> v;
     v.resize(2);


### PR DESCRIPTION
Previous behavior was that the vector was reset to zero size.

I'm the first to admit that I don't know what was the use of the commented out code in statement.cpp:134.
For my test case both number and rows were equal to 1 so the load_rowset was not executed.