### PR TITLE
Always initialize a variable to avoid -Wmaybe-uninitialized

### DIFF
--- a/include/soci/values.h
+++ b/include/soci/values.h
@@ -173,7 +173,7 @@ public:
             indicator * pind = new indicator(indic);
             indicators_.push_back(pind);
 
-            base_type baseValue;
+            base_type baseValue{};
             type_conversion<T>::to_base(value, baseValue, *pind);
 
             details::copy_holder<base_type> * pcopy =


### PR DESCRIPTION
This warning is sometimes given (e.g. when using optional<int>) and can't be easily suppressed from the application code, so ensure the variable is always initialized to avoid it.

Closes #1037.