### PR TITLE
Fix PostgreSQL Mac CI job

### DIFF
--- a/cmake/modules/FindPostgreSQL.cmake
+++ b/cmake/modules/FindPostgreSQL.cmake
@@ -27,7 +27,7 @@
 # In Windows the default installation of PostgreSQL uses that as part of the path.
 # E.g C:\Program Files\PostgreSQL\8.4.
 # Currently, the following version numbers are known to this module:
-# "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0"
+# "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0"
 #
 # To use this variable just do something like this:
 # set(POSTGRESQL_ADDITIONAL_VERSIONS "9.2" "8.4.4")
@@ -71,7 +71,7 @@ set(POSTGRESQL_ROOT_DIR_MESSAGE "Set the POSTGRESQL_ROOT system variable to wher
 
 
 set(POSTGRESQL_KNOWN_VERSIONS ${POSTGRESQL_ADDITIONAL_VERSIONS}
-    "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
+    "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
 
 # Define additional search paths for root directories.
 set( POSTGRESQL_ROOT_DIRECTORIES

--- a/cmake/modules/FindPostgreSQL.cmake
+++ b/cmake/modules/FindPostgreSQL.cmake
@@ -96,6 +96,12 @@ foreach(suffix ${POSTGRESQL_KNOWN_VERSIONS})
         "postgresql/${suffix}/server"
         "pgsql-${suffix}/include/server")
   endif()
+  if(APPLE)
+    list(APPEND POSTGRESQL_LIBRARY_ADDITIONAL_SEARCH_SUFFIXES
+        "postgresql@${suffix}")
+    list(APPEND POSTGRESQL_INCLUDE_ADDITIONAL_SEARCH_SUFFIXES
+        "postgresql@${suffix}")
+  endif()
 endforeach()
 
 #

--- a/scripts/ci/before_build_postgresql.sh
+++ b/scripts/ci/before_build_postgresql.sh
@@ -13,6 +13,7 @@ case "$(uname)" in
         ;;
 
     Darwin)
+        pg_ctl init
         pg_ctl start
         pg_isready --timeout=60
         createuser --superuser postgres


### PR DESCRIPTION
There doesn't seem to be any way to tell CMake where the files are (setting `POSTGRESQL_INCLUDE_DIR` and `POSTGRESQL_LIBRARY_DIR` from environment doesn't work, they have to be set in `CMakeLists.txt` itself, which is completely useless; setting `POSTGRESQL_ROOT` does work, but doesn't help) and our `FindPostgreSQL` module doesn't use `pg_config` for whatever reason (and neither does even the latest version in CMake Git, but that version can't be used anyhow because it depends on CMake features not present in the version we actually use), so add a hack to allow actually finding Postgres under Mac.