### PR TITLE
Include std::optional support automatically

### DIFF
--- a/include/soci/soci.h
+++ b/include/soci/soci.h
@@ -55,4 +55,9 @@
 #include "soci/boost-gregorian-date.h"
 #endif // SOCI_USE_BOOST
 
+// C++17
+#ifdef SOCI_HAVE_CXX17
+#include "soci/std-optional.h"
+#endif // SOCI_HAVE_CXX17
+
 #endif // SOCI_H_INCLUDED


### PR DESCRIPTION
This change automatically includes the `soci/std-optional.h` header file if the C++ standard is at least 17.

`std::optional` is more or less a "core feature" as of C++17 which in my opinion justifies auto-including this header. After all, similarly boost infrastructure is also included automatically (if present/enabled).