### PR TITLE
[read|write]_from_start implemented for multiple backends

### DIFF
--- a/include/soci/blob.h
+++ b/include/soci/blob.h
@@ -32,6 +32,7 @@ public:
     std::size_t get_len();
 
     // offset is backend-specific
+    [[deprecated("Use read_from_start instead")]]
     std::size_t read(std::size_t offset, char * buf, std::size_t toRead);
 
     // offset starts from 0
@@ -39,6 +40,7 @@ public:
         std::size_t offset = 0);
 
     // offset is backend-specific
+    [[deprecated("Use write_from_start instead")]]
     std::size_t write(std::size_t offset, char const * buf,
         std::size_t toWrite);
 

--- a/include/soci/db2/soci-db2.h
+++ b/include/soci/db2/soci-db2.h
@@ -229,8 +229,8 @@ struct db2_blob_backend : details::blob_backend
     ~db2_blob_backend() override;
 
     std::size_t get_len() override;
-    std::size_t read(std::size_t offset, char* buf, std::size_t toRead) override;
-    std::size_t write(std::size_t offset, char const* buf, std::size_t toWrite) override;
+    std::size_t read_from_start(char* buf, std::size_t toRead, std::size_t offset = 0) override;
+    std::size_t write_from_start(char const* buf, std::size_t toWrite, std::size_t offset = 0) override;
     std::size_t append(char const* buf, std::size_t toWrite) override;
     void trim(std::size_t newLen) override;
 

--- a/include/soci/empty/soci-empty.h
+++ b/include/soci/empty/soci-empty.h
@@ -138,9 +138,13 @@ struct empty_blob_backend : details::blob_backend
     ~empty_blob_backend() override;
 
     std::size_t get_len() override;
-    std::size_t read(std::size_t offset, char* buf, std::size_t toRead) override;
-    std::size_t write(std::size_t offset, char const* buf, std::size_t toWrite) override;
+
+    std::size_t read_from_start(char * buf, std::size_t toRead, std::size_t offset = 0) override;
+
+    std::size_t write_from_start(const char * buf, std::size_t toWrite, std::size_t offset = 0) override;
+
     std::size_t append(char const* buf, std::size_t toWrite) override;
+
     void trim(std::size_t newLen) override;
 
     empty_session_backend& session_;

--- a/include/soci/firebird/soci-firebird.h
+++ b/include/soci/firebird/soci-firebird.h
@@ -256,11 +256,13 @@ struct firebird_blob_backend : details::blob_backend
     ~firebird_blob_backend() override;
 
     std::size_t get_len() override;
-    std::size_t read(std::size_t offset, char *buf,
-        std::size_t toRead) override;
-    std::size_t write(std::size_t offset, char const *buf,
-        std::size_t toWrite) override;
+
+    std::size_t read_from_start(char * buf, std::size_t toRead, std::size_t offset = 0) override;
+
+    std::size_t write_from_start(const char * buf, std::size_t toWrite, std::size_t offset = 0) override;
+
     std::size_t append(char const *buf, std::size_t toWrite) override;
+
     void trim(std::size_t newLen) override;
 
     firebird_session_backend &session_;

--- a/include/soci/mysql/soci-mysql.h
+++ b/include/soci/mysql/soci-mysql.h
@@ -242,10 +242,8 @@ struct mysql_blob_backend : details::blob_backend
     ~mysql_blob_backend() override;
 
     std::size_t get_len() override;
-    std::size_t read(std::size_t offset, char *buf,
-        std::size_t toRead) override;
-    std::size_t write(std::size_t offset, char const *buf,
-        std::size_t toWrite) override;
+    std::size_t read_from_start(char *buf, std::size_t toRead, std::size_t offset = 0) override;
+    std::size_t write_from_start(char const *buf, std::size_t toWrite, std::size_t offset = 0) override;
     std::size_t append(char const *buf, std::size_t toWrite) override;
     void trim(std::size_t newLen) override;
 

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -298,10 +298,8 @@ struct odbc_blob_backend : details::blob_backend
     ~odbc_blob_backend() override;
 
     std::size_t get_len() override;
-    std::size_t read(std::size_t offset, char *buf,
-        std::size_t toRead) override;
-    std::size_t write(std::size_t offset, char const *buf,
-        std::size_t toWrite) override;
+    std::size_t read_from_start(char *buf, std::size_t toRead, std::size_t offset = 0) override;
+    std::size_t write_from_start(char const *buf, std::size_t toWrite, std::size_t offset = 0) override;
     std::size_t append(char const *buf, std::size_t toWrite) override;
     void trim(std::size_t newLen) override;
 

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -266,23 +266,21 @@ struct oracle_blob_backend : details::blob_backend
 
     std::size_t get_len() override;
 
