### PR TITLE
add support of bulk operations for ORM in ORACLE and SQLite backends

### DIFF
--- a/include/soci/soci-platform.h
+++ b/include/soci/soci-platform.h
@@ -64,6 +64,8 @@ namespace std {
     }
 }
 #endif // _MSC_VER < 1800
+#define strncasecmp _strnicmp
+#define strcasecmp _stricmp
 #endif // _MSC_VER
 
 #if defined(__CYGWIN__) || defined(__MINGW32__)

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -60,6 +60,10 @@ private:
     int result_;
 };
 
+
+typedef std::map<std::string, data_type> sqlite3_data_type_map;
+sqlite3_data_type_map get_data_type_map();
+
 struct sqlite3_statement_backend;
 struct sqlite3_standard_into_type_backend : details::standard_into_type_backend
 {
@@ -84,6 +88,7 @@ struct sqlite3_standard_into_type_backend : details::standard_into_type_backend
     int position_;
 };
 
+struct sqlite3_column;
 struct sqlite3_vector_into_type_backend : details::vector_into_type_backend
 {
     sqlite3_vector_into_type_backend(sqlite3_statement_backend &st)
@@ -106,6 +111,10 @@ struct sqlite3_vector_into_type_backend : details::vector_into_type_backend
     void *data_;
     details::exchange_type type_;
     int position_;
+
+private:
+    data_type get_column_type(int colNum);
+    sqlite3_column get_column(int colNum);
 };
 
 struct sqlite3_standard_use_type_backend : details::standard_use_type_backend

--- a/include/soci/statement.h
+++ b/include/soci/statement.h
@@ -138,8 +138,9 @@ private:
     template<typename T>
     void into_row()
     {
-        T * t = new T();
-        indicator * ind = new indicator(i_ok);
+        std::size_t bulk_size = row_->bulk_size();
+        std::vector<T>* t = new std::vector<T>(bulk_size);
+        std::vector<indicator>* ind = new std::vector<indicator>(bulk_size);
         row_->add_holder(t, ind);
         exchange_for_row(into(*t, *ind));
     }

--- a/include/soci/type-conversion.h
+++ b/include/soci/type-conversion.h
@@ -38,7 +38,7 @@ struct base_value_holder
 
 // Automatically create into_type from a type_conversion
 
-template <typename T>
+template <typename T, typename X>
 class conversion_into_type
     : private base_value_holder<T>,
       public into_type<typename type_conversion<T>::base_type>
@@ -80,7 +80,7 @@ private:
 
 // Automatically create use_type from a type_conversion
 
-template <typename T>
+template <typename T, typename X>
 class conversion_use_type
     : private base_value_holder<T>,
       public use_type<typename type_conversion<T>::base_type>
@@ -195,8 +195,8 @@ struct base_vector_holder
 
 // Automatically create a std::vector based into_type from a type_conversion
 
