### PR TITLE
Run macOS CI jobs under macOS 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,42 +34,6 @@ jobs:
           - backend: postgresql
             runner: macos-14
             name: PostgreSQL macOS
-          - backend: oracle
-            name: Oracle 11
-            no_boost: true
-          - backend: valgrind
-            name: Valgrind
-          - backend: odbc
-            # There are many leak reports under Ubuntu 22.04, see #1008.
-            container: ubuntu:18.04
-            name: ODBC
-          - backend: firebird
-            name: Firebird
-          - backend: postgresql
-            name: PostgreSQL Linux
-          - backend: mysql
-            name: MySQL
-          - backend: sqlite3
-            runner: macos-14
-            name: SQLite3 macOS
-          - backend: sqlite3
-            name: SQLite3 C++17
-            cxxstd: 17
-          - backend: sqlite3
-            name: SQLite3
-          - backend: empty
-            runner: macos-14
-            name: Empty macOS
-          - backend: empty
-            name: Empty
-            test_release_package: true
-          # Unsupported: db2exc package is only available in Ubuntu 14.04 not
-          # supported by GitHub Actions any longer, we'd need to run it in
-          # Docker container if we really need it.
-          # backend: db2
-          - backend: empty
-            name: Examples
-            build_examples: true
 
     env:
       SOCI_CI: true
@@ -140,6 +104,9 @@ jobs:
           if [ "${{matrix.build_examples}}" = true ]; then
             set_env_var BUILD_EXAMPLES YES
           fi
+
+      - name: Setup tmate
+        uses: mxschmitt/action-tmate@v3
 
       - name: Install dependencies
         run: ./scripts/ci/install.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
               ;;
 
             macOS)
-              set_env_var PGDATA /usr/local/var/postgres
+              set_env_var PGDATA /opt/homebrew/var/postgresql@14
               ;;
           esac
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,7 @@ jobs:
             set_env_var BUILD_EXAMPLES YES
           fi
 
-      - name: Install dependencies under Linux
-        if: runner.os == 'Linux'
+      - name: Install dependencies
         run: ./scripts/ci/install.sh
 
       - name: Prepare for build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           # Note: the jobs are ordered in the order of decreasing running
           # time, as this should minimize the total run-time of all jobs.
           - backend: postgresql
-            runner: macos-12
+            runner: macos-14
             name: PostgreSQL macOS
           - backend: oracle
             name: Oracle 11
@@ -50,7 +50,7 @@ jobs:
           - backend: mysql
             name: MySQL
           - backend: sqlite3
-            runner: macos-12
+            runner: macos-14
             name: SQLite3 macOS
           - backend: sqlite3
             name: SQLite3 C++17
@@ -58,7 +58,7 @@ jobs:
           - backend: sqlite3
             name: SQLite3
           - backend: empty
-            runner: macos-12
+            runner: macos-14
             name: Empty macOS
           - backend: empty
             name: Empty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ on:
       - .cirrus.yml
       - .github/workflows/codeql.yml
       - appveyor.yml
+  workflow_dispatch:
+    inputs:
+      enable_ssh:
+        type: boolean
+        description: 'Enable ssh server before running the job'
+        required: false
+        default: false
 
 jobs:
   build:
@@ -107,6 +114,7 @@ jobs:
 
       - name: Setup tmate
         uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.enable_ssh }}
 
       - name: Install dependencies
         run: ./scripts/ci/install.sh

--- a/scripts/ci/before_build_postgresql.sh
+++ b/scripts/ci/before_build_postgresql.sh
@@ -13,7 +13,6 @@ case "$(uname)" in
         ;;
 
     Darwin)
-        pg_ctl init
         pg_ctl start
         pg_isready --timeout=60
         createuser --superuser postgres

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -52,6 +52,19 @@ case "$(uname)" in
     FreeBSD)
         pkg install -q -y bash cmake
         ;;
+
+    Darwin)
+        case "${SOCI_CI_BACKEND}" in
+            postgresql)
+                brew install postgresql
+                ;;
+        esac
+        ;;
+
+    *)
+        echo "Unknown platform: $(uname)"
+        exit 1
+        ;;
 esac
 
 install_script="${SOCI_SOURCE_DIR}/scripts/ci/install_${SOCI_CI_BACKEND}.sh"


### PR DESCRIPTION
The currently used macOS 12 images are deprecated and will cease to be available on GitHub soon.