### PR TITLE
Add bigobj to msvc compile flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,8 +154,6 @@ if(NOT MSVC)
     set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES ${DL_INCLUDE_DIR})
     add_definitions(-DHAVE_DL=1)
   endif()
-else ()
-  add_compile_options(/bigobj)
 endif()
 
 if(Boost_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,8 @@ if(NOT MSVC)
     set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES ${DL_INCLUDE_DIR})
     add_definitions(-DHAVE_DL=1)
   endif()
+else ()
+  add_compile_options(/bigobj)
 endif()
 
 if(Boost_FOUND)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ colormsg(_HIBLUE_ "Configuring SOCI tests:")
 # This works around a problem when building in C++11 mode with clang (see #984).
 add_definitions(-DCATCH_CONFIG_CPP11_NO_SHUFFLE)
 
-if(NOT MSVC)
+if(MSVC)
   add_compile_options(/bigobj)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,10 @@ colormsg(_HIBLUE_ "Configuring SOCI tests:")
 # This works around a problem when building in C++11 mode with clang (see #984).
 add_definitions(-DCATCH_CONFIG_CPP11_NO_SHUFFLE)
 
+if(NOT MSVC)
+  add_compile_options(/bigobj)
+endif()
+
 include_directories(
   ${SOCI_SOURCE_DIR}/include/private
   ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Adding /bigobj to the compile options fixes an error when trying to compile soci using VS 2019