### PR TITLE
New the procedure call command for PostgreSQL

### DIFF
--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -711,7 +711,7 @@ std::string postgresql_statement_backend::get_parameter_name(int index) const
 std::string postgresql_statement_backend::rewrite_for_procedure_call(
     std::string const & query)
 {
-    std::string newQuery("select ");
+    std::string newQuery("call ");
     newQuery += query;
     return newQuery;
 }


### PR DESCRIPTION
When calling a PostgreSQL procedure with soci::procedure::execute(), an errror occurs indicating that "select" is not a valid command to call a procedure. In PostgreSQL, "CALL" command is used instead.
For other SQL languages, "select" is a valid command and works well.