### PR TITLE
Don't pipe wget output to tar during mold installation

### DIFF
--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -42,8 +42,10 @@ case "$(uname)" in
         run_apt install ${packages_to_install}
 
         # Get mold and replace the default linker with it.
-        wget --quiet -O- https://github.com/rui314/mold/releases/download/v2.4.0/mold-2.4.0-$(uname -m)-linux.tar.gz | \
-          sudo tar -C /usr/local --strip-components=1 -xzf -
+        mold_ver=2.4.0
+        mold_name=mold-${mold_ver}-$(uname -m)-linux.tar.gz
+        wget --quiet https://github.com/rui314/mold/releases/download/v${mold_ver}/${mold_name}
+        sudo tar -C /usr/local --strip-components=1 -xvzf ${mold_name}
         sudo ln -sf /usr/local/bin/mold /usr/bin/ld
         ;;
 


### PR DESCRIPTION
This fails with cryptic errors, so break the pipeline in parts.