### PR TITLE
Added handling of ssl_mode connection parameter to MySQL session

### DIFF
--- a/docs/backends/mysql.md
+++ b/docs/backends/mysql.md
@@ -54,6 +54,7 @@ The set of parameters used in the connection string for MySQL is:
 * `connect_timeout` - should be positive integer value that means seconds corresponding to `MYSQL_OPT_CONNECT_TIMEOUT`.
 * `read_timeout` - should be positive integer value that means seconds corresponding to `MYSQL_OPT_READ_TIMEOUT`.
 * `write_timeout` - should be positive integer value that means seconds corresponding to `MYSQL_OPT_WRITE_TIMEOUT`.
+* `ssl_mode` - should be one of the name constants `DISABLED`, `PREFERRED`, `REQUIRED`, `VERIFY_CA` or `VERIFY_IDENTITY` corresponding to `MYSQL_OPT_SSL_MODE` options.
 
 Once you have created a `session` object as shown above, you can use it to access the database, for example:
 

--- a/src/backends/mysql/session.cpp
+++ b/src/backends/mysql/session.cpp
@@ -200,7 +200,8 @@ void parse_connect_string(const string & connectString,
     string *charset, bool *charset_p, bool *reconnect_p,
     unsigned int *connect_timeout, bool *connect_timeout_p,
     unsigned int *read_timeout, bool *read_timeout_p,
-    unsigned int *write_timeout, bool *write_timeout_p)
+    unsigned int *write_timeout, bool *write_timeout_p,
+    unsigned int *ssl_mode, bool *ssl_mode_p)
 {
     *host_p = false;
     *user_p = false;
@@ -217,6 +218,7 @@ void parse_connect_string(const string & connectString,
     *connect_timeout_p = false;
     *read_timeout_p = false;
     *write_timeout_p = false;
+    *ssl_mode_p = false;
     string err = "Malformed connection string.";
     string::const_iterator i = connectString.begin(),
         end = connectString.end();
@@ -335,6 +337,15 @@ void parse_connect_string(const string & connectString,
             char *endp;
             *write_timeout = std::strtoul(val.c_str(), &endp, 10);
             *write_timeout_p = true;
+        } else if (par == "ssl_mode" && !*ssl_mode_p)
+        {
+            if (val=="DISABLED") *ssl_mode = SSL_MODE_DISABLED;
+            else if (val=="PREFERRED") *ssl_mode = SSL_MODE_PREFERRED;
+            else if (val=="REQUIRED") *ssl_mode = SSL_MODE_REQUIRED;
+            else if (val=="VERIFY_CA") *ssl_mode = SSL_MODE_VERIFY_CA;
+            else if (val=="VERIFY_IDENTITY") *ssl_mode = SSL_MODE_VERIFY_IDENTITY;
+            else throw soci_error(err);
+            *ssl_mode_p = true;
         }
         else
         {
@@ -365,10 +376,10 @@ mysql_session_backend::mysql_session_backend(
     string host, user, password, db, unix_socket, ssl_ca, ssl_cert, ssl_key,
         charset;
     int port, local_infile;
-    unsigned int connect_timeout, read_timeout, write_timeout;
+    unsigned int connect_timeout, read_timeout, write_timeout, ssl_mode;
     bool host_p, user_p, password_p, db_p, unix_socket_p, port_p,
         ssl_ca_p, ssl_cert_p, ssl_key_p, local_infile_p, charset_p, reconnect_p,
-        connect_timeout_p, read_timeout_p, write_timeout_p;
+        connect_timeout_p, read_timeout_p, write_timeout_p, ssl_mode_p;
     parse_connect_string(parameters.get_connect_string(), &host, &host_p, &user, &user_p,
         &password, &password_p, &db, &db_p,
         &unix_socket, &unix_socket_p, &port, &port_p,
@@ -376,7 +387,8 @@ mysql_session_backend::mysql_session_backend(
         &local_infile, &local_infile_p, &charset, &charset_p, &reconnect_p,
         &connect_timeout, &connect_timeout_p,
         &read_timeout, &read_timeout_p,
-        &write_timeout, &write_timeout_p);
+        &write_timeout, &write_timeout_p,
+        &ssl_mode, &ssl_mode_p);
     conn_ = mysql_init(NULL);
     if (conn_ == NULL)
     {
@@ -441,6 +453,14 @@ mysql_session_backend::mysql_session_backend(
             clean_up();
             throw soci_error("mysql_options(MYSQL_OPT_WRITE_TIMEOUT) failed.");
         }
+    }
+    if (ssl_mode_p)
+    {
+    	if (0 != mysql_options(conn_, MYSQL_OPT_SSL_MODE, &ssl_mode))
+    	{
+       		clean_up();
+       		throw soci_error("mysql_options(MYSQL_OPT_SSL_MODE) failed.");
+       	}
     }
     if (mysql_real_connect(conn_,
             host_p ? host.c_str() : NULL,

--- a/src/backends/mysql/session.cpp
+++ b/src/backends/mysql/session.cpp
@@ -344,7 +344,7 @@ void parse_connect_string(const string & connectString,
             else if (val=="REQUIRED") *ssl_mode = SSL_MODE_REQUIRED;
             else if (val=="VERIFY_CA") *ssl_mode = SSL_MODE_VERIFY_CA;
             else if (val=="VERIFY_IDENTITY") *ssl_mode = SSL_MODE_VERIFY_IDENTITY;
-            else throw soci_error(err);
+            else throw soci_error("\"ssl_mode\" setting is invalid");
             *ssl_mode_p = true;
         }
         else


### PR DESCRIPTION
This PR allows SOCI users to pass the ssl-mode parameter described [here](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode) when connecting to a MySQL database. The setting is passed as `ssl_mode`, with its value set to one of the name constants given in the above documentation: `DISABLED, PREFERRED, REQUIRED, VERIFY_CA` and `VERIFY_IDENTITY`. Used like this:
    
    auto connection_str = "host=localhost db=mydb user=fred pass='12345' ssl_mode=DISABLED";
    session sql(mysql, connection_str);

This patch implies that the documentation at https://soci.sourceforge.net/doc/master/backends/mysql/ needs to be fixed to include this parameter and its possible values.

**Motivation:** I found that a 32-bit client could not connect to a server, even though the server permitted unencrypted connections. The error returned was 2026. I believe this is because the default value of this parameter is PREFERRED, which implies that TLS protocol negotiations are initiated. Because the 32-bit client is no longer maintained, these fail - and no connection is made. The solution is to turn off SSL entirely (if the security situation permits it).

Of course, the parameter is also generally useful.