-template <typename T>
-class conversion_into_type<std::vector<T> >
+template <typename T, typename X>
+class conversion_into_type<std::vector<T> , X>
     : private base_vector_holder<T>,
       public into_type<std::vector<typename type_conversion<T>::base_type> >
 {
@@ -295,8 +295,8 @@ private:
 
 // Automatically create a std::vector based use_type from a type_conversion
 
-template <typename T>
-class conversion_use_type<std::vector<T> >
+template <typename T, typename X>
+class conversion_use_type<std::vector<T>, X >
      : private base_vector_holder<T>,
        public use_type<std::vector<typename type_conversion<T>::base_type> >
 {
@@ -408,13 +408,19 @@ private:
 template <typename T>
 into_type_ptr do_into(T & t, user_type_tag)
 {
-    return into_type_ptr(new conversion_into_type<T>(t));
+    return into_type_ptr(new conversion_into_type<T, typename type_conversion<T>::base_type>(t));
+}
+
+template <typename T>
+into_type_ptr do_into(std::vector<T>& t, user_type_tag)
+{
+    return into_type_ptr(new conversion_into_type<std::vector<T>, typename type_conversion<T>::base_type>(t));
 }
 
 template <typename T>
 into_type_ptr do_into(T & t, indicator & ind, user_type_tag)
 {
-    return into_type_ptr(new conversion_into_type<T>(t, ind));
+    return into_type_ptr(new conversion_into_type<T, typename type_conversion<T>::base_type>(t, ind));
 }
 
 template <typename T>
@@ -422,14 +428,14 @@ into_type_ptr do_into(std::vector<T> & t,
     std::size_t begin, size_t * end, user_type_tag)
 {
     return into_type_ptr(
-        new conversion_into_type<std::vector<T> >(t, begin, end));
+        new conversion_into_type<std::vector<T> , typename type_conversion<T>::base_type>(t, begin, end));
 }
 
 template <typename T>
 into_type_ptr do_into(std::vector<T> & t, std::vector<indicator> & ind,
     user_type_tag)
 {
-    return into_type_ptr(new conversion_into_type<std::vector<T> >(t, ind));
+    return into_type_ptr(new conversion_into_type<std::vector<T> , typename type_conversion<T>::base_type>(t, ind));
 }
 
 template <typename T>
@@ -437,33 +443,33 @@ into_type_ptr do_into(std::vector<T> & t, std::vector<indicator> & ind,
     std::size_t begin, size_t * end, user_type_tag)
 {
     return into_type_ptr(
-        new conversion_into_type<std::vector<T> >(t, ind, begin, end));
+        new conversion_into_type<std::vector<T> , typename type_conversion<T>::base_type>(t, ind, begin, end));
 }
 
 template <typename T>
 use_type_ptr do_use(T & t, std::string const & name, user_type_tag)
 {
-    return use_type_ptr(new conversion_use_type<T>(t, name));
+    return use_type_ptr(new conversion_use_type<T, typename type_conversion<T>::base_type>(t, name));
 }
 
 template <typename T>
 use_type_ptr do_use(T const & t, std::string const & name, user_type_tag)
 {
-    return use_type_ptr(new conversion_use_type<T>(t, name));
+    return use_type_ptr(new conversion_use_type<T, typename type_conversion<T>::base_type>(t, name));
 }
 
 template <typename T>
 use_type_ptr do_use(T & t, indicator & ind,
     std::string const & name, user_type_tag)
 {
-    return use_type_ptr(new conversion_use_type<T>(t, ind, name));
+    return use_type_ptr(new conversion_use_type<T, typename type_conversion<T>::base_type>(t, ind, name));
 }
 
 template <typename T>
 use_type_ptr do_use(T const & t, indicator & ind,
     std::string const & name, user_type_tag)
 {
-    return use_type_ptr(new conversion_use_type<T>(t, ind, name));
+    return use_type_ptr(new conversion_use_type<T, typename type_conversion<T>::base_type>(t, ind, name));
 }
 
 template <typename T>
@@ -472,7 +478,7 @@ use_type_ptr do_use(std::vector<T> & t,
     std::string const & name, user_type_tag)
 {
     return use_type_ptr(
-        new conversion_use_type<std::vector<T> >(t, begin, end, name));
+        new conversion_use_type<std::vector<T> , typename type_conversion<T>::base_type>(t, begin, end, name));
 }
 
 template <typename T>
@@ -481,7 +487,7 @@ use_type_ptr do_use(const std::vector<T> & t,
     std::string const & name, user_type_tag)
 {
     return use_type_ptr(
-        new conversion_use_type<std::vector<T> >(t, begin, end, name));
+        new conversion_use_type<std::vector<T> , typename type_conversion<T>::base_type>(t, begin, end, name));
 }
 
 template <typename T>
@@ -490,7 +496,7 @@ use_type_ptr do_use(std::vector<T> & t, std::vector<indicator> & ind,
     std::string const & name, user_type_tag)
 {
     return use_type_ptr(
-        new conversion_use_type<std::vector<T> >(t, ind, begin, end, name));
+        new conversion_use_type<std::vector<T> , typename type_conversion<T>::base_type>(t, ind, begin, end, name));
 }
 
 template <typename T>
