### PR TITLE
Make soci::row movable

### DIFF
--- a/include/soci/row.h
+++ b/include/soci/row.h
@@ -43,6 +43,9 @@ public:
     row();
     ~row();
 
+    row(row &&other) = default;
+    row &operator=(row &&other) = default;
+
     void uppercase_column_names(bool forceToUpper);
     void add_properties(column_properties const& cp);
     std::size_t size() const;

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -2469,6 +2469,16 @@ TEST_CASE_METHOD(common_tests, "Dynamic row binding", "[core][dynamic]")
 
         CHECK(r.get_properties(0).get_data_type() == dt_string);
         CHECK(r.get_properties(1).get_data_type() == dt_integer);
+
+        // Check if row object is movable
+        row moved = std::move(r);
+
+        CHECK(moved.size() == 2);
+        // We expect the moved-from row to become empty after the move operation
+        CHECK(r.size() == 0);
+
+        CHECK(moved.get_properties(0).get_data_type() == dt_string);
+        CHECK(moved.get_properties(1).get_data_type() == dt_integer);
     }
 }
 


### PR DESCRIPTION
Fixes #900

----

Note: I haven't actually verified that this fixes the linked issue. However, based on the comment in there that all that is needed was to make `soci::row` movable, this PR should indeed fix it.