### PR TITLE
Allow passing rvalues to soci::use()

### DIFF
--- a/include/soci/bind-values.h
+++ b/include/soci/bind-values.h
@@ -40,8 +40,8 @@ public:
 
     void exchange(use_type_ptr const& u) { push_back(u.get()); u.release(); }
 
-    template <typename T, typename Indicator>
-    void exchange(use_container<T, Indicator> const &uc)
+    template <typename T, typename Indicator, typename ByValueTag>
+    void exchange ( use_container<T, Indicator, ByValueTag> const &uc )
     {
 #ifdef SOCI_HAVE_BOOST
         exchange_(uc, (typename boost::fusion::traits::is_sequence<T>::type *)NULL);
@@ -111,9 +111,23 @@ private:
     void exchange_(use_container<T, Indicator> const &uc, ...)
     { exchange(do_use(uc.t, uc.ind, uc.name, typename details::exchange_traits<T>::type_family())); }
 
+    template <typename T, typename Indicator>
+    void exchange_ ( use_container<T, Indicator, std::true_type> const &uc, ... )
+    {
+        using type_family_tag = typename details::exchange_traits<T>::type_family;
+        exchange ( do_use ( uc.t, uc.ind, uc.name, type_family_tag (), std::true_type () ) );
+    }
+
     template <typename T>
-    void exchange_(use_container<T, details::no_indicator> const &uc, ...)
+    void exchange_ ( use_container<T, details::no_indicator> const &uc, ... )
     { exchange(do_use(uc.t, uc.name, typename details::exchange_traits<T>::type_family())); }
+
+    template <typename T>
+    void exchange_ ( use_container<T, details::no_indicator, std::true_type> const &uc, ... )
+    {
+        using type_family_tag = typename details::exchange_traits<T>::type_family;
+        exchange ( do_use ( uc.t, uc.name, type_family_tag (), std::true_type () ) );
+    }
 
     template <typename T, typename Indicator>
     void exchange_(use_container<const T, Indicator> const &uc, ...)

--- a/include/soci/statement.h
+++ b/include/soci/statement.h
@@ -50,8 +50,8 @@ public:
     { intos_.exchange(ic); }
 
     void exchange(use_type_ptr const & u) { uses_.exchange(u); }
-    template <typename T, typename Indicator>
-    void exchange(use_container<T, Indicator> const &uc)
+    template <typename T, typename Indicator, typename ByValueTag >
+    void exchange ( use_container<T, Indicator, ByValueTag> const &uc )
     { uses_.exchange(uc); }
 
 
@@ -198,8 +198,8 @@ public:
     template <typename T, typename Indicator>
     void exchange(details::into_container<T, Indicator>  const &ic) { impl_->exchange(ic); }
     void exchange(details::use_type_ptr const & u) { impl_->exchange(u); }
-    template <typename T, typename Indicator>
-    void exchange(details::use_container<T, Indicator>  const &uc) { impl_->exchange(uc); }
+    template <typename T, typename Indicator, typename ByValueTag>
+    void exchange(details::use_container<T, Indicator, ByValueTag>  const &uc) { impl_->exchange(uc); }
     void clean_up()                      { impl_->clean_up(); }
     void bind_clean_up()                 { impl_->bind_clean_up(); }
 

--- a/include/soci/type-conversion.h
+++ b/include/soci/type-conversion.h
@@ -183,6 +183,21 @@ private:
     SOCI_NOT_COPYABLE(conversion_use_type)
 };
 
+template <typename T>
+class by_value_conversion_use_type : value_holder<T>, public conversion_use_type<T>
+{
+public:
+    by_value_conversion_use_type ( T const& t, std::string const& name = std::string () )
+        : value_holder<T> ( t, i_ok ), conversion_use_type<T> ( value_holder<T>::saved_val_, name )
+    {
+    }
+
+    by_value_conversion_use_type ( T const& t, const indicator& ind, std::string const& name = std::string () )
+        : value_holder<T> ( t, ind ), conversion_use_type<T> ( value_holder<T>::saved_val_, value_holder<T>::saved_ind_, name )
+    {
+    }
+};
+
 // this class is used to ensure correct order of construction
 // of vector based into_type and use_type elements that use type_conversion
 
