### PR TITLE
Patch for issue #1058

### DIFF
--- a/src/core/statement.cpp
+++ b/src/core/statement.cpp
@@ -173,6 +173,7 @@ void statement_impl::bind_clean_up()
         delete indicators_[i];
         indicators_[i] = NULL;
     }
+    indicators_.clear();
 
     row_ = NULL;
     alreadyDescribed_ = false;


### PR DESCRIPTION
This small patch assures that the indicators_ vector is cleared after its content is deleted in bind_clean_up().
If this is not done the indicators_ vector grows indefinitely as it caches the deleted and NULLed indicators.
See issue #1058 for more explanation/comments.