-    std::size_t read(std::size_t offset, char *buf,
-        std::size_t toRead) override;
-
-    std::size_t read_from_start(char * buf, std::size_t toRead,
-        std::size_t offset) override
+    std::size_t read(std::size_t offset, char *buf, std::size_t toRead) override
     {
-        return read(offset + 1, buf, toRead);
+        // Offsets are 1-based in Oracle
+        return read_from_start(buf, toRead, offset - 1);
     }
 
-    std::size_t write(std::size_t offset, char const *buf,
-        std::size_t toWrite) override;
+    std::size_t read_from_start(char * buf, std::size_t toRead, std::size_t offset = 0) override;
 
-    std::size_t write_from_start(const char * buf, std::size_t toWrite,
-        std::size_t offset) override
+    std::size_t write(std::size_t offset, char const *buf, std::size_t toWrite) override
     {
-        return write(offset + 1, buf, toWrite);
+        // Offsets are 1-based in Oracle
+        return write_from_start(buf, toWrite, offset - 1);
     }
+
+    std::size_t write_from_start(const char * buf, std::size_t toWrite, std::size_t offset = 0) override;
 
     std::size_t append(char const *buf, std::size_t toWrite) override;
 
@@ -453,7 +451,7 @@ struct oracle_session_backend : details::session_backend
 
 struct oracle_backend_factory : backend_factory
 {
-	  oracle_backend_factory() {}
+      oracle_backend_factory() {}
     oracle_session_backend * make_session(
         connection_parameters const & parameters) const override;
 };

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -266,6 +266,7 @@ struct oracle_blob_backend : details::blob_backend
 
     std::size_t get_len() override;
 
