### PR TITLE
Disallowing constructing rowset from a session

### DIFF
--- a/include/soci/rowset.h
+++ b/include/soci/rowset.h
@@ -182,6 +182,8 @@ public:
         pimpl_->incRef();
     }
 
+    rowset(session const & session) = delete;
+
     ~rowset()
     {
         pimpl_->decRef();


### PR DESCRIPTION
After discussion on #1081 it was decided to explicitly disallow the implicit constructor `rowset(soci::session const & session)`.