### PR TITLE
Various improvements to dynamic backend loading

### DIFF
--- a/src/core/backend-loader.cpp
+++ b/src/core/backend-loader.cpp
@@ -27,8 +27,13 @@ using namespace soci::dynamic_backends;
 
 #include <windows.h>
 
+namespace
+{
+
 typedef CRITICAL_SECTION soci_mutex_t;
 typedef HMODULE soci_dynlib_handle_t;
+
+} // unnamed namespace
 
 #define LOCK(x) EnterCriticalSection(x)
 #define UNLOCK(x) LeaveCriticalSection(x)
@@ -83,8 +88,13 @@ private:
 #include <pthread.h>
 #include <dlfcn.h>
 
+namespace
+{
+
 typedef pthread_mutex_t soci_mutex_t;
 typedef void * soci_dynlib_handle_t;
+
+} // unnamed namespace
 
 #define LOCK(x) pthread_mutex_lock(x)
 #define UNLOCK(x) pthread_mutex_unlock(x)

--- a/src/core/backend-loader.cpp
+++ b/src/core/backend-loader.cpp
@@ -28,7 +28,7 @@ using namespace soci::dynamic_backends;
 #include <windows.h>
 
 typedef CRITICAL_SECTION soci_mutex_t;
-typedef HMODULE soci_handler_t;
+typedef HMODULE soci_dynlib_handle_t;
 
 #define LOCK(x) EnterCriticalSection(x)
 #define UNLOCK(x) LeaveCriticalSection(x)
@@ -84,7 +84,7 @@ private:
 #include <dlfcn.h>
 
 typedef pthread_mutex_t soci_mutex_t;
-typedef void * soci_handler_t;
+typedef void * soci_dynlib_handle_t;
 
 #define LOCK(x) pthread_mutex_lock(x)
 #define UNLOCK(x) pthread_mutex_unlock(x)
@@ -114,7 +114,7 @@ namespace // unnamed
 
 struct info
 {
-    soci_handler_t handler_;
+    soci_dynlib_handle_t handle_;
     backend_factory const * factory_;
 
     // The use count is the number of existing sessions using this backend (in
@@ -134,7 +134,7 @@ struct info
     // use count drops to 0.
     bool unload_requested_;
 
-    info() : handler_(0), factory_(0), use_count_(0), unload_requested_(false) {}
+    info() : handle_(0), factory_(0), use_count_(0), unload_requested_(false) {}
 };
 
 typedef std::map<std::string, info> factory_map;
@@ -216,7 +216,7 @@ private:
 // non-synchronized helpers for the other functions
 factory_map::iterator do_unload(factory_map::iterator i)
 {
-    soci_handler_t h = i->second.handler_;
+    soci_dynlib_handle_t h = i->second.handle_;
     if (h != NULL)
     {
         DLCLOSE(h);
@@ -259,7 +259,7 @@ void do_register_backend(std::string const & name, std::string const & shared_ob
     MSWErrorMessageBoxDisabler no_message_boxes;
 #endif
 
-    soci_handler_t h = 0;
+    soci_dynlib_handle_t h = 0;
     std::string fullFileName;
     if (shared_object.empty() == false)
     {
@@ -340,7 +340,7 @@ void do_register_backend(std::string const & name, std::string const & shared_ob
 
     info new_entry;
     new_entry.factory_ = f;
-    new_entry.handler_ = h;
+    new_entry.handle_ = h;
 
     factories_[name] = new_entry;
 }

--- a/src/core/backend-loader.cpp
+++ b/src/core/backend-loader.cpp
@@ -267,15 +267,23 @@ void do_register_backend(std::string const & name, std::string const & shared_ob
         else
         {
             msg << "Failed to find shared library \"" << LIBNAME(name) << "\" "
-                << "for backend " << name
-                << " (even using extra search path \"";
-            for (std::size_t i = 0; i != search_paths_.size(); ++i)
+                << "for backend " << name;
+
+            // We always add "." as the first search path element, so it's not
+            // really useful to show it, but do show the search path if there
+            // is something else in it.
+            if (search_paths_.size() > 1 ||
+                (!search_paths_.empty() && search_paths_[0] != "."))
             {
-                if (i != 0)
-                    msg << ":";
-                msg << search_paths_[i];
+                msg << " (even using extra search path \"";
+                for (std::size_t i = 0; i != search_paths_.size(); ++i)
+                {
+                    if (i != 0)
+                        msg << ":";
+                    msg << search_paths_[i];
+                }
+                msg << "\")";
             }
-            msg << "\")";
         }
         throw soci_error(msg.str());
     }

--- a/src/core/backend-loader.cpp
+++ b/src/core/backend-loader.cpp
@@ -307,11 +307,7 @@ factory_map::iterator do_unload(factory_map::iterator i)
         DLCLOSE(h);
     }
 
-    // TODO-C++11: Use erase() return value.
-    factory_map::iterator const to_erase = i;
-    ++i;
-    factories_.erase(to_erase);
-    return i;
+    return factories_.erase(i);
 }
 
 void do_unload_or_throw_if_in_use(std::string const & name)


### PR DESCRIPTION
Improve error messages and the default path for loading, especially under Unix, where `dlopen()` doesn't look into the directory containing the loading module by default.