### PR TITLE
soci::blob: Use unique_ptr 

### DIFF
--- a/include/soci/blob.h
+++ b/include/soci/blob.h
@@ -11,6 +11,7 @@
 #include "soci/soci-platform.h"
 // std
 #include <cstddef>
+#include <memory>
 
 namespace soci
 {
@@ -27,7 +28,10 @@ class SOCI_DECL blob
 {
 public:
     explicit blob(session & s);
-    ~blob();
+    ~blob() = default;
+
+    blob(blob &&other) = default;
+    blob &operator=(blob &&other) = default;
 
     std::size_t get_len();
 
@@ -50,10 +54,12 @@ public:
 
     void trim(std::size_t newLen);
 
-    details::blob_backend * get_backend() { return backEnd_; }
+    details::blob_backend * get_backend() { return backEnd_.get(); }
 
 private:
-    details::blob_backend * backEnd_;
+    SOCI_NOT_COPYABLE(blob)
+
+    std::unique_ptr<details::blob_backend> backEnd_;
 };
 
 } // namespace soci

--- a/src/core/blob.cpp
+++ b/src/core/blob.cpp
@@ -14,13 +14,8 @@
 using namespace soci;
 
 blob::blob(session & s)
+	: backEnd_{s.make_blob_backend()}
 {
-    backEnd_ = s.make_blob_backend();
-}
-
-blob::~blob()
-{
-    delete backEnd_;
 }
 
 std::size_t blob::get_len()


### PR DESCRIPTION
If a blob object was copied, on destruction a double-free would occur.

Fixes #957

Also make blobs movable in CXX11 or more recent