### PR TITLE
Rename library aliases to use shorter and more consistent names

### DIFF
--- a/cmake/SociBackend.cmake
+++ b/cmake/SociBackend.cmake
@@ -155,7 +155,7 @@ macro(soci_backend NAME)
           SHARED
           ${THIS_BACKEND_SOURCES}
           ${THIS_BACKEND_HEADERS})
-        add_library(SOCI::${THIS_BACKEND_TARGET} ALIAS ${THIS_BACKEND_TARGET})
+        add_library(Soci::${NAMEL} ALIAS ${THIS_BACKEND_TARGET})
 
         target_link_libraries(${THIS_BACKEND_TARGET}
           ${SOCI_CORE_TARGET}
@@ -193,7 +193,7 @@ macro(soci_backend NAME)
           STATIC
           ${THIS_BACKEND_SOURCES}
           ${THIS_BACKEND_HEADERS})
-        add_library(SOCI::${THIS_BACKEND_TARGET_STATIC} ALIAS ${THIS_BACKEND_TARGET_STATIC})
+        add_library(Soci::${NAMEL}_static ALIAS ${THIS_BACKEND_TARGET_STATIC})
 
         # Still need to link the libraries for tests to work
         target_link_libraries (${THIS_BACKEND_TARGET_STATIC}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -295,9 +295,9 @@ In the example above, regression tests for the sample Empty backend and SQLite 3
 CMake build produces set of shared and static libraries for SOCI core and backends separately.
 On Unix, for example, `build/lib` directory will consist of the static libraries named like `libsoci_core.a`, `libsoci_sqlite3.a` and shared libraries with names like `libsoci_core.so.4.0.0`, `libsoci_sqlite3.so.4.0.0`, and so on.
 
-If your project also uses CMake, you can simply use `find_package(SOCI)` to check for SOCI availability and `target_link_libraries()` to link with the SOCI libraries available under the names `SOCI::soci_core` and `SOCI::soci_<backend>` and ensure that SOCI headers can be included (i.e. there is no need to use `target_include_directories()` explicitly). An example of a very simple CMake-based project using SOCI is provided in the `examples/connect` directory.
+If your project also uses CMake, you can simply use `find_package(Soci)` to check for SOCI availability and `target_link_libraries()` to link with the SOCI libraries available under the names `Soci::core` and `Soci::<backend>` (or `Soci::<backend>_static` if you prefer linking statically) and ensure that SOCI headers can be included (i.e. there is no need to use `target_include_directories()` explicitly). An example of a very simple CMake-based project using SOCI is provided in the `examples/connect` directory.
 
-Alternatively, you can add SOCI as a subdirectory to your project and include it via `add_subdirectory()`. As before, `target_link_libraries()` is used to link with the SOCI libraries available under the names `SOCI::soci_core` and `SOCI::soci_<backend>`. An example of this can be found in the directory `examples/subdir-include`.
+Alternatively, you can add SOCI as a subdirectory to your project and include it via `add_subdirectory()`. As before, `target_link_libraries()` is used to link with the SOCI libraries available under the same names `Soci::core` and `Soci::<backend>` as above. An example of this can be found in the directory `examples/subdir-include`.
 
 If you don't use CMake but want to use SOCI in your program, you need to specify the paths to the SOCI headers and libraries in your build configuration and to
 tell the linker to link against the libraries you want to use in your program.

--- a/examples/subdir-include/CMakeLists.txt
+++ b/examples/subdir-include/CMakeLists.txt
@@ -22,9 +22,9 @@ add_executable(subdir_include subdir-include.cpp)
 # Link the soci_<backend> libraries you want to use here.
 # There is no need to explicitly use target_include_directories() for the
 # main headers or the generated header (soci/soci-config.h), because both
-# are automatically added as part of the SOCI::soci_core target.
+# are automatically added as part of the Soci::core target.
 target_link_libraries(subdir_include
     PRIVATE
-        SOCI::soci_core
-        SOCI::soci_empty
+        Soci::core
+        Soci::empty
 )

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -44,7 +44,7 @@ soci_target_output_name(${SOCI_CORE_TARGET} SOCI_CORE_TARGET_OUTPUT_NAME)
 #
 if (SOCI_SHARED)
   add_library(${SOCI_CORE_TARGET} SHARED ${SOCI_CORE_HEADERS} ${SOCI_CORE_SOURCES})
-  add_library(SOCI::${SOCI_CORE_TARGET} ALIAS ${SOCI_CORE_TARGET})
+  add_library(Soci::core ALIAS ${SOCI_CORE_TARGET})
 
   target_link_libraries(${SOCI_CORE_TARGET} ${SOCI_CORE_DEPS_LIBS})
 
@@ -86,7 +86,7 @@ if (SOCI_STATIC)
 
   add_library(${SOCI_CORE_TARGET_STATIC} STATIC
     ${SOCI_CORE_HEADERS} ${SOCI_CORE_SOURCES})
-  add_library(SOCI::${SOCI_CORE_TARGET_STATIC} ALIAS ${SOCI_CORE_TARGET_STATIC})
+  add_library(Soci::core_static ALIAS ${SOCI_CORE_TARGET_STATIC})
 
   # we still need to link against dl if we have it
   target_link_libraries (${SOCI_CORE_TARGET_STATIC}


### PR DESCRIPTION
Use "Soci::" rather than "SOCI::" as the prefix, for consistency with the other CMake variables defined by FindSoci.cmake.

Do not use "soci_" prefix for the library names which is completely redundant with the other prefix, writing "Soci::soci_" is clearly redundant.

See #982.