### PR TITLE
Restore a Win32 build on AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
       POSTGRESQL_ROOT: C:\Program Files\PostgreSQL\12
       MYSQL_DIR: C:\Program Files\MySql\MySQL Server 5.7
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    - G: "Visual Studio 15 2017 Win64"
+    - G: "Visual Studio 15 2017"
       BOOST_ROOT: C:\Libraries\boost_1_69_0
       MSSQL_VER: 2016
       POSTGRESQL_ROOT: C:\Program Files\PostgreSQL\11


### PR DESCRIPTION
The changes of 03af258a (Use more modern compiler versions for AppVeyor CI builds, 2022-09-18) made all AppVeyor CI builds 64 bits, but we still need to support 32 bit builds too, so change one of the build jobs to use 32 bits.