### PR TITLE
Improvement to connection parameters handling

### DIFF
--- a/docs/backends/postgresql.md
+++ b/docs/backends/postgresql.md
@@ -62,11 +62,6 @@ Note that in the single-row operation:
 * bulk queries are not supported, and
 * in order to fulfill the expectations of the underlying client library, the complete rowset has to be exhausted before executing further queries on the same session.
 
-Also please note that single rows mode requires PostgreSQL 9 or later, both at
-compile- and run-time. If you need to support earlier versions of PostgreSQL,
-you can define `SOCI_POSTGRESQL_NOSINGLEROWMODE` when building the library to
-disable it.
-
 Once you have created a `session` object as shown above, you can use it to access the database, for example:
 
 ```cpp

--- a/docs/backends/sqlite3.md
+++ b/docs/backends/sqlite3.md
@@ -47,14 +47,21 @@ session sql("sqlite3", "db=db.sqlite timeout=2 shared_cache=true");
 
 The set of parameters used in the connection string for SQLite is:
 
-* `dbname` or `db`
+* `dbname` or `db` - this parameter is required unless the entire connection
+string is just the database name, in which case it must not contain any `=`
+signs.
 * `timeout` - set sqlite busy timeout (in seconds) ([link](http://www.sqlite.org/c3ref/busy_timeout.html))
 * `readonly` - open database in read-only mode instead of the default read-write (note that the database file must already exist in this case, see [the documentation](https://www.sqlite.org/c3ref/open.html))
 * `nocreate` - open an existing database without creating a new one if it doesn't already exist (by default, a new database file is created).
 * `synchronous` - set the pragma synchronous flag ([link](http://www.sqlite.org/pragma.html#pragma_synchronous))
-* `shared_cache` - should be `true` ([link](http://www.sqlite.org/c3ref/enable_shared_cache.html))
+* `shared_cache` - enable or disabled shared pager cache ([link](http://www.sqlite.org/c3ref/enable_shared_cache.html))
 * `vfs` - set the SQLite VFS used to as OS interface. The VFS should be registered before opening the connection, see [the documenation](https://www.sqlite.org/vfs.html)
-* `foreign_keys` - set the pragma foreign_keys flag ([link](https://www.sqlite.org/pragma.html#pragma_foreign_keys)).
+* `foreign_keys` - set the pragma `foreign_keys` flag ([link](https://www.sqlite.org/pragma.html#pragma_foreign_keys)).
+
+Boolean options `readonly`, `nocreate`, and `shared_cache` can be either
+specified without any value, which is equivalent to setting them to `1`, or set
+to one of `1`, `yes`, `true` or `on` to enable the option or `0`, `no`, `false`
+or `off` to disable it. Specifying any other value results in an error.
 
 Once you have created a `session` object as shown above, you can use it to access the database, for example:
 

--- a/include/private/soci-case.h
+++ b/include/private/soci-case.h
@@ -1,0 +1,58 @@
+//
+// Copyright (C) 2024 Vadim Zeitlin.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_PRIVATE_SOCI_CASE_H_INCLUDED
+#define SOCI_PRIVATE_SOCI_CASE_H_INCLUDED
+
+#include <cctype>
+#include <string>
+
+namespace soci
+{
+
+namespace details
+{
+
+// Simplistic conversions of strings to upper/lower case.
+//
+// This doesn't work correctly for arbitrary Unicode strings for well-known
+// reasons (such conversions can't be done correctly on char by char basis),
+// but they do work for ASCII strings that we deal with and for anything else
+// we'd need ICU -- which we could start using later, if necessary, by just
+// replacing these functions with the versions using ICU functions instead.
+
+inline std::string string_toupper(std::string const& s)
+{
+    std::string res;
+    res.reserve(s.size());
+
+    for (char c : s)
+    {
+        res += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    }
+
+    return res;
+}
+
+inline std::string string_tolower(std::string const& s)
+{
+    std::string res;
+    res.reserve(s.size());
+
+    for (char c : s)
+    {
+        res += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+
+    return res;
+}
+
+} // namespace details
+
+} // namespace soci
+
+#endif // SOCI_PRIVATE_SOCI_CASE_H_INCLUDED

--- a/include/soci/connection-parameters.h
+++ b/include/soci/connection-parameters.h
@@ -62,6 +62,10 @@ public:
     // Note that currently unknown options are simply ignored.
     void extract_options_from_space_separated_string();
 
+    // Build a space-separated string from the options, quoting the options
+    // values using the provided quote character.
+    std::string build_string_from_options(char quote) const;
+
 
     // Set the value of the given option, overwriting any previous value.
     void set_option(const char * name, std::string const & value)

--- a/include/soci/connection-parameters.h
+++ b/include/soci/connection-parameters.h
@@ -82,6 +82,20 @@ public:
         return true;
     }
 
+    // Same as get_option(), but also removes the option from the connection
+    // string if it was present in it.
+    bool extract_option(const char * name, std::string & value)
+    {
+        Options::iterator const it = options_.find(name);
+        if (it == options_.end())
+            return false;
+
+        value = it->second;
+        options_.erase(it);
+
+        return true;
+    }
+
     // Return true if the option with the given name has one of the values
     // considered to be true, i.e. "1", "yes", "true" or "on" or is empty.
     // Return false if the value is one of "0", "no", "false" or "off" or the

--- a/include/soci/connection-parameters.h
+++ b/include/soci/connection-parameters.h
@@ -51,6 +51,18 @@ public:
     void set_connect_string(const std::string & connectString) { connectString_ = connectString; }
     std::string const & get_connect_string() const { return connectString_; }
 
+
+    // For some (but not all) backends the connection string consists of
+    // space-separated name=value pairs. This function parses the string
+    // assuming it uses this syntax and sets the options accordingly.
+    //
+    // If it detects invalid syntax, e.g. a name without a corresponding value,
+    // it throws an exception.
+    //
+    // Note that currently unknown options are simply ignored.
+    void extract_options_from_space_separated_string();
+
+
     // Set the value of the given option, overwriting any previous value.
     void set_option(const char * name, std::string const & value)
     {

--- a/include/soci/connection-parameters.h
+++ b/include/soci/connection-parameters.h
@@ -82,12 +82,21 @@ public:
         return true;
     }
 
-    // Return true if the option with the given name was found with option_true
-    // value.
+    // Return true if the option with the given name has one of the values
+    // considered to be true, i.e. "1", "yes", "true" or "on" or is empty.
+    // Return false if the value is one of "0", "no", "false" or "off" or the
+    // option was not specified at all.
+    //
+    // Throw an exception if the option was given but the value is none of
+    // the above, comparing case-insensitively.
+    static bool is_true_value(const char * name, std::string const & value);
+
+    // Return true if the option with the given name was found with a "true"
+    // value in the sense of is_true_value() above.
     bool is_option_on(const char * name) const
     {
       std::string value;
-      return get_option(name, value) && value == option_true;
+      return get_option(name, value) && is_true_value(name, value);
     }
 
 private:

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -384,8 +384,7 @@ private:
 
 struct SOCI_POSTGRESQL_DECL postgresql_session_backend : details::session_backend
 {
-    postgresql_session_backend(connection_parameters const & parameters,
-        bool single_row_mode);
+    explicit postgresql_session_backend(connection_parameters const & parameters);
 
     ~postgresql_session_backend() override;
 

--- a/src/backends/firebird/session.cpp
+++ b/src/backends/firebird/session.cpp
@@ -9,7 +9,6 @@
 #include "soci/firebird/soci-firebird.h"
 #include "firebird/error-firebird.h"
 #include "soci/session.h"
-#include <locale>
 #include <map>
 #include <sstream>
 #include <string>
@@ -19,182 +18,6 @@ using namespace soci::details::firebird;
 
 namespace
 {
-
-// Helpers of explodeISCConnectString() for reading words from a string. "Word"
-// here is defined very loosely as just a sequence of non-space characters.
-//
-// All these helper functions update the input iterator to point to the first
-// character not consumed by them.
-
-// Advance the input iterator until the first non-space character or end of the
-// string.
-void skipWhiteSpace(std::string::const_iterator& i, std::string::const_iterator const &end)
-{
-    std::locale const loc;
-    for (; i != end; ++i)
-    {
-        if (!std::isspace(*i, loc))
-            break;
-    }
-}
-
-// Return the string of all characters until the first space or the specified
-// delimiter.
-//
-// Throws if the first non-space character after the end of the word is not the
-// delimiter. However just returns en empty string, without throwing, if
-// nothing is left at all in the string except for white space.
-std::string
-getWordUntil(std::string const &s, std::string::const_iterator &i, char delim)
-{
-    std::string::const_iterator const end = s.end();
-    skipWhiteSpace(i, end);
-
-    // We need to handle this case specially because it's not an error if
-    // nothing at all remains in the string. But if anything does remain, then
-    // we must have the delimiter.
-    if (i == end)
-        return std::string();
-
-    // Simply put anything until the delimiter into the word, stopping at the
-    // first white space character.
-    std::string word;
-    std::locale const loc;
-    for (; i != end; ++i)
-    {
-        if (*i == delim)
-            break;
-
-        if (std::isspace(*i, loc))
-        {
-            skipWhiteSpace(i, end);
-            if (i == end || *i != delim)
-            {
-                std::ostringstream os;
-                os << "Expected '" << delim << "' at position "
-                   << (i - s.begin() + 1)
-                   << " in Firebird connection string \""
-                   << s << "\".";
-
-                throw soci_error(os.str());
-            }
-
-            break;
-        }
-
-        word += *i;
-    }
-
-    if (i == end)
-    {
-        std::ostringstream os;
-        os << "Expected '" << delim
-           << "' not found before the end of the string "
-           << "in Firebird connection string \""
-           << s << "\".";
-
-        throw soci_error(os.str());
-    }
-
-    ++i;    // Skip the delimiter itself.
-
-    return word;
-}
-
-// Return a possibly quoted word, i.e. either just a sequence of non-space
-// characters or everything inside a double-quoted string.
-//
-// Throws if the word is quoted and the closing quote is not found. However
-// doesn't throw, just returns an empty string if there is nothing left.
-std::string
-getPossiblyQuotedWord(std::string const &s, std::string::const_iterator &i)
-{
-    std::string::const_iterator const end = s.end();
-    skipWhiteSpace(i, end);
-
-    std::string word;
-
-    if (i != end && *i == '"')
-    {
-        for (;;)
-        {
-            if (++i == end)
-            {
-                std::ostringstream os;
-                os << "Expected '\"' not found before the end of the string "
-                      "in Firebird connection string \""
-                   << s << "\".";
-
-                throw soci_error(os.str());
-            }
-
-            if (*i == '"')
-            {
-                ++i;
-                break;
-            }
-
-            word += *i;
-        }
-    }
-    else // Not quoted.
-    {
-        std::locale const loc;
-        for (; i != end; ++i)
-        {
-            if (std::isspace(*i, loc))
-                break;
-
-            word += *i;
-        }
-    }
-
-    return word;
-}
-
-// retrieves parameters from the uniform connect string which is supposed to be
-// in the form "key=value[ key2=value2 ...]" and the values may be quoted to
-// allow including spaces into them. Notice that currently there is no way to
-// include both a space and a double quote in a value.
-std::map<std::string, std::string>
-explodeISCConnectString(std::string const &connectString)
-{
-    std::map<std::string, std::string> parameters;
-
-    std::string key, value;
-    for (std::string::const_iterator i = connectString.begin(); ; )
-    {
-        key = getWordUntil(connectString, i, '=');
-        if (key.empty())
-            break;
-
-        value = getPossiblyQuotedWord(connectString, i);
-
-        parameters.insert(std::pair<std::string, std::string>(key, value));
-    }
-
-    return parameters;
-}
-
-// extracts given parameter from map previusly build with explodeISCConnectString
-bool getISCConnectParameter(std::map<std::string, std::string> const & m, std::string const & key,
-    std::string & value)
-{
-    std::map <std::string, std::string> :: const_iterator i;
-    value.clear();
-
-    i = m.find(key);
-
-    if (i != m.end())
-    {
-        value = i->second;
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
 
 void setDPBOption(std::string& dpb, int const option, std::string const & value)
 {
@@ -216,36 +39,35 @@ firebird_session_backend::firebird_session_backend(
     connection_parameters const & parameters) : dbhp_(0), trhp_(0)
                                          , decimals_as_strings_(false)
 {
-    // extract connection parameters
-    std::map<std::string, std::string>
-        params(explodeISCConnectString(parameters.get_connect_string()));
+    auto params = parameters;
+    params.extract_options_from_space_separated_string();
 
     ISC_STATUS stat[stat_size];
     std::string param;
 
     // preparing connection options
     std::string dpb;
-    if (getISCConnectParameter(params, "user", param))
+    if (params.get_option("user", param))
     {
         setDPBOption(dpb, isc_dpb_user_name, param);
     }
 
-    if (getISCConnectParameter(params, "password", param))
+    if (params.get_option("password", param))
     {
         setDPBOption(dpb, isc_dpb_password, param);
     }
 
-    if (getISCConnectParameter(params, "role", param))
+    if (params.get_option("role", param))
     {
         setDPBOption(dpb, isc_dpb_sql_role_name, param);
     }
 
-    if (getISCConnectParameter(params, "charset", param))
+    if (params.get_option("charset", param))
     {
         setDPBOption(dpb, isc_dpb_lc_ctype, param);
     }
 
-    if (getISCConnectParameter(params, "service", param) == false)
+    if (!params.get_option("service", param))
     {
         throw soci_error("Service name not specified.");
     }
@@ -258,7 +80,7 @@ firebird_session_backend::firebird_session_backend(
         throw_iscerror(stat);
     }
 
-    if (getISCConnectParameter(params, "decimals_as_strings", param))
+    if (params.get_option("decimals_as_strings", param))
     {
         decimals_as_strings_ = param == "1" || param == "Y" || param == "y";
     }

--- a/src/backends/oracle/factory.cpp
+++ b/src/backends/oracle/factory.cpp
@@ -9,11 +9,13 @@
 #include "soci/oracle/soci-oracle.h"
 #include "soci/connection-parameters.h"
 #include "soci/backend-loader.h"
+
+#include "soci-cstrtoi.h"
+
 #include <cctype>
 #include <cstdio>
 #include <cstring>
 #include <ctime>
-#include <sstream>
 
 #ifdef _MSC_VER
 #pragma warning(disable:4355)
@@ -45,11 +47,7 @@ int charset_code(const std::string & name)
     else
     {
         // allow explicit number value
-
-        std::istringstream ss(name);
-
-        ss >> code;
-        if (!ss)
+        if (!cstring_to_unsigned(code, name.c_str()))
         {
             throw soci_error("Invalid character set name.");
         }

--- a/src/backends/oracle/factory.cpp
+++ b/src/backends/oracle/factory.cpp
@@ -22,53 +22,6 @@
 using namespace soci;
 using namespace soci::details;
 
-// iterates the string pointed by i, searching for pairs of key value.
-// it returns the position after the value
-std::string::const_iterator get_key_value(std::string::const_iterator & i,
-                                          std::string::const_iterator const & end,
-                                          std::string & key,
-                                          std::string & value)
-{
-    bool in_value = false;
-    bool quoted = false;
-
-    key.clear();
-    value.clear();
-
-    while (i != end)
-    {
-        if (in_value == false)
-        {
-            if (*i == '=')
-            {
-                in_value = true;
-                if (i != end && *(i + 1) == '"')
-                {
-                    quoted = true;
-                    ++i; // jump over the quote
-                }
-            }
-            else if (!isspace(*i))
-            {
-                key += *i;
-            }
-        }
-        else
-        {
-            if ((quoted == true && *i == '"') || (quoted == false && isspace(*i)))
-            {
-                return ++i;
-            }
-            else
-            {
-                value += *i;
-            }
-        }
-        ++i;
-    }
-    return i;
-}
-
 // decode charset and ncharset names
 int charset_code(const std::string & name)
 {
@@ -105,84 +58,57 @@ int charset_code(const std::string & name)
     return code;
 }
 
-// retrieves service name, user name and password from the
-// uniform connect string
-void chop_connect_string(std::string const & connectString,
-    std::string & serviceName, std::string & userName,
-    std::string & password, int & mode, bool & decimals_as_strings,
-    int & charset, int & ncharset)
-{
-    serviceName.clear();
-    userName.clear();
-    password.clear();
-    mode = OCI_DEFAULT;
-    decimals_as_strings = false;
-    charset = 0;
-    ncharset = 0;
-
-    std::string key, value;
-    std::string::const_iterator i = connectString.begin();
-    while (i != connectString.end())
-    {
-        i = get_key_value(i, connectString.end(), key, value);
-        if (key == "service")
-        {
-            serviceName = value;
-        }
-        else if (key == "user")
-        {
-            userName = value;
-        }
-        else if (key == "password")
-        {
-            password = value;
-        }
-        else if (key == "mode")
-        {
-            if (value == "sysdba")
-            {
-                mode = OCI_SYSDBA;
-            }
-            else if (value == "sysoper")
-            {
-                mode = OCI_SYSOPER;
-            }
-            else if (value == "default")
-            {
-                mode = OCI_DEFAULT;
-            }
-            else
-            {
-                throw soci_error("Invalid connection mode.");
-            }
-        }
-        else if (key == "decimals_as_strings")
-        {
-            decimals_as_strings = value == "1" || value == "Y" || value == "y";
-        }
-        else if (key == "charset")
-        {
-            charset = charset_code(value);
-        }
-        else if (key == "ncharset")
-        {
-            ncharset = charset_code(value);
-        }
-    }
-}
-
-// concrete factory for Empty concrete strategies
 oracle_session_backend * oracle_backend_factory::make_session(
      connection_parameters const & parameters) const
 {
-    std::string serviceName, userName, password;
-    int mode;
-    bool decimals_as_strings;
-    int charset;
-    int ncharset;
+    std::string value;
 
-    chop_connect_string(parameters.get_connect_string(), serviceName, userName, password,
-        mode, decimals_as_strings, charset, ncharset);
+    auto params = parameters;
+    params.extract_options_from_space_separated_string();
+
+    std::string serviceName, userName, password;
+    params.get_option("service", serviceName);
+    params.get_option("user", userName);
+    params.get_option("password", password);
+
+    int mode = OCI_DEFAULT;
+    if (params.get_option("mode", value))
+    {
+        if (value == "sysdba")
+        {
+            mode = OCI_SYSDBA;
+        }
+        else if (value == "sysoper")
+        {
+            mode = OCI_SYSOPER;
+        }
+        else if (value == "default")
+        {
+            mode = OCI_DEFAULT;
+        }
+        else
+        {
+            throw soci_error("Invalid connection mode.");
+        }
+    }
+
+    bool decimals_as_strings = false;
+    if (params.get_option("decimals_as_strings", value))
+    {
+        decimals_as_strings = value == "1" || value == "Y" || value == "y";
+    }
+
+    int charset = 0;
+    if (params.get_option("charset", value))
+    {
+        charset = charset_code(value);
+    }
+
+    int ncharset = 0;
+    if (params.get_option("ncharset", value))
+    {
+        ncharset = charset_code(value);
+    }
 
     return new oracle_session_backend(serviceName, userName, password,
         mode, decimals_as_strings, charset, ncharset);

--- a/src/backends/postgresql/factory.cpp
+++ b/src/backends/postgresql/factory.cpp
@@ -18,103 +18,10 @@
 using namespace soci;
 using namespace soci::details;
 
-namespace // unnamed
-{
-
-// iterates the string pointed by i, searching for pairs of key value.
-// it returns the position after the value
-std::string::const_iterator get_key_value(std::string::const_iterator & i,
-                                          std::string::const_iterator const & end,
-                                          std::string & key,
-                                          std::string & value)
-{
-    bool in_value = false;
-    bool quoted = false;
-
-    key.clear();
-    value.clear();
-
-    while (i != end)
-    {
-        if (in_value == false)
-        {
-            if (*i == '=')
-            {
-                in_value = true;
-                if (i != end && *(i + 1) == '"')
-                {
-                    quoted = true;
-                    ++i; // jump over the quote
-                }
-            }
-            else if (!isspace(*i))
-            {
-                key += *i;
-            }
-        }
-        else
-        {
-            if ((quoted == true && *i == '"') || (quoted == false && isspace(*i)))
-            {
-                return ++i;
-            }
-            else
-            {
-                value += *i;
-            }
-        }
-        ++i;
-    }
-    return i;
-}
-
-// retrieves specific parameters from the
-// uniform connect string
-std::string chop_connect_string(std::string const & connectString,
-    bool & single_row_mode)
-{
-    std::string pruned_conn_string;
-
-    single_row_mode = false;
-
-    std::string key, value;
-    std::string::const_iterator i = connectString.begin();
-    while (i != connectString.end())
-    {
-        i = get_key_value(i, connectString.end(), key, value);
-        if (key == "singlerow" || key == "singlerows")
-        {
-            single_row_mode = (value == "true" || value == "yes");
-        }
-        else
-        {
-            if (pruned_conn_string.empty() == false)
-            {
-                pruned_conn_string += ' ';
-            }
-
-            pruned_conn_string += key + '=' + value;
-        }
-    }
-
-    return pruned_conn_string;
-}
-
-} // unnamed namespace
-
-// concrete factory for Empty concrete strategies
 postgresql_session_backend * postgresql_backend_factory::make_session(
      connection_parameters const & parameters) const
 {
-    bool single_row_mode;
-
-    const std::string pruned_conn_string =
-        chop_connect_string(parameters.get_connect_string(), single_row_mode);
-
-    connection_parameters pruned_parameters(parameters);
-    pruned_parameters.set_connect_string(pruned_conn_string);
-
-    return new postgresql_session_backend(pruned_parameters, single_row_mode);
+    return new postgresql_session_backend(parameters);
 }
 
 postgresql_backend_factory const soci::postgresql;

--- a/src/backends/postgresql/session.cpp
+++ b/src/backends/postgresql/session.cpp
@@ -141,10 +141,10 @@ std::string create_case_list_of_strings(const std::vector<std::string>& list)
 } // namespace unnamed
 
 postgresql_session_backend::postgresql_session_backend(
-    connection_parameters const& parameters, bool single_row_mode)
+    connection_parameters const& parameters)
     : statementCount_(0), conn_(0)
 {
-    single_row_mode_ = single_row_mode;
+    single_row_mode_ = false;
 
     connect(parameters);
 }
@@ -152,7 +152,34 @@ postgresql_session_backend::postgresql_session_backend(
 void postgresql_session_backend::connect(
     connection_parameters const& parameters)
 {
-    PGconn* conn = PQconnectdb(parameters.get_connect_string().c_str());
+    auto params = parameters;
+    params.extract_options_from_space_separated_string();
+
+    // Extract SOCI-specific options, i.e. check if they're present and remove
+    // them from params to avoid passing them to PQconnectdb() below.
+    std::string value;
+
+    // This one is not used by this backend, but can be present in the
+    // connection string if we're called from session::reconnect().
+    params.extract_option(option_reconnect, value);
+
+    // Notice that we accept both variants only for compatibility.
+    char const* name;
+    if (params.extract_option("singlerow", value))
+        name = "singlerow";
+    else if (params.extract_option("singlerows", value))
+        name = "singlerows";
+    else
+        name = nullptr;
+
+    if (name)
+    {
+        single_row_mode_ = connection_parameters::is_true_value(name, value);
+    }
+
+    // We can't use SOCI connection string with PQconnectdb() directly because
+    // libpq uses single quotes instead of double quotes used by SOCI.
+    PGconn* conn = PQconnectdb(params.build_string_from_options('\'').c_str());
     if (0 == conn || CONNECTION_OK != PQstatus(conn))
     {
         std::string msg = "Cannot establish connection to the database.";

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -16,15 +16,11 @@
 #include <sstream>
 #include <string>
 
+#include "soci-case.h"
+
 #ifdef _MSC_VER
 #pragma warning(disable:4355)
 #endif
-
-// This is used instead of tolower() just to avoid warnings about int to char
-// casts inside MSVS std::transform() implementation.
-char toLowerCh(char c) {
-    return static_cast<char>( std::tolower(c) );
-}
 
 using namespace soci;
 using namespace soci::details;
@@ -550,7 +546,7 @@ void sqlite3_statement_backend::describe_column(int colNum,
         dt.resize(siter - dt.begin());
 
     // do all comparisons in lower case
-    std::transform(dt.begin(), dt.end(), dt.begin(), toLowerCh);
+    dt = string_tolower(dt);
 
     sqlite3_data_type_map::const_iterator iter = dataTypeMap.find(dt);
     if (iter != dataTypeMap.end())

--- a/src/core/connection-parameters.cpp
+++ b/src/core/connection-parameters.cpp
@@ -201,68 +201,6 @@ skipWhiteSpace(std::string::const_iterator& i,
     }
 }
 
-// Return the string of all characters until the first space or the specified
-// delimiter.
-//
-// Throws if the first non-space character after the end of the word is not the
-// delimiter. However just returns en empty string, without throwing, if
-// nothing is left at all in the string except for white space.
-std::string
-getWordUntil(std::string const &s, std::string::const_iterator &i, char delim)
-{
-    std::string::const_iterator const end = s.end();
-    skipWhiteSpace(i, end);
-
-    // We need to handle this case specially because it's not an error if
-    // nothing at all remains in the string. But if anything does remain, then
-    // we must have the delimiter.
-    if (i == end)
-        return std::string();
-
-    // Simply put anything until the delimiter into the word, stopping at the
-    // first white space character.
-    std::string word;
-    for (; i != end; ++i)
-    {
-        if (*i == delim)
-            break;
-
-        if (isSpace(i))
-        {
-            skipWhiteSpace(i, end);
-            if (i == end || *i != delim)
-            {
-                std::ostringstream os;
-                os << "Expected '" << delim << "' at position "
-                   << (i - s.begin() + 1)
-                   << " in the connection string \""
-                   << s << "\".";
-
-                throw soci_error(os.str());
-            }
-
-            break;
-        }
-
-        word += *i;
-    }
-
-    if (i == end)
-    {
-        std::ostringstream os;
-        os << "Expected '" << delim
-           << "' not found before the end of the string "
-           << "in the connection string \""
-           << s << "\".";
-
-        throw soci_error(os.str());
-    }
-
-    ++i;    // Skip the delimiter itself.
-
-    return word;
-}
-
 // Return a possibly quoted word, i.e. either just a sequence of non-space
 // characters or everything inside a double-quoted string.
 //
@@ -314,15 +252,59 @@ getPossiblyQuotedWord(std::string const &s, std::string::const_iterator &i)
 }
 
 } // namespace anonymous
+
 void connection_parameters::extract_options_from_space_separated_string()
 {
+    constexpr char delim = '=';
+
+    std::string::const_iterator const end = connectString_.end();
     for (std::string::const_iterator i = connectString_.begin(); ; )
     {
-        const auto name = getWordUntil(connectString_, i, '=');
-        if (name.empty())
-            break;
+        skipWhiteSpace(i, end);
 
-        options_[name] = getPossiblyQuotedWord(connectString_, i);
+        // Anything until the delimiter or space is the name.
+        std::string name;
+        std::string value;
+        for (;;)
+        {
+            if (i == end || isSpace(i))
+                break;
+
+            if (*i == delim)
+            {
+                if (name.empty())
+                {
+                    std::ostringstream os;
+                    os << "Unexpected '"
+                       << delim
+                       << "' without a name at position "
+                       << (i - connectString_.begin() + 1)
+                       << " in the connection string \""
+                       << connectString_
+                       << "\".";
+
+                    throw soci_error(os.str());
+                }
+
+                ++i;    // Skip the delimiter itself.
+
+                // And get the option value which follows it.
+                value = getPossiblyQuotedWord(connectString_, i);
+                break;
+            }
+
+            name += *i++;
+        }
+
+        if (name.empty())
+        {
+            // We've reached the end of the string and there is nothing left.
+            break;
+        }
+
+        // Note that value may be empty here, we intentionally allow specifying
+        // options without values, e.g. just "switch" instead of "switch=1".
+        options_[name] = value;
     }
 }
 

--- a/src/core/connection-parameters.cpp
+++ b/src/core/connection-parameters.cpp
@@ -10,6 +10,8 @@
 #include "soci/soci-backend.h"
 #include "soci/backend-loader.h"
 
+#include "soci-case.h"
+
 char const * soci::option_reconnect = "reconnect";
 
 char const * soci::option_true = "1";
@@ -169,6 +171,32 @@ void connection_parameters::reset_after_move()
 {
     factory_ = nullptr;
     backendRef_ = nullptr;
+}
+
+/* static */
+bool
+connection_parameters::is_true_value(char const* name, std::string const& value)
+{
+    // At least for compatibility (but also because this is convenient and
+    // makes sense), we accept "readonly" as synonym for "readonly=1" etc.
+    if (value.empty())
+        return true;
+
+    std::string const val = details::string_tolower(value);
+
+    if (val == "1" || val == "yes" || val == "true" || val == "on")
+        return true;
+
+    if (val == "0" || val == "no" || val == "false" || val == "off")
+        return false;
+
+    std::ostringstream os;
+    os << R"(Invalid value ")"
+       << value
+       << R"(" for boolean option ")"
+       << name
+       << '"';
+    throw soci_error(os.str());
 }
 
 namespace

--- a/src/core/connection-parameters.cpp
+++ b/src/core/connection-parameters.cpp
@@ -336,4 +336,48 @@ void connection_parameters::extract_options_from_space_separated_string()
     }
 }
 
+std::string
+connection_parameters::build_string_from_options(char quote) const
+{
+    std::string res;
+
+    for (auto const& option : options_)
+    {
+        if (!res.empty())
+        {
+            res += ' ';
+        }
+
+        res += option.first;
+        res += '=';
+
+        // Quote the value if it contains spaces or the quote character itself.
+        auto const& value = option.second;
+        if (value.empty() ||
+                value.find(' ') != std::string::npos ||
+                    value.find(quote) != std::string::npos)
+        {
+            res += quote;
+
+            for (char c : value)
+            {
+                if (c == quote)
+                {
+                    res += '\\';
+                }
+
+                res += c;
+            }
+
+            res += quote;
+        }
+        else
+        {
+            res += value;
+        }
+    }
+
+    return res;
+}
+
 } // namespace soci

--- a/src/core/row.cpp
+++ b/src/core/row.cpp
@@ -10,9 +10,10 @@
 #include "soci/type-holder.h"
 
 #include <cstddef>
-#include <cctype>
 #include <sstream>
 #include <string>
+
+#include "soci-case.h"
 
 using namespace soci;
 using namespace details;
@@ -40,10 +41,7 @@ void row::add_properties(column_properties const &cp)
     std::string const & originalName = cp.get_name();
     if (uppercaseColumnNames_)
     {
-        for (std::size_t i = 0; i != originalName.size(); ++i)
-        {
-            columnName.push_back(static_cast<char>(std::toupper(originalName[i])));
-        }
+        columnName = string_toupper(originalName);
 
         // rewrite the column name in the column_properties object
         // as well to retain consistent views

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(soci_tests_common STATIC
   common/test-main.cpp
   common/test-boost.cpp
   common/test-common.cpp
+  common/test-connparams.cpp
   common/test-custom.cpp
   common/test-dynamic.cpp
   common/test-lob.cpp

--- a/tests/common/test-common.cpp
+++ b/tests/common/test-common.cpp
@@ -3730,6 +3730,7 @@ TEST_CASE_METHOD(common_tests, "Logger", "[core][log]")
 //
 // These variables are defined in other files we want to force linking with.
 extern volatile bool soci_use_test_boost;
+extern volatile bool soci_use_test_connparams;
 extern volatile bool soci_use_test_custom;
 extern volatile bool soci_use_test_dynamic;
 extern volatile bool soci_use_test_lob;
@@ -3742,6 +3743,7 @@ test_context_common::test_context_common()
     soci_use_test_boost = true;
 #endif
 
+    soci_use_test_connparams = true;
     soci_use_test_custom = true;
     soci_use_test_dynamic = true;
     soci_use_test_lob = true;

--- a/tests/common/test-connparams.cpp
+++ b/tests/common/test-connparams.cpp
@@ -124,6 +124,16 @@ TEST_CASE("connection_parameters::extract_option", "[core][connstring]")
     CHECK(!params.get_option("bar", value));
 }
 
+TEST_CASE("connection_parameters::build_string_from_options", "[core][connstring]")
+{
+    connection_parameters params(backEnd, R"(foo bar="baz" quux="1 2")");
+    params.extract_options_from_space_separated_string();
+
+    // Check that unecessary quotes are removed, empty value are explicitly
+    // specified and the required quotes are kept.
+    CHECK(params.build_string_from_options('\'') == "bar=baz foo='' quux='1 2'");
+}
+
 } // namespace tests
 
 } // namespace soci

--- a/tests/common/test-connparams.cpp
+++ b/tests/common/test-connparams.cpp
@@ -1,0 +1,112 @@
+//
+// Copyright (C) 2024 Vadim Zeitlin
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include "soci/soci.h"
+
+#include <catch.hpp>
+
+#include "test-context.h"
+
+namespace soci
+{
+
+namespace tests
+{
+
+// This variable is referenced from test-common.cpp to force linking this file.
+volatile bool soci_use_test_connparams = false;
+
+// A helper to check that parsing the given connection string works.
+connection_parameters parse_connection_string(std::string const& connstr)
+{
+    connection_parameters params(backEnd, connstr);
+
+    REQUIRE_NOTHROW(params.extract_options_from_space_separated_string());
+
+    return params;
+}
+
+// A similar one checking that the given connection string is invalid.
+void check_invalid_connection_string(std::string const& connstr)
+{
+    INFO(R"(Parsing invalid connection string ")" << connstr << R"(")");
+
+    connection_parameters params(backEnd, connstr);
+
+    CHECK_THROWS_AS(params.extract_options_from_space_separated_string(),
+                    soci_error);
+}
+
+// Another helper to check that the given option has the expected value.
+void
+check_option(connection_parameters const& params,
+             char const* name,
+             std::string const& expected)
+{
+    std::string value;
+    if ( params.get_option(name, value) )
+    {
+        CHECK(value == expected);
+    }
+    else
+    {
+        FAIL_CHECK(R"(Option ")" << name << R"(" not found)");
+    }
+}
+
+TEST_CASE("Connection string parsing", "[core][connstring]")
+{
+    SECTION("Invalid")
+    {
+        connection_parameters params(backEnd, "");
+
+        // Missing value.
+        check_invalid_connection_string("foo");
+        check_invalid_connection_string("foo=ok bar");
+
+        // Missing quote.
+        check_invalid_connection_string(R"(foo=")");
+        check_invalid_connection_string(R"(foo="bar)");
+        check_invalid_connection_string(R"(foo="bar" baz="quux )");
+
+        // This one is not invalid (empty values are allowed), but it check
+        // because it used to dereference an invalid iterator (see #1175).
+        REQUIRE_NOTHROW(parse_connection_string("bloordyblop="));
+    }
+
+    SECTION("Typical")
+    {
+        std::string const s = "dbname=/some/path host=some.where readonly=1 port=1234";
+        INFO(R"(Parsing connection string ")" << s << R"(")");
+
+        auto params = parse_connection_string(s);
+
+        check_option(params, "dbname", "/some/path");
+        check_option(params, "host", "some.where");
+        check_option(params, "port", "1234");
+        check_option(params, "readonly", "1");
+
+        std::string value;
+        CHECK_FALSE(params.get_option("user", value));
+    }
+
+    SECTION("Quotes")
+    {
+        std::string const s = R"(user="foo" pass="" service="bar baz")";
+        INFO(R"(Parsing connection string ")" << s << R"(")");
+
+        auto params = parse_connection_string(s);
+
+        check_option(params, "user", "foo");
+        check_option(params, "pass", "");
+        check_option(params, "service", "bar baz");
+    }
+}
+
+} // namespace tests
+
+} // namespace soci

--- a/tests/common/test-connparams.cpp
+++ b/tests/common/test-connparams.cpp
@@ -64,9 +64,9 @@ TEST_CASE("Connection string parsing", "[core][connstring]")
     {
         connection_parameters params(backEnd, "");
 
-        // Missing value.
-        check_invalid_connection_string("foo");
-        check_invalid_connection_string("foo=ok bar");
+        // Missing name.
+        check_invalid_connection_string("=");
+        check_invalid_connection_string("foo=ok =bar");
 
         // Missing quote.
         check_invalid_connection_string(R"(foo=")");

--- a/tests/common/test-connparams.cpp
+++ b/tests/common/test-connparams.cpp
@@ -107,6 +107,23 @@ TEST_CASE("Connection string parsing", "[core][connstring]")
     }
 }
 
+TEST_CASE("connection_parameters::extract_option", "[core][connstring]")
+{
+    std::string value;
+
+    connection_parameters params(backEnd, "foo bar=baz");
+    params.extract_options_from_space_separated_string();
+
+    // Extracting an option must remove it.
+    CHECK(params.extract_option("foo", value));
+    CHECK(!params.get_option("foo", value));
+
+    CHECK_FALSE(params.extract_option("baz", value));
+
+    CHECK(params.extract_option("bar", value));
+    CHECK(!params.get_option("bar", value));
+}
+
 } // namespace tests
 
 } // namespace soci

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -130,6 +130,17 @@ struct oid_table_creator : public table_creator_base
     }
 };
 
+TEST_CASE("PostgreSQL connection string", "[postgresql][connstring]")
+{
+    // There are no required parts in libpq connection string, so we can only
+    // test that invalid options are detected.
+    CHECK_THROWS_WITH(soci::session(backEnd, "bloordyblop=1"),
+                      Catch::Contains(R"(invalid connection option "bloordyblop")"));
+
+    CHECK_THROWS_WITH(soci::session(backEnd, "sslmode=bloordyblop"),
+                      Catch::Contains(R"(invalid sslmode value: "bloordyblop")"));
+}
+
 // ROWID test
 // Note: in PostgreSQL, there is no ROWID, there is OID.
 // It is still provided as a separate type for "portability",

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -1483,7 +1483,7 @@ public:
 
     std::string get_example_connection_string() const override
     {
-        return "Host=localhost;Port=5432;Database=test;User=postgres;Password=postgres";
+        return "host=localhost port=5432 dbname=test user=postgres password=postgres";
     }
 
     table_creator_base* table_creator_1(soci::session& s) const override


### PR DESCRIPTION
Don't duplicate almost (but not quite) identical code for parsing space-separated parameter strings in different backends and have only one, correct (i.e. avoiding the problem reported in #1175) version of it.

Also allow specifying options by calling `set_option()` instead of tweaking the connection string itself, e.g. it's now possible to just do

```cpp
  soci::connection_parameters params(connstr);
  params.set_option("nocreate", "1");
  soci::session s(params);
```

to prevent SQLite backend from creating the database file if it doesn't exist instead of having to manually append "nocreate" to `connstr`.