### PR TITLE
Add automatic type conversion to row::get()

### DIFF
--- a/include/soci/row.h
+++ b/include/soci/row.h
@@ -63,7 +63,7 @@ public:
     template <typename T>
     inline void add_holder(T* t, indicator* ind)
     {
-        holders_.push_back(new details::type_holder<T>(t));
+        holders_.push_back(details::holder::make_holder(t));
         indicators_.push_back(ind);
     }
 

--- a/include/soci/type-holder.h
+++ b/include/soci/type-holder.h
@@ -8,9 +8,14 @@
 #ifndef SOCI_TYPE_HOLDER_H_INCLUDED
 #define SOCI_TYPE_HOLDER_H_INCLUDED
 
-#include "soci/soci-platform.h"
-// std
-#include <cstring>
+#include "soci/soci-backend.h"
+#include "soci/soci-types.h"
+
+#include <cmath>
+#include <cstdint>
+#include <ctime>
+#include <limits>
+#include <type_traits>
 #include <typeinfo>
 
 namespace soci
@@ -44,49 +49,310 @@ T* checked_ptr_cast(U* ptr)
     return static_cast<T*>(ptr);
 }
 
-// Base class holder + derived class type_holder for storing type data
-// instances in a container of holder objects
-template <typename T>
-class type_holder;
+// Type safe conversion that fails at compilation if instantiated
+template <typename T, typename U, typename Enable = void>
+struct soci_cast
+{
+    static inline T cast(U)
+    {
+        throw std::bad_cast();
+    }
+};
 
