### PR TITLE
Replace the use of actions/checkout with a manual checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,9 @@ jobs:
               ;;
           esac
 
+          set -x
           git config --global init.defaultBranch master
-          git config --global --add safe.directory .
+          git config --global --add safe.directory `pwd`
           git config --global advice.detachedHead false
           git init .
           git remote add origin https://github.com/SOCI/soci.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,7 @@ jobs:
           esac
 
           git config --global init.defaultBranch master
-          git init soci
-          cd soci
+          git init .
           git remote add origin https://github.com/SOCI/soci.git
           git fetch --depth=1 origin $GITHUB_SHA
           git checkout FETCH_HEAD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
               ;;
           esac
 
+          git config --global init.defaultBranch master
           git init soci
           cd soci
           git remote add origin https://github.com/SOCI/soci.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
           esac
 
           git config --global init.defaultBranch master
+          git config --global --add safe.directory .
+          git config --global advice.detachedHead false
           git init .
           git remote add origin https://github.com/SOCI/soci.git
           git fetch --depth=1 origin $GITHUB_SHA

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        run: |
+          case "${{matrix.container}}" in
+            ubuntu:18.04)
+              export DEBIAN_FRONTEND=noninteractive
+
+              apt-get update -qq
+              apt-get install -qq git
+              ;;
+          esac
+
+          git init soci
+          cd soci
+          git remote add origin https://github.com/SOCI/soci.git
+          git fetch --depth=1 origin $GITHUB_SHA
+          git checkout FETCH_HEAD
 
       - name: Set environment variables
         run: |


### PR DESCRIPTION
v3 of this action triggers deprecation warnings and will stop working soon, while v4 doesn't work under Ubuntu 18.04 which we use for ODBC testing due to https://github.com/actions/checkout/issues/1442