### PR TITLE
Creating empty constructor for rowset

### DIFF
--- a/include/soci/rowset.h
+++ b/include/soci/rowset.h
@@ -113,6 +113,11 @@ public:
 
     typedef rowset_iterator<T> iterator;
 
+    rowset_impl()
+        : refs_(1), st_(nullptr), define_(nullptr)
+    {
+    }
+
     rowset_impl(details::prepare_temp_type const & prep)
         : refs_(1), st_(new statement(prep)), define_(new T())
     {
@@ -135,8 +140,8 @@ public:
 
     iterator begin() const
     {
-        // No ownership transfer occurs here
-        return iterator(*st_, *define_);
+        // No ownership transfer occurs here. Empty rowset doesn't have any valid begin iterator.
+        return st_ ? iterator(*st_, *define_) : iterator();
     }
 
     iterator end() const
@@ -180,6 +185,11 @@ public:
         : pimpl_(other.pimpl_)
     {
         pimpl_->incRef();
+    }
+
+    rowset()
+       : pimpl_(new details::rowset_impl<T>())
+    {
     }
 
     // Due to the existence of conversion from session to prepare_temp_type, it

--- a/include/soci/rowset.h
+++ b/include/soci/rowset.h
@@ -214,6 +214,11 @@ public:
         return *this;
     }
 
+    void clear()
+    {
+        *this = rowset();
+    }
+
     const_iterator begin() const
     {
         return pimpl_->begin();

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -2945,6 +2945,12 @@ TEST_CASE_METHOD(common_tests, "Rowset iteration", "[core][rowset]")
 
             CHECK(5 == std::distance(rs.begin(), rs.end()));
         }
+        {
+            rowset<row> rs = (sql.prepare << "select * from soci_test");
+
+            rs.clear();
+            CHECK(rs.begin() == rs.end());
+        }
     }
 
 }

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -2889,6 +2889,11 @@ TEST_CASE_METHOD(common_tests, "Rowset creation and copying", "[core][rowset]")
     auto_table_creator tableCreator(tc_.table_creator_1(sql));
     {
         // Open empty rowset
+	rowset<row> rs1;
+	CHECK(rs1.begin() == rs1.end());
+    }
+    {
+        // Load empty rowset
         rowset<row> rs1 = (sql.prepare << "select * from soci_test");
         CHECK(rs1.begin() == rs1.end());
     }
@@ -2909,7 +2914,7 @@ TEST_CASE_METHOD(common_tests, "Rowset creation and copying", "[core][rowset]")
     if (!tc_.has_multiple_select_bug())
     {
         // Assignment
-        rowset<row> rs1 = (sql.prepare << "select * from soci_test");
+        rowset<row> rs1;
         rowset<row> rs2 = (sql.prepare << "select * from soci_test");
         rowset<row> rs3 = (sql.prepare << "select * from soci_test");
         rs1 = rs2;


### PR DESCRIPTION
This PR allows the creation of an empty `rowset` as per #1057