### PR TITLE
Fix for supporting enum types with rowset in Postgresql backend

### DIFF
--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -21,6 +21,7 @@
 #include "soci/connection-parameters.h"
 #include <libpq-fe.h>
 #include <vector>
+#include <unordered_map>
 
 namespace soci
 {
@@ -312,7 +313,7 @@ struct postgresql_statement_backend : details::statement_backend
 
     // the following map is used to keep the results of column
     // type queries with custom types
-    typedef std::map<unsigned long, char> CategoryByColumnOID;
+    typedef std::unordered_map<unsigned long, char> CategoryByColumnOID;
     CategoryByColumnOID categoryByColumnOID_;
 };
 

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -309,6 +309,11 @@ struct postgresql_statement_backend : details::statement_backend
 
     typedef std::map<std::string, char **> UseByNameBuffersMap;
     UseByNameBuffersMap useByNameBuffers_;
+
+    // the following map is used to keep the results of column
+    // type queries with custom types
+    typedef std::map<unsigned long, char> CategoryByColumnOID;
+    CategoryByColumnOID categoryByColumnOID_;
 };
 
 struct postgresql_rowid_backend : details::rowid_backend

--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -783,7 +783,7 @@ void postgresql_statement_backend::describe_column(int colNum, data_type & type,
     {
         int form = PQfformat(result_, pos);
         int size = PQfsize(result_, pos);
-        if (form == 0 && size == -1)
+        if (form == 0 && (size == -1 || size == 4))
         {
             type = dt_string;
         }

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -1155,6 +1155,8 @@ TEST_CASE("test_enum_with_explicit_custom_type_string_rowset", "[postgresql][bin
         s2.execute(true);
 
         type_value = result->get<TestStringEnum>("type");
+
+        delete result;
     }
 
     CHECK(type_value==TestStringEnum::VALUE_STR_2);
@@ -1233,6 +1235,8 @@ TEST_CASE("test_enum_with_explicit_custom_type_int_rowset", "[postgresql][bind-v
         s2.execute(true);
 
         type_value = result->get<TestIntEnum>("type");
+
+        delete result;
     }
 
     CHECK(type_value==TestIntEnum::VALUE_INT_2);

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -24,6 +24,90 @@ backend_factory const &backEnd = *soci::factory_postgresql();
 
 // Postgres-specific tests
 
+typedef enum {
+    VALUE_STR_1=0,
+    VALUE_STR_2,
+    VALUE_STR_3
+} TestStringEnum;
+
+typedef enum {
+    VALUE_INT_1=0,
+    VALUE_INT_2,
+    VALUE_INT_3
+} TestIntEnum;
+
+namespace soci {
+template <> struct type_conversion<TestStringEnum>
+{
+    typedef std::string base_type;
+    static void from_base(const std::string & v, indicator & ind, TestStringEnum & p)
+    {
+        if (ind == i_null)
+            throw soci_error("Null value not allowed for this type");
+
+        if( v.compare("A") == 0 )
+            p = TestStringEnum::VALUE_STR_1;
+        else if( v.compare("B") == 0 )
+            p = TestStringEnum::VALUE_STR_2;
+        else if( v.compare("C") == 0 )
+            p = TestStringEnum::VALUE_STR_3;
+        else
+            throw soci_error("Value not allowed for this type");
+    }
+    static void to_base(TestStringEnum & p, std::string & v, indicator & ind)
+    {
+        switch( p ) {
+        case TestStringEnum::VALUE_STR_1:
+            v = "A";
+            ind = i_ok;
+            return;
+        case TestStringEnum::VALUE_STR_2:
+            v = "B";
+            ind = i_ok;
+            return;
+        case TestStringEnum::VALUE_STR_3:
+            v = "C";
+            ind = i_ok;
+            return;
+        default:
+            throw soci_error("Value not allowed for this type");
+        }
+    }
+};
+
+template <> struct type_conversion<TestIntEnum>
+{
+    typedef int base_type;
+    static void from_base(const int & v, indicator & ind, TestIntEnum & p)
+    {
+        if (ind == i_null)
+            throw soci_error("Null value not allowed for this type");
+
+        switch( v ) {
+        case 0: case 1: case 2:
+            p = (TestIntEnum)v;
+            ind = i_ok;
+            return;
+        default:
+            throw soci_error("Null value not allowed for this type");
+        }
+    }
+    static void to_base(TestIntEnum & p, int & v, indicator & ind)
+    {
+        switch( p ) {
+        case TestIntEnum::VALUE_INT_1:
+        case TestIntEnum::VALUE_INT_2:
+        case TestIntEnum::VALUE_INT_3:
+            v = (int)p;
+            ind = i_ok;
+            return;
+        default:
+            throw soci_error("Value not allowed for this type");
+        }
+    }
+};
+}
+
 struct oid_table_creator : public table_creator_base
 {
     oid_table_creator(soci::session& sql)
@@ -1014,6 +1098,162 @@ TEST_CASE("false_bind_variable_inside_identifier", "[postgresql][bind-variables]
     CHECK(col_name.compare("column_with:colon") == 0);
     CHECK(fct_return_value == 2020);
     CHECK(type_value.compare("en_one")==0);
+}
+
+// test_enum_with_explicit_custom_type_string_rowset
+struct test_enum_with_explicit_custom_type_string_rowset : table_creator_base
+{
+    test_enum_with_explicit_custom_type_string_rowset(soci::session & sql)
+        : table_creator_base(sql)
+        , msession(sql)
+    {
+        try
+        {
+            sql << "CREATE TYPE EnumType AS ENUM ('A','B','C');";
+            sql << "CREATE TABLE soci_test (Type EnumType NOT NULL DEFAULT 'A');";
+        }
+        catch(...)
+        {
+            drop();
+        }
+
+    }
+    ~test_enum_with_explicit_custom_type_string_rowset(){
+        drop();
+    }
+private:
+    void drop()
+    {
+        try
+        {
+            msession << "drop table if exists soci_test;";
+            msession << "DROP TYPE IF EXISTS EnumType ;";
+        }
+        catch (soci_error const& e){
+            std::cerr << e.what() << std::endl;
+        }
+    }
+    soci::session& msession;
+};
+TEST_CASE("test_enum_with_explicit_custom_type_string_rowset", "[postgresql][bind-variables]")
+{
+    TestStringEnum test_value = TestStringEnum::VALUE_STR_2;
+    TestStringEnum type_value;
+
+    {
+        soci::session sql(backEnd, connectString);
+        test_enum_with_explicit_custom_type_string_rowset tableCreator(sql);
+
+        statement s1 = (sql.prepare << "insert into soci_test values(:val);", use(test_value, "val"));
+        statement s2 = (sql.prepare << "SELECT Type FROM soci_test;");
+
+        s1.execute(false);
+        
+        soci::row* result = new soci::row();
+        s2.define_and_bind();
+        s2.exchange_for_rowset(soci::into(*result));
+        s2.execute(true);
+
+        type_value = result->get<TestStringEnum>("type");
+    }
+
+    CHECK(type_value==TestStringEnum::VALUE_STR_2);
+}
+TEST_CASE("test_enum_with_explicit_custom_type_string_into", "[postgresql][bind-variables]")
+{
+    TestStringEnum test_value = TestStringEnum::VALUE_STR_2;
+    TestStringEnum type_value;
+
+    {
+        soci::session sql(backEnd, connectString);
+        test_enum_with_explicit_custom_type_string_rowset tableCreator(sql);
+
+        statement s1 = (sql.prepare << "insert into soci_test values(:val);", use(test_value, "val"));
+        statement s2 = (sql.prepare << "SELECT Type FROM soci_test;", into(type_value));
+
+        s1.execute(false);
+        s2.execute(true);
+    }
+
+    CHECK(type_value==TestStringEnum::VALUE_STR_2);
+}
+
+// test_enum_with_explicit_custom_type_int_rowset
+struct test_enum_with_explicit_custom_type_int_rowset : table_creator_base
+{
+    test_enum_with_explicit_custom_type_int_rowset(soci::session & sql)
+        : table_creator_base(sql)
+        , msession(sql)
+    {
+
+        try
+        {
+            sql << "CREATE TABLE soci_test( Type smallint)";
+            ;
+        }
+        catch(...)
+        {
+            drop();
+        }
+
+    }
+    ~test_enum_with_explicit_custom_type_int_rowset(){
+        drop();
+    }
+private:
+    void drop()
+    {
+        try
+        {
+            msession << "drop table if exists soci_test;";
+        }
+        catch (soci_error const& e){
+            std::cerr << e.what() << std::endl;
+        }
+    }
+    soci::session& msession;
+};
+TEST_CASE("test_enum_with_explicit_custom_type_int_rowset", "[postgresql][bind-variables]")
+{
+    TestIntEnum test_value = TestIntEnum::VALUE_INT_2;
+    TestIntEnum type_value;
+
+    {
+        soci::session sql(backEnd, connectString);
+        test_enum_with_explicit_custom_type_int_rowset tableCreator(sql);
+
+        statement s1 = (sql.prepare << "insert into soci_test(Type) values(:val)", use(test_value, "val"));
+        statement s2 = (sql.prepare << "SELECT Type FROM soci_test ;");
+
+        s1.execute(false);
+
+        soci::row* result = new soci::row();
+        s2.define_and_bind();
+        s2.exchange_for_rowset(soci::into(*result));
+        s2.execute(true);
+
+        type_value = result->get<TestIntEnum>("type");
+    }
+
+    CHECK(type_value==TestIntEnum::VALUE_INT_2);
+}
+TEST_CASE("test_enum_with_explicit_custom_type_int_into", "[postgresql][bind-variables]")
+{
+    TestIntEnum test_value = TestIntEnum::VALUE_INT_2;
+    TestIntEnum type_value;
+
+    {
+        soci::session sql(backEnd, connectString);
+        test_enum_with_explicit_custom_type_int_rowset tableCreator(sql);
+
+        statement s1 = (sql.prepare << "insert into soci_test(Type) values(:val)", use(test_value, "val"));
+        statement s2 = (sql.prepare << "SELECT Type FROM soci_test ;", into(type_value));
+
+        s1.execute(false);
+        s2.execute(true);
+    }
+
+    CHECK(type_value==TestIntEnum::VALUE_INT_2);
 }
 
 // false_bind_variable_inside_identifier


### PR DESCRIPTION
Hello everyone,
i've been develpoing a feature on a project called ZoneMinder which wants to introduce SOCI to support at this time the MySQL and Postgresql databases (https://github.com/ZoneMinder/zoneminder/pull/3644).

During development i've encountered an issue when combining the rowset and custom enum types features, when they are used together a strongly typed enum fails to be selected with error:
```
unknown data type with typelem: 104811 for colNum: 1 with name: type while
executing "SELECT Type FROM soci_test;"
```

This PR addresses that issue and i hope it is can be included in the main project, let me know if there is any improvement / change that would need to be addressed.
