### PR TITLE
Switch FreeBSD CI builds to 13.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,7 +18,7 @@ task:
       env:
         SOCI_CI_BACKEND: sqlite3
   freebsd_instance:
-    image_family: freebsd-13-0
+    image_family: freebsd-13-2
   install_script: ./scripts/ci/install.sh
   before_build_script: ./scripts/ci/before_build.sh
   build_script: ./scripts/ci/build.sh


### PR DESCRIPTION
The builds using 13.0 fail with weird libc dependency errors:

ld-elf.so.1: /lib/libc.so.7: version FBSD_1.7 required by /usr/local/lib/libuv.so.1 not found
