### PR TITLE
Move check for PostgreSQL 9.3 to CMake from the source file

### DIFF
--- a/src/backends/postgresql/CMakeLists.txt
+++ b/src/backends/postgresql/CMakeLists.txt
@@ -11,8 +11,22 @@
 
 include(CMakeDependentOption)
 
+option(SOCI_POSTGRESQL_NO_LO64
+  "Do not use lo_xxx64() functions for compatibility with PostgreSQL < 9.3"
+  OFF)
+
+if (POSTGRESQL_VERSION VERSION_LESS "9.3.0")
+  set(SOCI_POSTGRESQL_NO_LO64 ON CACHE BOOL "Avoid using lo_xxx64() functions" FORCE)
+endif()
+
+if(SOCI_POSTGRESQL_NO_LO64)
+  add_definitions(-DSOCI_POSTGRESQL_NO_LO64=1)
+endif()
+
 soci_backend(PostgreSQL
   DEPENDS PostgreSQL
   DESCRIPTION "SOCI backend for PostgreSQL"
   AUTHORS "Maciej Sobczak, Stephen Hutton"
   MAINTAINERS "Mateusz Loskot")
+
+boost_report_value(SOCI_POSTGRESQL_NO_LO64)

--- a/src/backends/postgresql/blob.cpp
+++ b/src/backends/postgresql/blob.cpp
@@ -8,7 +8,6 @@
 #define SOCI_POSTGRESQL_SOURCE
 #include "soci/postgresql/soci-postgresql.h"
 #include <libpq/libpq-fs.h> // libpq
-#include <pg_config.h>      // for PG_VERSION_NUM
 #include <cctype>
 #include <cstdio>
 #include <cstring>
@@ -25,7 +24,7 @@ using namespace soci::details;
 
 // We need this helper function when using ancient PostgreSQL versions without
 // support for 64-bit offets.
-#if PG_VERSION_NUM < 90300
+#ifdef SOCI_POSTGRESQL_NO_LO64
 static int pg_check_fits_32_bits(std::size_t len)
 {
     if (len > 0x7fffffff)
@@ -159,7 +158,7 @@ void postgresql_blob_backend::trim(std::size_t newLen)
 
     init();
 
-#if PG_VERSION_NUM >= 90300
+#ifndef SOCI_POSTGRESQL_NO_LO64
     int ret_code = lo_truncate64(session_.conn_, details_.fd, newLen);
 #else
     int ret_code = lo_truncate(session_.conn_, details_.fd, pg_check_fits_32_bits(newLen));
@@ -251,7 +250,7 @@ void postgresql_blob_backend::reset()
 std::size_t do_seek(std::size_t toOffset, int from,
         soci::postgresql_session_backend &session, soci::postgresql_blob_backend::blob_details &details)
 {
-#if PG_VERSION_NUM >= 90300
+#ifndef SOCI_POSTGRESQL_NO_LO64
     pg_int64 pos = lo_lseek64(session.conn_, details.fd, static_cast<pg_int64>(toOffset), from);
 #else
     int pos = lo_lseek(session.conn_, details.fd, pg_check_fits_32_bits(toOffset), from);


### PR DESCRIPTION
Unfortunately pg_config.h is not available in all installations under
Windows, so don't rely on being able to include it and instead check
POSTGRESQL_VERSION in CMake and define SOCI_POSTGRESQL_NO_LO64 if
necessary.

This has an additional advantage of allowing to test this code easily
even when using PostgreSQL >= 9.3 by turning on this option.
