### PR TITLE
Add support for Network address types for PostgreSQL

### DIFF
--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -766,6 +766,8 @@ void postgresql_statement_backend::describe_column(int colNum, data_type & type,
     case 2950: // uuid
     case 829:  // macaddr
     case 869:  // inet
+    case 650:  // cidr
+    case 774:  // macaddr8
         type = dt_string;
         break;
 

--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -764,6 +764,8 @@ void postgresql_statement_backend::describe_column(int colNum, data_type & type,
     case 114:  // json
     case 17:   // bytea
     case 2950: // uuid
+    case 829:  // macaddr
+    case 869:  // inet
         type = dt_string;
         break;
 
@@ -826,6 +828,7 @@ void postgresql_statement_backend::describe_column(int colNum, data_type & type,
             case 'T': // time type
             case 'S': // string type
             case 'U': // user type
+            case 'I': // network address type
                 type = dt_string;
                 break;
 


### PR DESCRIPTION
Hello, 
I noticed a missing support for Network address types for PostgreSQL. I added the support and they are returned s strings. 