### PR TITLE
Trace shell scripts when using GitHub Actions debug output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,14 @@ jobs:
               ;;
           esac
 
+          case "${{matrix.container}}" in
+            ubuntu:18.04)
+              # We need to use this option as GitHub certificate is not recognized by
+              # wget in this old container otherwise.
+              set_env_var SOCI_WGET_OPTIONS --no-check-certificate
+              ;;
+          esac
+
           if [ -n "${{matrix.cxxstd}}" ]; then
             set_env_var SOCI_CXXSTD ${{matrix.cxxstd}}
           fi

--- a/scripts/ci/common.sh
+++ b/scripts/ci/common.sh
@@ -15,6 +15,10 @@ if [ "$SOCI_CI" != "true" ] ; then
 	exit 1
 fi
 
+if [ -n "$RUNNER_DEBUG" ]; then
+  set -x
+fi
+
 backend_settings=${SOCI_SOURCE_DIR}/scripts/ci/${SOCI_CI_BACKEND}.sh
 if [ -f ${backend_settings} ]; then
     . ${backend_settings}

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -44,7 +44,7 @@ case "$(uname)" in
         # Get mold and replace the default linker with it.
         mold_ver=2.4.0
         mold_name=mold-${mold_ver}-$(uname -m)-linux.tar.gz
-        wget https://github.com/rui314/mold/releases/download/v${mold_ver}/${mold_name}
+        wget $SOCI_WGET_OPTIONS https://github.com/rui314/mold/releases/download/v${mold_ver}/${mold_name}
         sudo tar -C /usr/local --strip-components=1 -xzf ${mold_name}
         sudo ln -sf /usr/local/bin/mold /usr/bin/ld
         ;;

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -42,8 +42,10 @@ case "$(uname)" in
         run_apt install ${packages_to_install}
 
         # Get mold and replace the default linker with it.
-        wget --quiet -O- https://github.com/rui314/mold/releases/download/v2.4.0/mold-2.4.0-$(uname -m)-linux.tar.gz | \
-          sudo tar -C /usr/local --strip-components=1 -xzf -
+        mold_ver=2.4.0
+        mold_name=mold-${mold_ver}-$(uname -m)-linux.tar.gz
+        wget https://github.com/rui314/mold/releases/download/v${mold_ver}/${mold_name}
+        sudo tar -C /usr/local --strip-components=1 -xzf ${mold_name}
         sudo ln -sf /usr/local/bin/mold /usr/bin/ld
         ;;
 


### PR DESCRIPTION
This should give more information when rerunning failed actions with debug output enabled.