### PR TITLE
make session and connection_parameters movable.

### DIFF
--- a/include/soci/connection-parameters.h
+++ b/include/soci/connection-parameters.h
@@ -39,7 +39,9 @@ public:
     explicit connection_parameters(std::string const & fullConnectString);
 
     connection_parameters(connection_parameters const& other);
+    connection_parameters(connection_parameters && other);
     connection_parameters& operator=(connection_parameters const& other);
+    connection_parameters& operator=(connection_parameters && other);
 
     ~connection_parameters();
 

--- a/include/soci/connection-parameters.h
+++ b/include/soci/connection-parameters.h
@@ -79,6 +79,8 @@ public:
     }
 
 private:
+    void reset_after_move();
+
     // The backend and connection string specified in our ctor.
     backend_factory const * factory_;
     std::string connectString_;

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -194,6 +194,8 @@ public:
 private:
     SOCI_NOT_COPYABLE(session)
 
+    void reset_after_move();
+
     std::ostringstream query_stream_;
     std::unique_ptr<details::query_transformation_function> query_transformation_;
 

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -55,6 +55,9 @@ public:
     explicit session(std::string const & connectString);
     explicit session(connection_pool & pool);
 
+    session(session &&other);
+    session &operator=(session &&other);
+
     ~session();
 
     void open(connection_parameters const & parameters);

--- a/src/core/connection-parameters.cpp
+++ b/src/core/connection-parameters.cpp
@@ -119,6 +119,16 @@ connection_parameters::connection_parameters(connection_parameters const& other)
         backendRef_->inc_ref();
 }
 
+connection_parameters::connection_parameters(connection_parameters && other)
+    : factory_(std::move(other.factory_)),
+      connectString_(std::move(other.connectString_)),
+      backendRef_(std::move(other.backendRef_)),
+      options_(std::move(other.options_))
+{
+    other.factory_ = nullptr;
+    other.backendRef_ = nullptr;
+}
+
 connection_parameters& connection_parameters::operator=(connection_parameters const& other)
 {
     // Order is important in case of self-assignment.
@@ -131,6 +141,22 @@ connection_parameters& connection_parameters::operator=(connection_parameters co
     connectString_ = other.connectString_;
     backendRef_ = other.backendRef_;
     options_ = other.options_;
+
+    return *this;
+}
+
+connection_parameters& connection_parameters::operator=(connection_parameters && other)
+{
+    if (backendRef_ && backendRef_ != other.backendRef_)
+        backendRef_->dec_ref();
+
+    factory_ = std::move (other.factory_);
+    connectString_ = std::move(other.connectString_);
+    backendRef_ = std::move(other.backendRef_);
+    options_ = std::move(other.options_);
+
+    other.factory_ = nullptr;
+    other.backendRef_ = nullptr;
 
     return *this;
 }

--- a/src/core/connection-parameters.cpp
+++ b/src/core/connection-parameters.cpp
@@ -125,8 +125,7 @@ connection_parameters::connection_parameters(connection_parameters && other)
       backendRef_(std::move(other.backendRef_)),
       options_(std::move(other.options_))
 {
-    other.factory_ = nullptr;
-    other.backendRef_ = nullptr;
+    other.reset_after_move();
 }
 
 connection_parameters& connection_parameters::operator=(connection_parameters const& other)
@@ -155,8 +154,7 @@ connection_parameters& connection_parameters::operator=(connection_parameters &&
     backendRef_ = std::move(other.backendRef_);
     options_ = std::move(other.options_);
 
-    other.factory_ = nullptr;
-    other.backendRef_ = nullptr;
+    other.reset_after_move();
 
     return *this;
 }
@@ -165,6 +163,12 @@ connection_parameters::~connection_parameters()
 {
     if (backendRef_)
       backendRef_->dec_ref();
+}
+
+void connection_parameters::reset_after_move()
+{
+    factory_ = nullptr;
+    backendRef_ = nullptr;
 }
 
 } // namespace soci

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4337,6 +4337,10 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
         CHECK(!sql_0.get_backend());
         CHECK(sql_1.is_connected());
         CHECK(sql_1.get_backend());
+
+        sql_1 = std::move(sql_1);
+        CHECK(sql_1.is_connected());
+        CHECK(sql_1.get_backend());
     }
 }
 

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4319,6 +4319,25 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
         }
     }
 
+    {
+        // check move semantics of session
+
+        soci::session sql_0;
+        soci::session sql_1 = std::move(sql_0);
+
+        CHECK(!sql_0.is_connected());
+        CHECK(!sql_1.is_connected());
+
+        sql_0.open(backEndFactory_, connectString_);
+        CHECK(sql_0.is_connected());
+        CHECK(sql_0.get_backend());
+
+        sql_1 = std::move(sql_0);
+        CHECK(!sql_0.is_connected());
+        CHECK(!sql_0.get_backend());
+        CHECK(sql_1.is_connected());
+        CHECK(sql_1.get_backend());
+    }
 }
 
 #ifdef SOCI_HAVE_BOOST

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4322,7 +4322,9 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
     {
         // check move semantics of session
 
+        #if  __GNUC__ >= 13 || defined (__clang__)
         SOCI_GCC_WARNING_SUPPRESS(self-move)
+        #endif
 
         soci::session sql_0;
         soci::session sql_1 = std::move(sql_0);
@@ -4344,7 +4346,9 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
         CHECK(sql_1.is_connected());
         CHECK(sql_1.get_backend());
 
+        #if __GNUC__ >= 13 || defined (__clang__)
         SOCI_GCC_WARNING_RESTORE(self-move)
+        #endif
     }
 }
 

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -4322,6 +4322,8 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
     {
         // check move semantics of session
 
+        SOCI_GCC_WARNING_SUPPRESS(self-move)
+
         soci::session sql_0;
         soci::session sql_1 = std::move(sql_0);
 
@@ -4341,6 +4343,8 @@ TEST_CASE_METHOD(common_tests, "Connection and reconnection", "[core][connect]")
         sql_1 = std::move(sql_1);
         CHECK(sql_1.is_connected());
         CHECK(sql_1.get_backend());
+
+        SOCI_GCC_WARNING_RESTORE(self-move)
     }
 }
 


### PR DESCRIPTION
This is a second try of https://github.com/SOCI/soci/pull/1096

- Although it seems not absolutely necessary, I've also made connection_parameters movable
- The logger inside class session could also be made movable but that was a bit difficult because it doesn't support impl = nullptr case. So I've left it alone for now and it should resort to making a clone/copy.
- I've added a test case. Not sure if it's in the right or wrong place though.  The test coverage might be not excessive, but it does catch the error (segfault here) when default move ctor / operator= is used for class session, as I had it originally.