+// Type safe conversion that is a noop
+template <typename T, typename U>
+struct soci_cast<
+    T, U,
+    typename std::enable_if<std::is_same<T, U>::value>::type>
+{
+    static inline T cast(U val)
+    {
+        return val;
+    }
+};
+
+// Type safe conversion that is widening the type
+template <typename T, typename U>
+struct soci_cast<
+    T, U,
+    typename std::enable_if<(
+        !std::is_same<T, U>::value &&
+        std::is_integral<T>::value &&
+        std::is_integral<U>::value
+    )>::type>
+{
+    static inline T cast(U val) {
+        const intmax_t t_min = intmax_t((std::numeric_limits<T>::min)());
+        const intmax_t u_min = intmax_t((std::numeric_limits<U>::min)());
+        const uintmax_t t_max = uintmax_t((std::numeric_limits<T>::max)());
+        const uintmax_t u_max = uintmax_t((std::numeric_limits<U>::max)());
+
+        if ((t_min > u_min && val < static_cast<U>(t_min)) ||
+            (t_max < u_max && val > static_cast<U>(t_max)))
+        {
+            throw std::bad_cast();
+        }
+
+        return static_cast<T>(val);
+    }
+};
+
+union type_holder
+{
+    std::string* s;
+    int8_t* i8;
+    int16_t* i16;
+    int32_t* i32;
+    int64_t* i64;
+    uint8_t* u8;
+    uint16_t* u16;
+    uint32_t* u32;
+    uint64_t* u64;
+    double* d;
+    std::tm* t;
+};
+
+template <typename T>
+struct type_holder_trait
+{
+    static_assert(std::is_same<T, void>::value, "Unmatched raw type");
+    // dummy value to satisfy the template engine, never used
+    static const db_type type = (db_type)0;
+};
+
+template <>
+struct type_holder_trait<std::string>
+{
+    static const db_type type = db_string;
+};
+
+template <>
+struct type_holder_trait<int8_t>
+{
+    static const db_type type = db_int8;
+};
+
+template <>
+struct type_holder_trait<int16_t>
+{
+    static const db_type type = db_int16;
+};
+
+template <>
+struct type_holder_trait<int32_t>
+{
+    static const db_type type = db_int32;
+};
+
+template <>
+struct type_holder_trait<int64_t>
+{
+    static const db_type type = db_int64;
+};
+
+template <>
+struct type_holder_trait<uint8_t>
+{
+    static const db_type type = db_uint8;
+};
+
+template <>
+struct type_holder_trait<uint16_t>
+{
+    static const db_type type = db_uint16;
+};
+
+template <>
+struct type_holder_trait<uint32_t>
+{
+    static const db_type type = db_uint32;
+};
+
+template <>
+struct type_holder_trait<uint64_t>
+{
+    static const db_type type = db_uint64;
+};
+
+#if defined(SOCI_INT64_IS_LONG)
+template <>
+struct type_holder_trait<long long> : type_holder_trait<int64_t>
+{
+};
+
+template <>
+struct type_holder_trait<unsigned long long> : type_holder_trait<uint64_t>
+{
+};
+#elif defined(SOCI_LONG_IS_64_BIT)
+template <>
+struct type_holder_trait<long> : type_holder_trait<int64_t>
+{
+};
+
+template <>
+struct type_holder_trait<unsigned long> : type_holder_trait<uint64_t>
+{
+};
+#else
+template <>
+struct type_holder_trait<long> : type_holder_trait<int32_t>
+{
+};
+
+template <>
+struct type_holder_trait<unsigned long> : type_holder_trait<uint32_t>
+{
+};
+#endif
+
+template <>
+struct type_holder_trait<double>
+{
+    static const db_type type = db_double;
+};
+
+template <>
+struct type_holder_trait<std::tm>
+{
+    static const db_type type = db_date;
+};
+
+// Base class for storing type data instances in a container of holder objects
 class holder
 {
 public:
-    holder() {}
-    virtual ~holder() {}
-
-    template<typename T>
-    T get()
+    template <typename T>
+    static holder* make_holder(T* val)
     {
-        type_holder<T>* p = checked_ptr_cast<type_holder<T> >(this);
-        if (p)
+         return new holder(type_holder_trait<T>::type, val);
+    }
+
+    ~holder()
+    {
+        switch (dt_)
         {
-            return p->template value<T>();
+        case db_double:
+            delete val_.d;
+            break;
+        case db_int8:
+            delete val_.i8;
+            break;
+        case db_int16:
+            delete val_.i16;
+            break;
+        case db_int32:
+            delete val_.i32;
+            break;
+        case db_int64:
+            delete val_.i64;
+            break;
+        case db_uint8:
+            delete val_.u8;
+            break;
+        case db_uint16:
+            delete val_.u16;
+            break;
+        case db_uint32:
+            delete val_.u32;
+            break;
+        case db_uint64:
+            delete val_.u64;
+            break;
+        case db_date:
+            delete val_.t;
+            break;
+        case db_blob:
+        case db_xml:
+        case db_string:
+            delete val_.s;
+            break;
+        default:
+            break;
         }
-        else
+    }
+
+    template <typename T>
+    constexpr T get() const
+    {
+        switch (dt_)
         {
+        case db_int8:
+            return soci_cast<T, int8_t>::cast(*val_.i8);
+        case db_int16:
+            return soci_cast<T, int16_t>::cast(*val_.i16);
+        case db_int32:
+            return soci_cast<T, int32_t>::cast(*val_.i32);
+        case db_int64:
+            return soci_cast<T, int64_t>::cast(*val_.i64);
+        case db_uint8:
+            return soci_cast<T, uint8_t>::cast(*val_.u8);
+        case db_uint16:
+            return soci_cast<T, uint16_t>::cast(*val_.u16);
+        case db_uint32:
+            return soci_cast<T, uint32_t>::cast(*val_.u32);
+        case db_uint64:
+            return soci_cast<T, uint64_t>::cast(*val_.u64);
+        case db_double:
+            return soci_cast<T, double>::cast(*val_.d);
+        case db_date:
+            return soci_cast<T, std::tm>::cast(*val_.t);
+        case db_blob:
+        case db_xml:
+        case db_string:
+            return soci_cast<T, std::string>::cast(*val_.s);
+        default:
             throw std::bad_cast();
         }
     }
 
 private:
+    holder(db_type dt, void* val) : dt_(dt)
+    {
+        switch (dt_)
+        {
+        case db_double:
+            val_.d = static_cast<double*>(val);
+            break;
+        case db_int8:
+            val_.i8 = static_cast<int8_t*>(val);
+            break;
+        case db_int16:
+            val_.i16 = static_cast<int16_t*>(val);
+            break;
+        case db_int32:
+            val_.i32 = static_cast<int32_t*>(val);
+            break;
+        case db_int64:
+            val_.i64 = static_cast<int64_t*>(val);
+            break;
+        case db_uint8:
+            val_.u8 = static_cast<uint8_t*>(val);
+            break;
+        case db_uint16:
+            val_.u16 = static_cast<uint16_t*>(val);
+            break;
+        case db_uint32:
+            val_.u32 = static_cast<uint32_t*>(val);
+            break;
+        case db_uint64:
+            val_.u64 = static_cast<uint64_t*>(val);
+            break;
+        case db_date:
+            val_.t = static_cast<std::tm*>(val);
+            break;
+        case db_blob:
+        case db_xml:
+        case db_string:
+            val_.s = static_cast<std::string*>(val);
+            break;
+        default:
+            break;
+        }
+    }
 
-    template<typename T>
-    T value();
-};
-
-template <typename T>
-class type_holder : public holder
-{
-public:
-    type_holder(T * t) : t_(t) {}
-    ~type_holder() override { delete t_; }
-
-    template<typename TypeValue>
-    TypeValue value() const { return *t_; }
-
-private:
-    T * t_;
+    const db_type dt_;
+    type_holder val_;
 };
 
 } // namespace details

