### PR TITLE
Add back support for PostgreSQL 9.2

### DIFF
--- a/docs/backends/postgresql.md
+++ b/docs/backends/postgresql.md
@@ -12,17 +12,13 @@ The SOCI PostgreSQL backend is supported for use with PostgreSQL >= 7.3, althoug
 
 |PostgreSQL|OS|Compiler|
 |--- |--- |--- |
-|9.6|Windows Server 2016|MSVC++ 14.1|
-|9.4|Windows Server 2012 R2|MSVC++ 14.0|
-|9.4|Windows Server 2012 R2|MSVC++ 12.0|
-|9.4|Windows Server 2012 R2|MSVC++ 11.0|
-|9.4|Windows Server 2012 R2|Mingw-w64/GCC 4.8|
-|9.3|Ubuntu 12.04|g++ 4.6.3|
-|9.0|Mac OS X 10.6.6|g++ 4.2|
-|8.4|FreeBSD 8.2|g++ 4.1|
-|8.4|Debian 6|g++ 4.3|
-|8.4|RedHat 5|g++ 4.3|
-|10.03|macOS High Sierra 10.13.5|AppleClang 9.1.0.9020039|
+| 14|macOS 11.7|AppleClang 13|
+| 14|Ubuntu 22.04|gcc 11.4|
+| 13|Windows Server 2019|MSVS 2022|
+| 12|Windows Server 2019|MSVS 2019|
+| 11|Windows Server 2016|MSVS 2017|
+| 10|Windows Server 2012 R2|MSVS 2015|
+|9.4|Windows Server 2012 R2|Mingw-w64/GCC 8.1|
 
 ### Required Client Libraries
 

--- a/docs/backends/postgresql.md
+++ b/docs/backends/postgresql.md
@@ -6,7 +6,7 @@ SOCI backend for accessing PostgreSQL database.
 
 ### Supported Versions
 
-The SOCI PostgreSQL backend is supported for use with PostgreSQL >= 7.3, although versions older than 8.0 will suffer from limited feature support. See below for details.
+The SOCI PostgreSQL backend is supported for use with PostgreSQL >= 9.0, although older versions may suffer from limited feature support. See below for details.
 
 ### Tested Platforms
 
@@ -158,9 +158,3 @@ The PostgreSQL backend provides the following concrete classes for native API ac
 
 The PostgreSQL backend supports working with data stored in columns of type UUID via simple string operations. All string representations of UUID supported by PostgreSQL are accepted on input, the backend will return the standard
 format of UUID on output. See the test `test_uuid_column_type_support` for usage examples.
-
-## Configuration options
-
-To support older PostgreSQL versions, the following configuration macros are recognized:
-
-* `SOCI_POSTGRESQL_NOSINLGEROWMODE` - disable single mode retrieving query results row-by-row. It is necessary for PostgreSQL prior to version 9.

--- a/docs/backends/postgresql.md
+++ b/docs/backends/postgresql.md
@@ -125,7 +125,9 @@ The PostgreSQL backend has full support for SOCI's [bulk operations](../binding.
 
 ### blob Data Type
 
-The PostgreSQL backend supports working with data stored in columns of type Blob, via SOCI's [blob](../lobs.md) class with the exception that trimming is not supported.
+The PostgreSQL backend supports working with data stored in columns of type Blob, via SOCI's [blob](../lobs.md) class.
+
+Note that 64-bit offsets require PostgreSQL client library 9.3 or later.
 
 ### rowid Data Type
 

--- a/src/backends/postgresql/CMakeLists.txt
+++ b/src/backends/postgresql/CMakeLists.txt
@@ -11,22 +11,8 @@
 
 include(CMakeDependentOption)
 
-option(SOCI_POSTGRESQL_NOSINGLEROWMODE
-  "Do not use single row mode. PostgreSQL <9 portability."
-  OFF)
-
-if (POSTGRESQL_VERSION VERSION_LESS "9.0.0")
-  set(SOCI_POSTGRESQL_NOSINGLEROWMODE ON CACHE BOOL "Use single row mode for PostgreSQL 9+" FORCE)
-endif()
-
-if(SOCI_POSTGRESQL_NOSINGLEROWMODE)
-  add_definitions(-DSOCI_POSTGRESQL_NOSINGLEROWMODE=1)
-endif()
-
 soci_backend(PostgreSQL
   DEPENDS PostgreSQL
   DESCRIPTION "SOCI backend for PostgreSQL"
   AUTHORS "Maciej Sobczak, Stephen Hutton"
   MAINTAINERS "Mateusz Loskot")
-
-boost_report_value(SOCI_POSTGRESQL_NOSINLGEROWMODE)


### PR DESCRIPTION
This was broken by the recent blob-related changes (see #992) but is still needed.

cc @Krzmbrzl