@@ -499,7 +505,7 @@ use_type_ptr do_use(const std::vector<T> & t, std::vector<indicator> & ind,
     std::string const & name, user_type_tag)
 {
     return use_type_ptr(
-        new conversion_use_type<std::vector<T> >(t, ind, begin, end, name));
+        new conversion_use_type<std::vector<T> , typename type_conversion<T>::base_type>(t, ind, begin, end, name));
 }
 
 } // namespace details

--- a/include/soci/type-holder.h
+++ b/include/soci/type-holder.h
@@ -12,12 +12,28 @@
 // std
 #include <cstring>
 #include <typeinfo>
+#include <vector>
 
 namespace soci
 {
 
 namespace details
 {
+
+// this class is for pass test [commontests.h, test12()],
+// otherwise the test will failed with undefined runtime error.
+// default:: any type convert is not allowed
+template <typename from, typename to>
+class convertible {
+public:
+    enum { ALLOW = 0 };
+};
+
+template <typename T>
+class convertible<T, T> {
+public:
+    enum { ALLOW = 1 };
+};
 
 // Returns U* as T*, if the dynamic type of the pointer is really T.
 //
@@ -47,21 +63,47 @@ T* checked_ptr_cast(U* ptr)
 // Base class holder + derived class type_holder for storing type data
 // instances in a container of holder objects
 template <typename T>
-class type_holder;
+class vector_type_holder;
 
-class holder
+class vector_holder
 {
 public:
-    holder() {}
-    virtual ~holder() {}
+    vector_holder() {}
+    virtual ~vector_holder() { }
 
     template<typename T>
-    T get()
+    T get(std::size_t pos)
     {
-        type_holder<T>* p = checked_ptr_cast<type_holder<T> >(this);
-        if (p)
+        // statement_impl::bind_into have those types::
+        // std::string, double, int, long long, unsigned long long, std::tm
+
+        // typeid() + static_cast is faster than dynamic_cast
+
+        const std::type_info& ti = this->type();
+
+        if (ti == typeid(int))
         {
-            return p->template value<T>();
+            return cast<int, T>(pos);
+        }
+        else if (ti == typeid(double))
+        {
+            return cast<double, T>(pos);
+        }
+        else if (ti == typeid(std::string))
+        {
+            return cast<std::string, T>(pos);
+        }
+        else if (ti == typeid(long long))
+        {
+            return cast<long long, T>(pos);
+        }
+        else if (ti == typeid(unsigned long long))
+        {
+            return cast<unsigned long long, T>(pos);
+        }
+        else if (ti == typeid(std::tm))
+        {
+            return cast<std::tm, T>(pos);
         }
         else
         {
@@ -69,25 +111,89 @@ public:
         }
     }
 
-private:
+    virtual const std::type_info& type() const = 0;
 
-    template<typename T>
-    T value();
+private:
+    template <typename Holder_T, typename T, std::size_t allow>
+    class ret
+    {
+    public:
+        static T return_value(const Holder_T& h)
+        {
+            return (T)h;
+        }
+    };
+
+    template <typename Holder_T, typename T>
+    class ret<Holder_T, T, 0> {
+    public:
+        static T return_value(const Holder_T&)
+        {
+            throw std::bad_cast();
+        }
+    };
+
+    template <typename Holder_T, typename T>
+    T cast(std::size_t pos)
+    {
+        vector_type_holder<Holder_T>* p = static_cast<vector_type_holder<Holder_T>*>(this);
+        Holder_T& h = p->template value<Holder_T>(pos);
+        return ret<Holder_T, T, convertible<Holder_T, T>::ALLOW>::return_value(h);
+    }
+
+    template <typename T>
+    T& value(std::size_t pos) const;
 };
 
 template <typename T>
-class type_holder : public holder
+class vector_type_holder : public vector_holder
 {
 public:
-    type_holder(T * t) : t_(t) {}
-    ~type_holder() override { delete t_; }
+    vector_type_holder(std::vector<T>* vec) : vec_(vec) {}
+    ~vector_type_holder() override { delete vec_; }
 
     template<typename TypeValue>
-    TypeValue value() const { return *t_; }
+    TypeValue& value(std::size_t pos) const { return (*vec_)[pos]; }
+
+    const std::type_info& type() const override { return typeid(T); }
 
 private:
-    T * t_;
+    std::vector<T>* vec_;
 };
+
+// partial convertible class
+#define CONVERTIBLE(T, R, yes_no) \
+    template <>                   \
+    class convertible<T, R>       \
+    {                             \
+    public:                       \
+        enum                      \
+        {                         \
+            ALLOW = yes_no        \
+        };                        \
+    }
+
+#define INTEGRAL_CONVERTIBLE(T)            \
+    CONVERTIBLE(T, bool, 1);               \
+    CONVERTIBLE(T, char, 1);               \
+    CONVERTIBLE(T, unsigned char, 1);      \
+    CONVERTIBLE(T, short, 1);              \
+    CONVERTIBLE(T, unsigned short, 1);     \
+    CONVERTIBLE(T, int, 1);                \
+    CONVERTIBLE(T, unsigned int, 1);       \
+    CONVERTIBLE(T, long, 1);               \
+    CONVERTIBLE(T, unsigned long, 1);      \
+    CONVERTIBLE(T, long long, 1);          \
+    CONVERTIBLE(T, unsigned long long, 1); \
+    CONVERTIBLE(T, float, 1);              \
+    CONVERTIBLE(T, double, 1);             \
+    CONVERTIBLE(T, long double, 1)
+
+// int, double, long long, unsigned long long
+INTEGRAL_CONVERTIBLE(int);
+INTEGRAL_CONVERTIBLE(double);
+INTEGRAL_CONVERTIBLE(long long);
+INTEGRAL_CONVERTIBLE(unsigned long long);
 
 } // namespace details
 

--- a/include/soci/values.h
+++ b/include/soci/values.h
@@ -47,6 +47,9 @@ class SOCI_DECL values
     friend class details::into_type<values>;
     friend class details::use_type<values>;
 
+    template <typename TT, typename X> 
+    friend class details::conversion_into_type;
+
 public:
 
     values() : row_(NULL), currentPos_(0), uppercaseColumnNames_(false) {}
@@ -243,7 +246,7 @@ private:
     std::vector<details::standard_use_type *> uses_;
     std::map<details::use_type_base *, indicator *> unused_;
     std::vector<indicator *> indicators_;
-    std::map<std::string, std::size_t> index_;
+    std::map<std::string, std::size_t, CaseInsensitiveComparator> index_;
     std::vector<details::copy_base *> deepCopies_;
 
     mutable std::size_t currentPos_;

--- a/src/backends/oracle/statement.cpp
+++ b/src/backends/oracle/statement.cpp
@@ -298,6 +298,11 @@ void oracle_statement_backend::describe_column(int colNum, data_type &type,
             {
                 type = dt_double;
             }
+        }        
+        //create table T(t number)--> select t+0 from T; we get: scale=precision=0, size=22
+        else if (dbscale == 0 && dbprec == 0 && dbsize == 22)
+        {
+            type = dt_double;
         }
         else if (dbprec <= std::numeric_limits<int>::digits10)
         {

--- a/src/core/row.cpp
+++ b/src/core/row.cpp
@@ -16,9 +16,11 @@
 using namespace soci;
 using namespace details;
 
-row::row()
+row::row(std::size_t bulk_size)
     : uppercaseColumnNames_(false)
     , currentPos_(0)
+    , bulk_pos_(0)
+    , bulk_size_(bulk_size)
 {}
 
 row::~row()
@@ -79,7 +81,7 @@ void row::clean_up()
 
 indicator row::get_indicator(std::size_t pos) const
 {
-    return *indicators_.at(pos);
+    return (*indicators_.at(pos))[bulk_pos_];
 }
 
 indicator row::get_indicator(std::string const &name) const

--- a/src/core/statement.cpp
+++ b/src/core/statement.cpp
@@ -520,6 +520,13 @@ bool statement_impl::resize_intos(std::size_t upperBound)
         intos_[i]->resize((std::size_t)rows);
     }
 
+    //for bulk ORM operations
+    std::size_t const ifrsize = intosForRow_.size();
+    for (std::size_t i = 0; i != ifrsize; ++i)
+    {
+        intosForRow_[i]->resize((std::size_t)rows);
+    }
+    
     return rows > 0 ? true : false;
 }
 

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -1524,6 +1524,87 @@ public:
     }
 };
 
