### PR TITLE
Delete soci::use for rvalues to prevent accidental stack-use-after-scope

### DIFF
--- a/include/soci/use.h
+++ b/include/soci/use.h
@@ -46,6 +46,13 @@ private:
 
 } // namespace details
 
+// soci::use is deleted for rvalues because it will likely lead to subtle stack-use-after-scope bugs.
+template <typename T>
+details::use_container<T, details::no_indicator> use(T &&t, const std::string &name = std::string()) = delete;
+
+template <typename T>
+details::use_container<const T, indicator> use(T &&t, indicator & ind, std::string const &name = std::string()) = delete;
+
 template <typename T>
 details::use_container<T, details::no_indicator> use(T &t, const std::string &name = std::string())
 { return details::use_container<T, details::no_indicator>(t, name); }

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -1028,8 +1028,8 @@ TEST_CASE("Oracle to_number with rowset", "[oracle][rowset][to_number]")
         rs = (sql.prepare << "select to_number('123456789012345') from dual");
     double d = rs.begin()->get<double>(0);
     ASSERT_EQUAL_EXACT(d, 123456789012345);
-
-    rs = (sql.prepare << "select to_number(:t) from dual", use(3.14));
+    const double pi = 3.14;
+    rs = (sql.prepare << "select to_number(:t) from dual", use(pi));
     d = rs.begin()->get<double>(0);
     ASSERT_EQUAL_EXACT(d, 3.14);
 }


### PR DESCRIPTION
https://github.com/SOCI/soci/issues/1070

This would break compilation of code that currently has subtle stack-use-after-scope bugs.