--- a/tests/common-tests.h
+++ b/tests/common-tests.h
@@ -3317,6 +3317,122 @@ TEST_CASE_METHOD(common_tests, "Dynamic binding with type conversions", "[core][
     }
 }
 
+// Dynamic bindings with type casts
+TEST_CASE_METHOD(common_tests, "Dynamic row binding 4", "[core][dynamic]")
+{
+    soci::session sql(backEndFactory_, connectString_);
+
+    SECTION("simple type cast")
+    {
+        auto_table_creator tableCreator(tc_.table_creator_1(sql));
+
+        sql << "insert into soci_test(id, d, str, tm)"
+            << " values(10, 20.0, 'foobar',"
+            << tc_.to_date_time("2005-12-19 22:14:17")
+            << ")";
+
+        {
+            row r;
+            sql << "select id from soci_test", into(r);
+
+            static_assert(std::numeric_limits<int32_t>::digits10 == 9, "");
+            CHECK(r.size() == 1);
+            CHECK(r.get<int8_t>(0) == 10);
+            CHECK(r.get<int16_t>(0) == 10);
+            CHECK(r.get<int32_t>(0) == 10);
+            CHECK(r.get<int64_t>(0) == 10);
+            CHECK(r.get<uint8_t>(0) == 10);
+            CHECK(r.get<uint16_t>(0) == 10);
+            CHECK(r.get<uint32_t>(0) == 10);
+            CHECK(r.get<uint64_t>(0) == 10);
+            CHECK_THROWS_AS(r.get<double>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<std::string>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<std::tm>(0), std::bad_cast);
+        }
+        {
+            row r;
+            sql << "select d from soci_test", into(r);
+
+            CHECK(r.size() == 1);
+            CHECK_THROWS_AS(r.get<int8_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<int16_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<int32_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<int64_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<uint8_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<uint16_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<uint32_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<uint64_t>(0), std::bad_cast);
+            ASSERT_EQUAL_APPROX(r.get<double>(0), 20.0);
+            CHECK_THROWS_AS(r.get<std::string>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<std::tm>(0), std::bad_cast);
+        }
+        {
+            row r;
+            sql << "select str from soci_test", into(r);
+
+            CHECK(r.size() == 1);
+            CHECK_THROWS_AS(r.get<int8_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<int16_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<int32_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<int64_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<uint8_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<uint16_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<uint32_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<uint64_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<double>(0), std::bad_cast);
+            CHECK(r.get<std::string>(0) == "foobar");
+            CHECK_THROWS_AS(r.get<std::tm>(0), std::bad_cast);
+        }
+        {
+            row r;
+            sql << "select tm from soci_test", into(r);
+
+            CHECK(r.size() == 1);
+            CHECK_THROWS_AS(r.get<int8_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<int16_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<int32_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<int64_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<uint8_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<uint16_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<uint32_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<uint64_t>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<double>(0), std::bad_cast);
+            CHECK_THROWS_AS(r.get<std::string>(0), std::bad_cast);
+            CHECK(r.get<std::tm>(0).tm_year == 105);
+            CHECK(r.get<std::tm>(0).tm_mon == 11);
+            CHECK(r.get<std::tm>(0).tm_mday == 19);
+            CHECK(r.get<std::tm>(0).tm_hour == 22);
+            CHECK(r.get<std::tm>(0).tm_min == 14);
+            CHECK(r.get<std::tm>(0).tm_sec == 17);
+        }
+    }
+    SECTION("overflowing type cast")
+    {
+        auto_table_creator tableCreator(tc_.table_creator_1(sql));
+
+        sql << "insert into soci_test(id)"
+            << " values("
+            << (std::numeric_limits<int32_t>::max)()
+            << ")";
+
+        row r;
+        sql << "select id from soci_test", into(r);
+
+        intmax_t v = intmax_t((std::numeric_limits<int32_t>::max)());
+        uintmax_t uv = uintmax_t((std::numeric_limits<int32_t>::max)());
+
+        CHECK(r.size() == 1);
+        CHECK_THROWS_AS(r.get<int8_t>(0), std::bad_cast);
+        CHECK_THROWS_AS(r.get<int16_t>(0), std::bad_cast);
+        CHECK(r.get<int32_t>(0) == v);
+        CHECK(r.get<int64_t>(0) == v);
+        CHECK_THROWS_AS(r.get<uint8_t>(0), std::bad_cast);
+        CHECK_THROWS_AS(r.get<uint16_t>(0), std::bad_cast);
+        CHECK(r.get<uint32_t>(0) == uv);
+        CHECK(r.get<uint64_t>(0) == uv);
+    }
+}
+
 TEST_CASE_METHOD(common_tests, "Prepared insert with ORM", "[core][orm]")
 {
     soci::session sql(backEndFactory_, connectString_);

--- a/tests/mysql/test-mysql.cpp
+++ b/tests/mysql/test-mysql.cpp
@@ -702,6 +702,7 @@ TEST_CASE("MySQL tinyint", "[mysql][int][tinyint]")
     REQUIRE(r.size() == 1);
     CHECK(r.get_properties("val").get_data_type() == dt_long_long);
     CHECK(r.get_properties("val").get_db_type() == db_uint32);
+    CHECK(r.get<long long>("val") == 0xffffff00);
     CHECK(r.get<unsigned>("val") == 0xffffff00);
     CHECK(r.get<uint32_t>("val") == 0xffffff00);
   }