@@ -438,6 +453,18 @@ into_type_ptr do_into(std::vector<T> & t, std::vector<indicator> & ind,
 {
     return into_type_ptr(
         new conversion_into_type<std::vector<T> >(t, ind, begin, end));
+}
+
+template <typename T>
+use_type_ptr do_use ( T& t, std::string const& name, user_type_tag, std::true_type )
+{
+    return use_type_ptr ( new by_value_conversion_use_type<T> ( t, name ) );
+}
+
+template <typename T>
+use_type_ptr do_use ( T& t, indicator& ind, std::string const& name, user_type_tag, std::true_type )
+{
+    return use_type_ptr ( new by_value_conversion_use_type<T> ( t, ind, name ) );
 }
 
 template <typename T>

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -701,7 +701,7 @@ TEST_CASE_METHOD ( common_tests, "Rvalues in use", "[core][basics][rvalue]" )
         int r;
         statement   s ( sql );
         s.alloc ();
-        s.prepare ( "select :t from soci_test" );
+        s.prepare ( "select :t::int from soci_test" );
         {
             s.exchange ( use ( 3 ) );
             s.exchange ( into ( r ) );
@@ -715,7 +715,7 @@ TEST_CASE_METHOD ( common_tests, "Rvalues in use", "[core][basics][rvalue]" )
         indicator   r_ind;
         statement   s ( sql );
         s.alloc ();
-        s.prepare ( "select :t from soci_test" );
+        s.prepare ( "select :t::int from soci_test" );
         {
             s.exchange ( use ( 3, i_null ) );
             s.exchange ( into ( r, r_ind ) );
@@ -730,7 +730,7 @@ TEST_CASE_METHOD ( common_tests, "Rvalues in use", "[core][basics][rvalue]" )
         int r;
         statement   s ( sql );
         s.alloc ();
-        s.prepare ( "select :t from soci_test" );
+        s.prepare ( "select :t::int from soci_test" );
         {
             s.exchange ( use ( MyInt ( 3 ) ) );
             s.exchange ( into ( r ) );
@@ -744,7 +744,7 @@ TEST_CASE_METHOD ( common_tests, "Rvalues in use", "[core][basics][rvalue]" )
         indicator   r_ind;
         statement   s ( sql );
         s.alloc ();
-        s.prepare ( "select :t from soci_test" );
+        s.prepare ( "select :t::int from soci_test" );
         {
             s.exchange ( use ( MyInt ( 3 ), i_null ) );
             s.exchange ( into ( r, r_ind ) );

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -692,65 +692,65 @@ TEST_CASE_METHOD(common_tests, "Basic functionality", "[core][basics]")
 TEST_CASE_METHOD ( common_tests, "Rvalues in use", "[core][basics][rvalue]" )
 {
     soci::session sql ( backEndFactory_, connectString_ );
-
-    auto_table_creator tableCreator ( tc_.table_creator_1 ( sql ) );
-    sql << "insert into soci_test (id) values (" << 123 << ")";             // we need one row in the table
-
     // base types
     {
+        auto_table_creator tableCreator ( tc_.table_creator_1 ( sql ) );
         int r;
         statement   s ( sql );
         s.alloc ();
-        s.prepare ( "select :t::int from soci_test" );
+        s.prepare ( "insert into soci_test (id) values (:t)" );
         {
             s.exchange ( use ( 3 ) );
-            s.exchange ( into ( r ) );
         }
         s.define_and_bind ();
         s.execute ( true );
+        sql << "select id from soci_test", into ( r );
         CHECK ( r == 3 );
     }
     {
+        auto_table_creator tableCreator ( tc_.table_creator_1 ( sql ) );
         int r{0};
         indicator   r_ind;
         statement   s ( sql );
         s.alloc ();
-        s.prepare ( "select :t::int from soci_test" );
+        s.prepare ( "insert into soci_test (id) values (:t)" );
         {
             s.exchange ( use ( 3, i_null ) );
-            s.exchange ( into ( r, r_ind ) );
         }
         s.define_and_bind ();
         s.execute ( true );
+        sql << "select id from soci_test", into ( r, r_ind );
         CHECK ( r == 0 );
         CHECK ( r_ind == i_null );
     }
     // conversion types
     {
+        auto_table_creator tableCreator ( tc_.table_creator_1 ( sql ) );
         int r;
         statement   s ( sql );
         s.alloc ();
-        s.prepare ( "select :t::int from soci_test" );
+        s.prepare ( "insert into soci_test (id) values (:t)" );
         {
             s.exchange ( use ( MyInt ( 3 ) ) );
-            s.exchange ( into ( r ) );
         }
         s.define_and_bind ();
         s.execute ( true );
+        sql << "select id from soci_test", into ( r );
         CHECK ( r == 3 );
     }
     {
+        auto_table_creator tableCreator ( tc_.table_creator_1 ( sql ) );
         int r{-1};
         indicator   r_ind;
         statement   s ( sql );
         s.alloc ();
-        s.prepare ( "select :t::int from soci_test" );
+        s.prepare ( "insert into soci_test (id) values (:t)" );
         {
             s.exchange ( use ( MyInt ( 3 ), i_null ) );
-            s.exchange ( into ( r, r_ind ) );
         }
         s.define_and_bind ();
         s.execute ( true );
+        sql << "select id from soci_test", into ( r, r_ind );
         CHECK ( r == -1 );
         CHECK ( r_ind == i_null );
     }


### PR DESCRIPTION
It is a useful when we can write soci::use( 3 ) or soci::use (string_holder("once used string"))
So, for rvalue case we have to use a specific type of use_container. And the overload of the exchange() and do_use() functions. As a result we have a "use_type" object of new derived class "by_value_use_type" (or "by_value_conversion_use_type"), which contains the copy of the rvalue