+    [[deprecated("Use read_from_start instead")]]
     std::size_t read(std::size_t offset, char *buf, std::size_t toRead) override
     {
         // Offsets are 1-based in Oracle
@@ -274,6 +275,7 @@ struct oracle_blob_backend : details::blob_backend
 
     std::size_t read_from_start(char * buf, std::size_t toRead, std::size_t offset = 0) override;
 
+    [[deprecated("Use write_from_start instead")]]
     std::size_t write(std::size_t offset, char const *buf, std::size_t toWrite) override
     {
         // Offsets are 1-based in Oracle

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -328,23 +328,9 @@ struct postgresql_blob_backend : details::blob_backend
 
     std::size_t get_len() override;
 
-    std::size_t read(std::size_t offset, char * buf,
-        std::size_t toRead) override;
+    std::size_t read_from_start(char * buf, std::size_t toRead, std::size_t offset = 0) override;
 
-    std::size_t read_from_start(char * buf, std::size_t toRead,
-        std::size_t offset) override
-    {
-        return read(offset, buf, toRead);
-    }
-
-    std::size_t write(std::size_t offset, char const * buf,
-        std::size_t toWrite) override;
-
-    std::size_t write_from_start(const char * buf, std::size_t toWrite,
-        std::size_t offset) override
-    {
-        return write(offset, buf, toWrite);
-    }
+    std::size_t write_from_start(const char * buf, std::size_t toWrite, std::size_t offset = 0) override;
 
     std::size_t append(char const * buf, std::size_t toWrite) override;
 

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -227,23 +227,13 @@ public:
 
     virtual std::size_t get_len() = 0;
 
-    virtual std::size_t read(std::size_t offset, char* buf,
-        std::size_t toRead) = 0;
+    virtual std::size_t read(std::size_t offset, char* buf, std::size_t toRead) { return read_from_start(buf, toRead, offset); }
 
-    virtual std::size_t read_from_start(char * /* buf */, std::size_t /* toRead */,
-        std::size_t /* offset */)
-    {
-        throw soci_error("read_from_start is not implemented for this backend");
-    }
+    virtual std::size_t read_from_start(char* buf, std::size_t toRead, std::size_t offset) = 0;
 
-    virtual std::size_t write(std::size_t offset, char const* buf,
-        std::size_t toWrite) = 0;
+    virtual std::size_t write(std::size_t offset, char const* buf, std::size_t toWrite) { return write_from_start(buf, toWrite, offset); }
 
-    virtual std::size_t write_from_start(const char * /* buf */, std::size_t /* toWrite */,
-        std::size_t /* offset */)
-    {
-        throw soci_error("write_from_start is not implemented for this backend");
-    }
+    virtual std::size_t write_from_start(const char* buf, std::size_t toWrite, std::size_t offset) = 0;
 
     virtual std::size_t append(char const* buf, std::size_t toWrite) = 0;
 

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -227,10 +227,12 @@ public:
 
     virtual std::size_t get_len() = 0;
 
+    [[deprecated("Use read_from_start instead")]]
     virtual std::size_t read(std::size_t offset, char* buf, std::size_t toRead) { return read_from_start(buf, toRead, offset); }
 
     virtual std::size_t read_from_start(char* buf, std::size_t toRead, std::size_t offset) = 0;
 
+    [[deprecated("Use write_from_start instead")]]
     virtual std::size_t write(std::size_t offset, char const* buf, std::size_t toWrite) { return write_from_start(buf, toWrite, offset); }
 
     virtual std::size_t write_from_start(const char* buf, std::size_t toWrite, std::size_t offset) = 0;

--- a/include/soci/soci-platform.h
+++ b/include/soci/soci-platform.h
@@ -115,6 +115,31 @@ namespace std {
     #endif
 #endif
 
+// Define SOCI_ALLOW_DEPRECATED_BEGIN and SOCI_ALLOW_DEPRECATED_END
+// Ref.: https://www.fluentcpp.com/2019/08/30/how-to-disable-a-warning-in-cpp/
+#if defined(__GNUC__) || defined(__clang__)
+# define SOCI_ALLOW_DEPRECATED_BEGIN \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated\"") \
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+# define SOCI_ALLOW_DEPRECATED_END \
+    _Pragma("GCC diagnostic pop")
+#elif defined(_MSC_VER)
+# define SOCI_ALLOW_DEPRECATED_BEGIN \
+    __pragma(warning(push)) \
+    __pragma(warning(disable: 4973 )) \
+    __pragma(warning(disable: 4974 )) \
+    __pragma(warning(disable: 4995 )) \
+    __pragma(warning(disable: 4996 ))
+# define SOCI_ALLOW_DEPRECATED_END \
+    __pragma(warning(pop))
+# define SOCI_DONT_WARN(statement) statement
+#else
+# pragma message("WARNING: SOCI_ALLOW_DEPRECATED_* not available for this compilet")
+# define SOCI_ALLOW_DEPRECATED_BEGIN
+# define SOCI_ALLOW_DEPRECATED_END
+#endif
+
 #define SOCI_NOT_ASSIGNABLE(classname) \
 public: \
     classname(const classname&) = default; \

--- a/include/soci/soci-simple.h
+++ b/include/soci/soci-simple.h
@@ -37,7 +37,9 @@ SOCI_DECL void soci_destroy_blob(blob_handle b);
 
 SOCI_DECL int soci_blob_get_len(blob_handle b);
 SOCI_DECL int soci_blob_read(blob_handle b, int offset, char *buf, int toRead);
+SOCI_DECL int soci_blob_read_from_start(blob_handle b, char *buf, int toRead, int offset = 0);
 SOCI_DECL int soci_blob_write(blob_handle b, int offset, char const *buf, int toWrite);
+SOCI_DECL int soci_blob_write_from_start(blob_handle b, char const *buf, int toWrite, int offset = 0);
 SOCI_DECL int soci_blob_append(blob_handle b, char const *buf, int toWrite);
 SOCI_DECL int soci_blob_trim(blob_handle b, int newLen);
 

--- a/include/soci/soci-simple.h
+++ b/include/soci/soci-simple.h
@@ -36,8 +36,10 @@ SOCI_DECL blob_handle soci_create_blob(session_handle s);
 SOCI_DECL void soci_destroy_blob(blob_handle b);
 
 SOCI_DECL int soci_blob_get_len(blob_handle b);
+[[deprecated("Use soci_blob_read_from_start instead")]]
 SOCI_DECL int soci_blob_read(blob_handle b, int offset, char *buf, int toRead);
 SOCI_DECL int soci_blob_read_from_start(blob_handle b, char *buf, int toRead, int offset = 0);
+[[deprecated("Use soci_blob_write_from_start instead")]]
 SOCI_DECL int soci_blob_write(blob_handle b, int offset, char const *buf, int toWrite);
 SOCI_DECL int soci_blob_write_from_start(blob_handle b, char const *buf, int toWrite, int offset = 0);
 SOCI_DECL int soci_blob_append(blob_handle b, char const *buf, int toWrite);

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -256,16 +256,19 @@ struct sqlite3_blob_backend : details::blob_backend
     ~sqlite3_blob_backend() override;
 
     std::size_t get_len() override;
-    std::size_t read(std::size_t offset, char *buf,
-                             std::size_t toRead) override;
-    std::size_t write(std::size_t offset, char const *buf,
-                              std::size_t toWrite) override;
+
+    std::size_t read_from_start(char * buf, std::size_t toRead, std::size_t offset = 0) override;
+
+    std::size_t write_from_start(const char * buf, std::size_t toWrite, std::size_t offset = 0) override;
+
     std::size_t append(char const *buf, std::size_t toWrite) override;
+
     void trim(std::size_t newLen) override;
 
     sqlite3_session_backend &session_;
 
     std::size_t set_data(char const *buf, std::size_t toWrite);
+
     const char *get_buffer() const { return buf_; }
 
 private:

--- a/src/backends/db2/blob.cpp
+++ b/src/backends/db2/blob.cpp
@@ -34,16 +34,13 @@ std::size_t db2_blob_backend::get_len()
     return 0;
 }
 
-std::size_t db2_blob_backend::read(
-    std::size_t /* offset */, char * /* buf */, std::size_t /* toRead */)
+std::size_t db2_blob_backend::read_from_start(char * /* buf */, std::size_t /* toRead */, std::size_t /* offset */)
 {
     // ...
     return 0;
 }
 
-std::size_t db2_blob_backend::write(
-    std::size_t /* offset */, char const * /* buf */,
-    std::size_t /* toWrite */)
+std::size_t db2_blob_backend::write_from_start(char const * /* buf */, std::size_t /* toWrite */, std::size_t /* offset */)
 {
     // ...
     return 0;

--- a/src/backends/db2/blob.cpp
+++ b/src/backends/db2/blob.cpp
@@ -10,7 +10,7 @@
 #include "soci/db2/soci-db2.h"
 
 #ifdef _MSC_VER
-#pragma warning(disable:4355)
+# pragma warning(disable:4355 4702)
 #endif
 
 using namespace soci;
@@ -20,40 +20,39 @@ using namespace soci::details;
 db2_blob_backend::db2_blob_backend(db2_session_backend &session)
     : session_(session)
 {
-    // ...
+    throw soci_error("BLOBs are not supported.");
 }
 
 db2_blob_backend::~db2_blob_backend()
 {
-    // ...
 }
 
 std::size_t db2_blob_backend::get_len()
 {
-    // ...
-    return 0;
+    throw soci_error("BLOBs are not supported.");
 }
 
 std::size_t db2_blob_backend::read_from_start(char * /* buf */, std::size_t /* toRead */, std::size_t /* offset */)
 {
-    // ...
-    return 0;
+    throw soci_error("BLOBs are not supported.");
 }
 
 std::size_t db2_blob_backend::write_from_start(char const * /* buf */, std::size_t /* toWrite */, std::size_t /* offset */)
 {
-    // ...
-    return 0;
+    throw soci_error("BLOBs are not supported.");
 }
 
 std::size_t db2_blob_backend::append(
     char const * /* buf */, std::size_t /* toWrite */)
 {
-    // ...
-    return 0;
+    throw soci_error("BLOBs are not supported.");
 }
 
 void db2_blob_backend::trim(std::size_t /* newLen */)
 {
-    // ...
+    throw soci_error("BLOBs are not supported.");
 }
+
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif

--- a/src/backends/empty/blob.cpp
+++ b/src/backends/empty/blob.cpp
@@ -33,16 +33,13 @@ std::size_t empty_blob_backend::get_len()
     return 0;
 }
 
-std::size_t empty_blob_backend::read(
-    std::size_t /* offset */, char * /* buf */, std::size_t /* toRead */)
+std::size_t empty_blob_backend::read_from_start(char * /* buf */, std::size_t /* toRead */, std::size_t /* offset */)
 {
     // ...
     return 0;
 }
 
-std::size_t empty_blob_backend::write(
-    std::size_t /* offset */, char const * /* buf */,
-    std::size_t /* toWrite */)
+std::size_t empty_blob_backend::write_from_start(char const * /* buf */, std::size_t /* toWrite */, std::size_t /* offset */)
 {
     // ...
     return 0;

--- a/src/backends/empty/blob.cpp
+++ b/src/backends/empty/blob.cpp
@@ -9,7 +9,8 @@
 #include "soci/empty/soci-empty.h"
 
 #ifdef _MSC_VER
-#pragma warning(disable:4355)
+# pragma warning(push)
+# pragma warning(disable:4355 4702)
 #endif
 
 using namespace soci;
@@ -19,40 +20,39 @@ using namespace soci::details;
 empty_blob_backend::empty_blob_backend(empty_session_backend &session)
     : session_(session)
 {
-    // ...
+    throw soci_error("BLOBs are not supported.");
 }
 
 empty_blob_backend::~empty_blob_backend()
 {
-    // ...
 }
 
 std::size_t empty_blob_backend::get_len()
 {
-    // ...
-    return 0;
+    throw soci_error("BLOBs are not supported.");
 }
 
 std::size_t empty_blob_backend::read_from_start(char * /* buf */, std::size_t /* toRead */, std::size_t /* offset */)
 {
-    // ...
-    return 0;
+    throw soci_error("BLOBs are not supported.");
 }
 
 std::size_t empty_blob_backend::write_from_start(char const * /* buf */, std::size_t /* toWrite */, std::size_t /* offset */)
 {
-    // ...
-    return 0;
+    throw soci_error("BLOBs are not supported.");
 }
 
 std::size_t empty_blob_backend::append(
     char const * /* buf */, std::size_t /* toWrite */)
 {
-    // ...
-    return 0;
+    throw soci_error("BLOBs are not supported.");
 }
 
 void empty_blob_backend::trim(std::size_t /* newLen */)
 {
-    // ...
+    throw soci_error("BLOBs are not supported.");
 }
+
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif

--- a/src/backends/firebird/blob.cpp
+++ b/src/backends/firebird/blob.cpp
@@ -32,8 +32,7 @@ std::size_t firebird_blob_backend::get_len()
     return data_.size();
 }
 
-std::size_t firebird_blob_backend::read(
-    std::size_t offset, char * buf, std::size_t toRead)
+std::size_t firebird_blob_backend::read_from_start(char * buf, std::size_t toRead, std::size_t offset)
 {
     if (from_db_ && (loaded_ == false))
     {
@@ -62,8 +61,7 @@ std::size_t firebird_blob_backend::read(
     return limit;
 }
 
-std::size_t firebird_blob_backend::write(std::size_t offset, char const * buf,
-                                       std::size_t toWrite)
+std::size_t firebird_blob_backend::write_from_start(char const * buf, std::size_t toWrite, std::size_t offset)
 {
     if (from_db_ && (loaded_ == false))
     {

--- a/src/backends/firebird/common.cpp
+++ b/src/backends/firebird/common.cpp
@@ -233,7 +233,7 @@ void copy_from_blob(firebird_statement_backend &st, char *buf, std::string &out)
     std::size_t const len_total = blob.get_len();
     out.resize(len_total);
 
-    std::size_t const len_read = blob.read(0, &out[0], len_total);
+    std::size_t const len_read = blob.read_from_start(&out[0], len_total);
     if (len_read != len_total)
     {
         std::ostringstream os;

--- a/src/backends/mysql/blob.cpp
+++ b/src/backends/mysql/blob.cpp
@@ -33,15 +33,12 @@ std::size_t mysql_blob_backend::get_len()
     throw soci_error("BLOBs are not supported.");
 }
 
-std::size_t mysql_blob_backend::read(
-    std::size_t /* offset */, char * /* buf */, std::size_t /* toRead */)
+std::size_t mysql_blob_backend::read_from_start(char * /* buf */, std::size_t /* toRead */, std::size_t /* offset */)
 {
     throw soci_error("BLOBs are not supported.");
 }
 
-std::size_t mysql_blob_backend::write(
-    std::size_t /* offset */, char const * /* buf */,
-    std::size_t /* toWrite */)
+std::size_t mysql_blob_backend::write_from_start(char const * /* buf */, std::size_t /* toWrite */, std::size_t /* offset */)
 {
     throw soci_error("BLOBs are not supported.");
 }

--- a/src/backends/odbc/blob.cpp
+++ b/src/backends/odbc/blob.cpp
@@ -8,6 +8,11 @@
 #define SOCI_ODBC_SOURCE
 #include "soci/odbc/soci-odbc.h"
 
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable:4702)
+#endif
+
 using namespace soci;
 using namespace soci::details;
 
@@ -15,40 +20,39 @@ using namespace soci::details;
 odbc_blob_backend::odbc_blob_backend(odbc_session_backend &session)
     : session_(session)
 {
-    // ...
+    throw soci_error("BLOBs are not supported.");
 }
 
 odbc_blob_backend::~odbc_blob_backend()
 {
-    // ...
 }
 
 std::size_t odbc_blob_backend::get_len()
 {
-    // ...
-    return 0;
+    throw soci_error("BLOBs are not supported.");
 }
 
 std::size_t odbc_blob_backend::read_from_start(char * /* buf */, std::size_t /* toRead */, std::size_t /* offset */)
 {
-    // ...
-    return 0;
+    throw soci_error("BLOBs are not supported.");
 }
 
 std::size_t odbc_blob_backend::write_from_start(char const * /* buf */, std::size_t /* toWrite */, std::size_t /* offset */)
 {
-    // ...
-    return 0;
+    throw soci_error("BLOBs are not supported.");
 }
 
 std::size_t odbc_blob_backend::append(
     char const * /* buf */, std::size_t /* toWrite */)
 {
-    // ...
-    return 0;
+    throw soci_error("BLOBs are not supported.");
 }
 
 void odbc_blob_backend::trim(std::size_t /* newLen */)
 {
-    // ...
+    throw soci_error("BLOBs are not supported.");
 }
+
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif

--- a/src/backends/odbc/blob.cpp
+++ b/src/backends/odbc/blob.cpp
@@ -29,16 +29,13 @@ std::size_t odbc_blob_backend::get_len()
     return 0;
 }
 
-std::size_t odbc_blob_backend::read(
-    std::size_t /* offset */, char * /* buf */, std::size_t /* toRead */)
+std::size_t odbc_blob_backend::read_from_start(char * /* buf */, std::size_t /* toRead */, std::size_t /* offset */)
 {
     // ...
     return 0;
 }
 
-std::size_t odbc_blob_backend::write(
-    std::size_t /* offset */, char const * /* buf */,
-    std::size_t /* toWrite */)
+std::size_t odbc_blob_backend::write_from_start(char const * /* buf */, std::size_t /* toWrite */, std::size_t /* offset */)
 {
     // ...
     return 0;

--- a/src/backends/oracle/blob.cpp
+++ b/src/backends/oracle/blob.cpp
@@ -53,13 +53,12 @@ std::size_t oracle_blob_backend::get_len()
     return static_cast<std::size_t>(len);
 }
 
-std::size_t oracle_blob_backend::read(
-    std::size_t offset, char *buf, std::size_t toRead)
+std::size_t oracle_blob_backend::read_from_start(char *buf, std::size_t toRead, std::size_t offset)
 {
     ub4 amt = static_cast<ub4>(toRead);
 
     sword res = OCILobRead(session_.svchp_, session_.errhp_, lobp_, &amt,
-        static_cast<ub4>(offset), reinterpret_cast<dvoid*>(buf),
+        static_cast<ub4>(offset + 1), reinterpret_cast<dvoid*>(buf),
         amt, 0, 0, 0, 0);
     if (res != OCI_SUCCESS)
     {
@@ -69,13 +68,12 @@ std::size_t oracle_blob_backend::read(
     return static_cast<std::size_t>(amt);
 }
 
-std::size_t oracle_blob_backend::write(
-    std::size_t offset, char const *buf, std::size_t toWrite)
+std::size_t oracle_blob_backend::write_from_start(char const *buf, std::size_t toWrite, std::size_t offset)
 {
     ub4 amt = static_cast<ub4>(toWrite);
 
     sword res = OCILobWrite(session_.svchp_, session_.errhp_, lobp_, &amt,
-        static_cast<ub4>(offset),
+        static_cast<ub4>(offset + 1),
         reinterpret_cast<dvoid*>(const_cast<char*>(buf)),
         amt, OCI_ONE_PIECE, 0, 0, 0, 0);
     if (res != OCI_SUCCESS)

--- a/src/backends/postgresql/blob.cpp
+++ b/src/backends/postgresql/blob.cpp
@@ -49,8 +49,7 @@ std::size_t postgresql_blob_backend::get_len()
     return static_cast<std::size_t>(pos);
 }
 
-std::size_t postgresql_blob_backend::read(
-    std::size_t offset, char * buf, std::size_t toRead)
+std::size_t postgresql_blob_backend::read_from_start(char * buf, std::size_t toRead, std::size_t offset)
 {
     int const pos = lo_lseek(session_.conn_, fd_,
         static_cast<int>(offset), SEEK_SET);
@@ -68,8 +67,7 @@ std::size_t postgresql_blob_backend::read(
     return static_cast<std::size_t>(readn);
 }
 
-std::size_t postgresql_blob_backend::write(
-    std::size_t offset, char const * buf, std::size_t toWrite)
+std::size_t postgresql_blob_backend::write_from_start(char const * buf, std::size_t toWrite, std::size_t offset)
 {
     int const pos = lo_lseek(session_.conn_, fd_,
         static_cast<int>(offset), SEEK_SET);

--- a/src/backends/sqlite3/blob.cpp
+++ b/src/backends/sqlite3/blob.cpp
@@ -33,8 +33,7 @@ std::size_t sqlite3_blob_backend::get_len()
     return len_;
 }
 
-std::size_t sqlite3_blob_backend::read(
-    std::size_t offset, char * buf, std::size_t toRead)
+std::size_t sqlite3_blob_backend::read_from_start(char * buf, std::size_t toRead, std::size_t offset)
 {
     size_t r = toRead;
 
@@ -51,9 +50,7 @@ std::size_t sqlite3_blob_backend::read(
 }
 
 
-std::size_t sqlite3_blob_backend::write(
-    std::size_t offset, char const * buf,
-    std::size_t toWrite)
+std::size_t sqlite3_blob_backend::write_from_start(char const * buf, std::size_t toWrite, std::size_t offset)
 {
     const char* oldBuf = buf_;
     std::size_t oldLen = len_;
@@ -114,5 +111,5 @@ std::size_t sqlite3_blob_backend::set_data(char const *buf, std::size_t toWrite)
         buf_ = 0;
         len_ = 0;
     }
-    return write(0, buf, toWrite);
+    return write_from_start(buf, toWrite);
 }

--- a/src/core/blob.cpp
+++ b/src/core/blob.cpp
@@ -8,6 +8,7 @@
 #define SOCI_SOURCE
 #include "soci/blob.h"
 #include "soci/session.h"
+#include "soci/soci-platform.h"
 
 #include <cstddef>
 
@@ -30,7 +31,9 @@ std::size_t blob::get_len()
 
 std::size_t blob::read(std::size_t offset, char *buf, std::size_t toRead)
 {
+    SOCI_ALLOW_DEPRECATED_BEGIN
     return backEnd_->read(offset, buf, toRead);
+    SOCI_ALLOW_DEPRECATED_END
 }
 
 std::size_t blob::read_from_start(char * buf, std::size_t toRead,
@@ -42,7 +45,9 @@ std::size_t blob::read_from_start(char * buf, std::size_t toRead,
 std::size_t blob::write(
     std::size_t offset, char const * buf, std::size_t toWrite)
 {
+    SOCI_ALLOW_DEPRECATED_BEGIN
     return backEnd_->write(offset, buf, toWrite);
+    SOCI_ALLOW_DEPRECATED_END
 }
 
 std::size_t blob::write_from_start(const char * buf, std::size_t toWrite,

--- a/src/core/soci-simple.cpp
+++ b/src/core/soci-simple.cpp
@@ -192,7 +192,9 @@ SOCI_DECL int soci_blob_read(blob_handle b, int offset, char *buf, int toRead)
     blob_wrapper *blob = static_cast<blob_wrapper *>(b);
     try
     {
+        SOCI_ALLOW_DEPRECATED_BEGIN
         return static_cast<int>(blob->blob_.read(offset, buf, toRead));
+        SOCI_ALLOW_DEPRECATED_END
     }
     catch (std::exception &e)
     {
@@ -234,7 +236,9 @@ SOCI_DECL int soci_blob_write(blob_handle b, int offset, char const *buf, int to
     blob_wrapper *blob = static_cast<blob_wrapper *>(b);
     try
     {
+        SOCI_ALLOW_DEPRECATED_BEGIN
         return static_cast<int>(blob->blob_.write(offset, buf, toWrite));
+        SOCI_ALLOW_DEPRECATED_END
     }
     catch (std::exception &e)
     {

--- a/src/core/soci-simple.cpp
+++ b/src/core/soci-simple.cpp
@@ -208,12 +208,54 @@ SOCI_DECL int soci_blob_read(blob_handle b, int offset, char *buf, int toRead)
     }
 }
 
+SOCI_DECL int soci_blob_read_from_start(blob_handle b, char *buf, int toRead, int offset)
+{
+    blob_wrapper *blob = static_cast<blob_wrapper *>(b);
+    try
+    {
+        return static_cast<int>(blob->blob_.read_from_start(buf, toRead, offset));
+    }
+    catch (std::exception &e)
+    {
+        blob->is_ok = false;
+        blob->error_message = e.what();
+        return -1;
+    }
+    catch (...)
+    {
+        blob->is_ok = false;
+        blob->error_message = "unknown exception";
+        return -1;
+    }
+}
+
 SOCI_DECL int soci_blob_write(blob_handle b, int offset, char const *buf, int toWrite)
 {
     blob_wrapper *blob = static_cast<blob_wrapper *>(b);
     try
     {
         return static_cast<int>(blob->blob_.write(offset, buf, toWrite));
+    }
+    catch (std::exception &e)
+    {
+        blob->is_ok = false;
+        blob->error_message = e.what();
+        return -1;
+    }
+    catch (...)
+    {
+        blob->is_ok = false;
+        blob->error_message = "unknown exception";
+        return -1;
+    }
+}
+
+SOCI_DECL int soci_blob_write_from_start(blob_handle b, char const *buf, int toWrite, int offset)
+{
+    blob_wrapper *blob = static_cast<blob_wrapper *>(b);
+    try
+    {
+        return static_cast<int>(blob->blob_.write_from_start(buf, toWrite, offset));
     }
     catch (std::exception &e)
     {

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -535,10 +535,10 @@ TEST_CASE("Firebird blobs", "[firebird][blob]")
         blob b(sql);
 
         char str1[] = "Hello";
-        b.write(0, str1, strlen(str1));
+        b.write_from_start(str1, strlen(str1));
 
         char str2[20];
-        std::size_t i = b.read(3, str2, 2);
+        std::size_t i = b.read_from_start(str2, 2, 3);
         str2[i] = '\0';
         CHECK(str2[0] == 'l');
         CHECK(str2[1] == 'o');
@@ -557,11 +557,11 @@ TEST_CASE("Firebird blobs", "[firebird][blob]")
         sql << "select img from test7 where id = 1", into(b);
 
         std::vector<char> text(b.get_len());
-        b.read(0, &text[0], b.get_len());
+        b.read_from_start(&text[0], b.get_len());
         CHECK(strncmp(&text[0], "Hello, Firebird!", b.get_len()) == 0);
 
         char str1[] = "FIREBIRD";
-        b.write(7, str1, strlen(str1));
+        b.write_from_start(str1, strlen(str1), 7);
 
         // after modification blob must be written to database
         sql << "update test7 set img=? where id=1", use(b);
@@ -574,12 +574,12 @@ TEST_CASE("Firebird blobs", "[firebird][blob]")
         sql << "select img from test7 where id = 1", into(b);
 
         std::vector<char> text(b.get_len());
-        b.read(0, &text[0], b.get_len());
+        b.read_from_start(&text[0], b.get_len());
 
         char str1[] = "HELLO";
-        b.write(0, str1, strlen(str1));
+        b.write_from_start(str1, strlen(str1));
 
-        b.read(0, &text[0], b.get_len());
+        b.read_from_start(&text[0], b.get_len());
         CHECK(strncmp(&text[0], "HELLO, FIREBIRD!", b.get_len()) == 0);
 
         b.trim(5);
@@ -594,12 +594,12 @@ TEST_CASE("Firebird blobs", "[firebird][blob]")
 
         st.fetch();
         std::vector<char> text(b.get_len());
-        b.read(0, &text[0], b.get_len());
+        b.read_from_start(&text[0], b.get_len());
         CHECK(strncmp(&text[0], "Hello, FIREBIRD!", b.get_len()) == 0);
 
         st.fetch();
         text.resize(b.get_len());
-        b.read(0, &text[0], b.get_len());
+        b.read_from_start(&text[0], b.get_len());
         CHECK(strncmp(&text[0], "HELLO", b.get_len()) == 0);
     }
 
@@ -621,7 +621,7 @@ TEST_CASE("Firebird blobs", "[firebird][blob]")
         const int blobSize = 65536; //max segment size is 65535(unsigned short)
         std::vector<char> data(blobSize);
         blob b(sql);
-        b.write(0, data.data(), blobSize);
+        b.write_from_start(data.data(), blobSize);
         sql << "insert into test7(id, img) values(3,?)", use(b);
 
         //now read blob back from database and make sure it has correct content and size
@@ -629,7 +629,7 @@ TEST_CASE("Firebird blobs", "[firebird][blob]")
         sql << "select img from test7 where id = 3", into(br);
         std::vector<char> data2(br.get_len());
         if(br.get_len()>0)
-            br.read(0, data2.data(), br.get_len());
+            br.read_from_start(data2.data(), br.get_len());
         CHECK(data == data2);
     }
 

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -285,7 +285,7 @@ TEST_CASE("SQLite blob", "[sqlite][blob]")
         sql << "select img from soci_test where id = 7", into(b);
         CHECK(b.get_len() == 0);
 
-        b.write(0, buf, sizeof(buf));
+        b.write_from_start(buf, sizeof(buf));
         CHECK(b.get_len() == sizeof(buf));
         sql << "update soci_test set img=? where id = 7", use(b);
 
@@ -298,7 +298,7 @@ TEST_CASE("SQLite blob", "[sqlite][blob]")
         sql << "select img from soci_test where id = 8", into(b);
         CHECK(b.get_len() == 2 * sizeof(buf));
         char buf2[100];
-        b.read(0, buf2, 10);
+        b.read_from_start(buf2, 10);
         CHECK(std::strncmp(buf2, "abcdefghij", 10) == 0);
 
         sql << "select img from soci_test where id = 7", into(b);


### PR DESCRIPTION
#508 added the functions `read_from_start` and `write_from_start` to the BLOB interface in order to work around the issue that the offsets in the plain `read` and `write` functions in the interface are backend-dependent (e.g. some start from 0 and some from 1).

However, that PR only implemented these functions for Postgresql and Oracle and for all other backends, the default implementation throws an exception stating that the function was not implemented/available.

Looking at existing test-cases involving read/write operations on BLOBs, I extracted the expected offset specification for a couple more backends and implemented the `read_from_start` and `write_from_start` functions accordingly.

Note: As I see it, these functions are now implemented for all backends that Soci supports BLOBs for in the first place.

TODO:
- [x] Make sure all test still pass (will have to use CI for that)
- [x] ~~Extend BLOB documentation to mention backend-specific offsets and that read/write from start is preferred (where available)~~ Current docs already covers everything