@@ -714,6 +715,7 @@ TEST_CASE("MySQL tinyint", "[mysql][int][tinyint]")
     REQUIRE(r.size() == 1);
     CHECK(r.get_properties("val").get_data_type() == dt_integer);
     CHECK(r.get_properties("val").get_db_type() == db_int8);
+    CHECK(r.get<int>("val") == -123);
     CHECK(r.get<int8_t>("val") == -123);
   }
   {
@@ -725,6 +727,7 @@ TEST_CASE("MySQL tinyint", "[mysql][int][tinyint]")
     REQUIRE(r.size() == 1);
     CHECK(r.get_properties("val").get_data_type() == dt_integer);
     CHECK(r.get_properties("val").get_db_type() == db_uint8);
+    CHECK(r.get<int>("val") == 123);
     CHECK(r.get<uint8_t>("val") == 123);
   }
   {

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -1214,7 +1214,7 @@ struct test_enum_with_explicit_custom_type_int_rowset : table_creator_base
 
         try
         {
-            sql << "CREATE TABLE soci_test( Type integer)";
+            sql << "CREATE TABLE soci_test( Type smallint)";
             ;
         }
         catch (...)


### PR DESCRIPTION
As discussed in https://github.com/SOCI/soci/issues/1088, it is possible that the merge of https://github.com/SOCI/soci/pull/1116 might require users to use a different data type when calling `row::get<T>(...)`.

This PR tries to add implicit conversions between data types in the most conservative way. I.e., conversions are only defined between integer types.
Unit tests that previously had to be changed to conform to the stricter type mapping are also reverted back to their old state.

The work here is based on https://github.com/SOCI/soci/pull/1097.