### PR TITLE
Disable the use of SSL options in MySQL backend with MariaDB

### DIFF
--- a/docs/backends/mysql.md
+++ b/docs/backends/mysql.md
@@ -54,7 +54,7 @@ The set of parameters used in the connection string for MySQL is:
 * `connect_timeout` - should be positive integer value that means seconds corresponding to `MYSQL_OPT_CONNECT_TIMEOUT`.
 * `read_timeout` - should be positive integer value that means seconds corresponding to `MYSQL_OPT_READ_TIMEOUT`.
 * `write_timeout` - should be positive integer value that means seconds corresponding to `MYSQL_OPT_WRITE_TIMEOUT`.
-* `ssl_mode` - should be one of the name constants `DISABLED`, `PREFERRED`, `REQUIRED`, `VERIFY_CA` or `VERIFY_IDENTITY` corresponding to `MYSQL_OPT_SSL_MODE` options.
+* `ssl_mode` - should be one of the name constants `DISABLED`, `PREFERRED`, `REQUIRED`, `VERIFY_CA` or `VERIFY_IDENTITY` corresponding to `MYSQL_OPT_SSL_MODE` options (note that this option is currently not supported when using MariaDB).
 
 Once you have created a `session` object as shown above, you can use it to access the database, for example:
 


### PR DESCRIPTION
MariaDB doesn't have these options, so the code didn't compile when using it -- not supporting the options is not great, but better than failing to build.

----

I'm not sure what's the right thing to do here, but this at least allows the build to succeed when using MariaDB headers.