### PR TITLE
Avoid MSVC deprecation warnings for oracle_blob_backend functions

### DIFF
--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -269,21 +269,7 @@ struct oracle_blob_backend : details::blob_backend
 
     std::size_t get_len() override;
 
-    [[deprecated("Use read_from_start instead")]]
-    std::size_t read(std::size_t offset, void *buf, std::size_t toRead) override
-    {
-        // Offsets are 1-based in Oracle
-        return read_from_start(buf, toRead, offset - 1);
-    }
-
     std::size_t read_from_start(void * buf, std::size_t toRead, std::size_t offset = 0) override;
-
-    [[deprecated("Use write_from_start instead")]]
-    std::size_t write(std::size_t offset, const void *buf, std::size_t toWrite) override
-    {
-        // Offsets are 1-based in Oracle
-        return write_from_start(buf, toWrite, offset - 1);
-    }
 
     std::size_t write_from_start(const void * buf, std::size_t toWrite, std::size_t offset = 0) override;
 
@@ -300,6 +286,18 @@ struct oracle_blob_backend : details::blob_backend
     void ensure_initialized();
 
 private:
+    std::size_t do_deprecated_read(std::size_t offset, void *buf, std::size_t toRead) override
+    {
+        // Offsets are 1-based in Oracle
+        return read_from_start(buf, toRead, offset - 1);
+    }
+
+    std::size_t do_deprecated_write(std::size_t offset, const void *buf, std::size_t toWrite) override
+    {
+        // Offsets are 1-based in Oracle
+        return write_from_start(buf, toWrite, offset - 1);
+    }
+
     oracle_session_backend &session_;
 
     locator_t lobp_;

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -304,13 +304,7 @@ public:
 
     virtual std::size_t get_len() = 0;
 
-    [[deprecated("Use read_from_start instead")]]
-    virtual std::size_t read(std::size_t offset, void* buf, std::size_t toRead) { return read_from_start(buf, toRead, offset); }
-
     virtual std::size_t read_from_start(void* buf, std::size_t toRead, std::size_t offset) = 0;
-
-    [[deprecated("Use write_from_start instead")]]
-    virtual std::size_t write(std::size_t offset, const void* buf, std::size_t toWrite) { return write_from_start(buf, toWrite, offset); }
 
     virtual std::size_t write_from_start(const void* buf, std::size_t toWrite, std::size_t offset) = 0;
 
@@ -318,7 +312,18 @@ public:
 
     virtual void trim(std::size_t newLen) = 0;
 
+    // Deprecated functions with backend-specific semantics preserved only for
+    // compatibility.
+    [[deprecated("Use read_from_start instead")]]
+    std::size_t read(std::size_t offset, void* buf, std::size_t toRead) { return do_deprecated_read(offset, buf, toRead); }
+
+    [[deprecated("Use write_from_start instead")]]
+    virtual std::size_t write(std::size_t offset, const void* buf, std::size_t toWrite) { return do_deprecated_write(offset, buf, toWrite); }
+
 private:
+    virtual std::size_t do_deprecated_read(std::size_t offset, void* buf, std::size_t toRead) { return read_from_start(buf, toRead, offset); }
+    virtual std::size_t do_deprecated_write(std::size_t offset, const void* buf, std::size_t toWrite) { return write_from_start(buf, toWrite, offset); }
+
     SOCI_NOT_COPYABLE(blob_backend)
 };
 


### PR DESCRIPTION
Overriding a deprecated virtual function results in a warning, at least
when using MSVS, so don't do this and override a non-deprecated private
virtual function called from the deprecated public ones.

No real changes, just refactor the code to avoid warnings.
