### PR TITLE
Make Firebird test reference correct database

### DIFF
--- a/tests/firebird/CMakeLists.txt
+++ b/tests/firebird/CMakeLists.txt
@@ -13,4 +13,4 @@ soci_backend_test(
   BACKEND Firebird
   DEPENDS Firebird
   SOURCE test-firebird.cpp ${SOCI_TESTS_COMMON}
-  CONNSTR "service=/tmp/test.fdb user=SYSDBA password=masterkey")
+  CONNSTR "service=/tmp/soci_test.fdb user=SYSDBA password=masterkey")


### PR DESCRIPTION
In the CI, a database called `soci_test` is created
https://github.com/SOCI/soci/blob/9bcc5f8a9181886f4c73ea5b4671b35d8722cb3a/scripts/ci/before_build_firebird.sh#L9
but the `CMakeLists.txt` for the Firebird test encoded a database name of `test`. Somehow this still worked on the CI, but it didn't work for me locally.
Furthermore, using `soci_test` as the table name makes things more consistent with the tests for other backends.