### PR TITLE
Only prepare for describe if statement type is 'SELECT' for Oracle backend

### DIFF
--- a/src/backends/oracle/statement.cpp
+++ b/src/backends/oracle/statement.cpp
@@ -164,21 +164,34 @@ std::string oracle_statement_backend::rewrite_for_procedure_call(
 
 int oracle_statement_backend::prepare_for_describe()
 {
-    sword res = OCIStmtExecute(session_.svchp_, stmtp_, session_.errhp_,
-        1, 0, 0, 0, OCI_DESCRIBE_ONLY);
+    ub2 statementType = 0;
+    sword res = OCIAttrGet(static_cast<dvoid*>(stmtp_),
+        static_cast<ub4>(OCI_HTYPE_STMT), static_cast<dvoid*>(&statementType),
+        0, static_cast<ub4>(OCI_ATTR_STMT_TYPE), session_.errhp_);
     if (res != OCI_SUCCESS)
     {
         throw_oracle_soci_error(res, session_.errhp_);
     }
 
-    int cols;
-    res = OCIAttrGet(static_cast<dvoid*>(stmtp_),
-        static_cast<ub4>(OCI_HTYPE_STMT), static_cast<dvoid*>(&cols),
-        0, static_cast<ub4>(OCI_ATTR_PARAM_COUNT), session_.errhp_);
-
-    if (res != OCI_SUCCESS)
+    int cols = 0;
+    if (statementType == OCI_STMT_SELECT)
     {
-        throw_oracle_soci_error(res, session_.errhp_);
+        res = OCIStmtExecute(session_.svchp_, stmtp_, session_.errhp_,
+            1, 0, 0, 0, OCI_DESCRIBE_ONLY);
+        if (res != OCI_SUCCESS)
+        {
+            throw_oracle_soci_error(res, session_.errhp_);
+        }
+
+        int cols;
+        res = OCIAttrGet(static_cast<dvoid*>(stmtp_),
+            static_cast<ub4>(OCI_HTYPE_STMT), static_cast<dvoid*>(&cols),
+            0, static_cast<ub4>(OCI_ATTR_PARAM_COUNT), session_.errhp_);
+
+        if (res != OCI_SUCCESS)
+        {
+            throw_oracle_soci_error(res, session_.errhp_);
+        }
     }
 
     return cols;


### PR DESCRIPTION
In my use-case I always call statement::exchange_for_rowset, even if the query for the statement does not return any result, since type of query used to create the statement is unknown beforehand.

OCIStmtExecute call with OCI_DESCRIBE_ONLY in oracle_statement_backend::prepare_for_describe will fail (with "ORA-24333: zero iteration count" error) for non-SELECT queries, since there's nothing to describe.

My proposed change to the library is to the call to OCIStmtExecute if the statement type is OCI_STMT_SELECT.