+void test_orm_bulk()
+{
+    //session sql(backEndFactory_, connectString_);
+    //auto_table_creator tableCreator(tc_.table_creator_3(sql));
+    session sql(backEnd, connectString);
+    table_creator_three one(sql);
+
+    sql << "insert into soci_test values('john', '(404)123-4567')";
+    sql << "insert into soci_test values('doe', '(404)123-4567')";
+
+    std::vector<PhonebookEntry> vec_orm(10);
+    sql << "select * from soci_test", into(vec_orm);
+
+    assert(vec_orm.size() == 2);
+
+    for (std::vector<PhonebookEntry>::iterator it=vec_orm.begin();
+        it != vec_orm.end();
+        ++it
+        )
+    {
+        if (it->name == "john")
+        {
+            assert(it->phone == "(404)123-4567");
+        }
+        else if (it->name == "doe")
+        {
+            assert(it->phone == "(404)123-4567");
+        }
+    }
+
+    std::cout << "test ORM bulk select passed" << std::endl;
+}
+
+void test_convert()
+{
+    //session sql(backEndFactory_, connectString_);
+    //auto_table_creator tableCreator(tc_.table_creator_1(sql));
+
+    session sql(backEnd, connectString);
+    table_creator_one one(sql);
+
+    sql << "insert into soci_test(id, sh) values(1, 10.5)";
+
+    double d1, d2;
+    sql << "select sh+0, sh from soci_test", into(d1), into(d2);
+    assert(are_doubles_approx_equal(d1, d2));
+    assert(are_doubles_approx_equal(d1, 10.5));
+
+    soci::rowset<soci::row> rs1 = (
+        sql.prepare << "select sh+0.6 sh_0, sh from soci_test");
+
+    soci::rowset<soci::row>::const_iterator it1 = rs1.begin();
+    soci::row const & row1 = *it1;
+
+    {
+        int i;
+        i = row1.get<int>(0);
+        assert(i == 11);
+        i = row1.get<int>(1);
+        assert(i == 10);
+    }
+
+    {
+        double i;
+        i = row1.get<double>(0);
+        assert(are_doubles_approx_equal(i, 11.1));
+        i = row1.get<double>(1);
+        assert(are_doubles_approx_equal(i, 10.5));
+    }
+
+    {
+        float i;
+        i = row1.get<float>(0);
+        assert(are_doubles_approx_equal(i, 11.1f));
+        i = row1.get<float>(1);
+        assert(are_doubles_approx_equal(i, 10.5f));
+    }
+
+    std::cout << "test convert passed" << std::endl;
+}
+
 int main(int argc, char** argv)
 {
 #ifdef _MSC_VER


### PR DESCRIPTION
Hello everyone,

I am excited to submit this pull request, which (re)introduces support for bulk operations in the SOCI library's ORM (Object-Relational Mapping) functionality. This work is based on the initial [groundwork](https://github.com/SOCI/soci/pull/168) laid by @abc100m, and I have built upon their contributions to enhance the capabilities of the library.

I would appreciate it if the community could review and provide feedback on the changes. Your insights and suggestions are valuable in ensuring the quality and effectiveness of this new feature.

Thank you for your attention and consideration. I look forward to collaborating with you all to further enhance the SOCI library.

Best regards,
Aleksey