### PR TITLE
Allow to row::get blob into suitable containers

### DIFF
--- a/docs/types.md
+++ b/docs/types.md
@@ -138,6 +138,53 @@ Users are encouraged to use the latter as it supports a wider range of numerical
 The mapping of underlying database column types to SOCI datatypes is database specific.
 See the [backend documentation](backends/index.md) for details.
 
+While `row::get<T>()` (semantically) copies the internally stored data (that was fetched from the database), there is also `row::move_as<T>`, which
+instead makes use of C++11's move semantics by moving the data out of the `row` instance. In case the used `T` does not support move semantics,
+`move_as` is functionally equivalent to `get`.
+
+### Dealing with Blobs
+
+If the fetched data is of type `db_blob` it is strongly recommended to use `row::move_as<blob>()` in order to obtain the data as a `blob` object. This
+allows for the most flexible and efficient access of the underlying data.
+
+Note that it is not possible to `row::get<blob>()` as `blob` objects are not copyable. However, you can instead get the blob's data into a
+`std::string` or a `std::vector<T>` as long as `T` has a size of exactly one byte (i.e. is a byte-like type such as `char` or `std::byte`). Depending
+on the used backend, this will either directly fetch the data from the database directly into the provided container or copy the already fetched data
+into the provided container.
+
+If you want to use a different container than the ones mentioned above, you need to specialize the `soci::is_contiguous_resizable_container` trait.
+E.g.
+```cpp
+template<>
+struct ::soci::is_contiguous_resizable_container<MyAwesomeContainer> : std::true_type {};
+
+template<typename ValueType>
+struct ::soci::is_contiguous_resizable_container<boost::container::vector<ValueType>, std::enable_if_t<sizeof(ValueType) == sizeof(char)>> : std::true_type {};
+```
+Potentially, you may also need to specialize the `soci::contiguous_resizable_container_accessor` struct, if the default implementation doesn't work
+for your custom container type:
+```cpp
+template<typename T, typename = std::enable_if_t<is_contiguous_resizable_container_v<T>>>
+struct contiguous_resizable_container_accessor
+{
+    // Gets the pointer to the beginning of the data store
+    static void *data(T &container)
+    {
+        static_assert(sizeof(decltype(container[0])) == sizeof(char), "Expected value-type of container to be byte-sized");
+        return &container[0];
+    }
+
+    // Gets the size **in bytes** of this container
+    static std::size_t size(const T &container) { return container.size(); }
+
+    // Resizes the container to the given size **in bytes**
+    static void resize(T &container, std::size_t size) { container.resize(size); }
+};
+```
+
+
+### Indicators
+
 The `row` also provides access to indicators for each column:
 
 ```cpp
@@ -148,6 +195,8 @@ if (r.get_indicator(0) != soci::i_null)
     std::cout << r.get<std::string>(0);
 }
 ```
+
+### Stream API
 
 It is also possible to extract data from the `row` object using its stream-like interface, where each extracted variable should have matching type respective to its position in the chain:
 

--- a/include/soci/row.h
+++ b/include/soci/row.h
@@ -72,6 +72,12 @@ public:
     column_properties const& get_properties(std::size_t pos) const;
     column_properties const& get_properties(std::string const& name) const;
 
+#ifdef _MSC_VER
+// MSVC complains about "unreachable code" in case get<base_type> can
+// be determined at compile time to throw.
+#pragma warning(push)
+#pragma warning(disable:4702)
+#endif
     template <typename T>
     T get(std::size_t pos) const
     {
@@ -104,6 +110,9 @@ public:
 
         return ret;
     }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
     template <typename T>
     T get(std::size_t pos, T const &nullValue) const

--- a/include/soci/type-holder.h
+++ b/include/soci/type-holder.h
@@ -38,14 +38,17 @@ constexpr bool is_contiguous_resizable_container_v = is_contiguous_resizable_con
 template<typename T, typename = std::enable_if_t<is_contiguous_resizable_container_v<T>>>
 struct contiguous_resizable_container_accessor
 {
+    // Gets the pointer to the beginning of the data store
     static void *data(T &container)
     {
         static_assert(sizeof(decltype(container[0])) == sizeof(char), "Expected value-type of container to be byte-sized");
         return &container[0];
     }
 
+    // Gets the size **in bytes** of this container
     static std::size_t size(const T &container) { return container.size(); }
 
+    // Resizes the container to the given size **in bytes**
     static void resize(T &container, std::size_t size) { container.resize(size); }
 };
 

--- a/include/soci/type-holder.h
+++ b/include/soci/type-holder.h
@@ -195,27 +195,6 @@ struct soci_cast<T, blob,
     }
 };
 
-template<>
-struct soci_cast<std::string, blob,void>
-{
-    static inline std::string cast(blob &blob)
-    {
-        std::string data;
-        data.resize(blob.get_len());
-
-        if  (data.empty())
-        {
-            return data;
-        }
-
-        // std::string::data() doesn't return non-const pointer
-        // before C++17. Hence, we have to use the uglier version.
-        blob.read_from_start(&data[0], data.size(), 0);
-
-        return data;
-    }
-};
-
 union type_holder
 {
     std::string* s;

--- a/tests/common/test-lob.cpp
+++ b/tests/common/test-lob.cpp
@@ -11,6 +11,10 @@
 
 #include "test-context.h"
 
+#include <vector>
+#include <list>
+#include <set>
+
 namespace soci
 {
 
@@ -667,6 +671,9 @@ TEST_CASE_METHOD(common_tests, "BLOB", "[core][blob]")
 
                 // Container is required to hold a type that has a size of 1 byte
                 CHECK_THROWS(currentRow.get<std::vector<int>>(0));
+                // Container has to use contiguous storage
+                CHECK_THROWS(currentRow.get<std::list<char>>(0));
+                CHECK_THROWS(currentRow.get<std::set<char>>(0));
 
                 CHECK(strData.size() == 10);
                 CHECK(vecData.size() == 10);

--- a/tests/common/test-lob.cpp
+++ b/tests/common/test-lob.cpp
@@ -653,6 +653,31 @@ TEST_CASE_METHOD(common_tests, "BLOB", "[core][blob]")
             }
             CHECK(containedData);
         }
+        SECTION("get into container")
+        {
+            soci::rowset< soci::row > rowSet = (sql.prepare << "select b from soci_test where id=:id", soci::use(id1));
+            bool containedData = false;
+            for (auto it = rowSet.begin(); it != rowSet.end(); ++it)
+            {
+                containedData = true;
+                const soci::row &currentRow = *it;
+
+                std::string strData = currentRow.get<std::string>(0);
+                std::vector<unsigned char> vecData = currentRow.get<std::vector<unsigned char>>(0);
+
+                // Container is required to hold a type that has a size of 1 byte
+                CHECK_THROWS(currentRow.get<std::vector<int>>(0));
+
+                CHECK(strData.size() == 10);
+                CHECK(vecData.size() == 10);
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    CHECK(strData[i] == dummy_data[i]);
+                    CHECK(vecData[i] == dummy_data[i]);
+                }
+            }
+            CHECK(containedData);
+        }
         SECTION("reusing bound blob")
         {
             int secondID = id2 + 1;

--- a/tests/common/test-lob.cpp
+++ b/tests/common/test-lob.cpp
@@ -671,7 +671,8 @@ TEST_CASE_METHOD(common_tests, "BLOB", "[core][blob]")
 
                 // Container is required to hold a type that has a size of 1 byte
                 CHECK_THROWS(currentRow.get<std::vector<int>>(0));
-                // Container has to use contiguous storage
+                // Using containers for which the soci::is_contiguous_resizable_container trait is not
+                // defined yield a std::bad_cast exception.
                 CHECK_THROWS(currentRow.get<std::list<char>>(0));
                 CHECK_THROWS(currentRow.get<std::set<char>>(0));
 


### PR DESCRIPTION
"Suitable" means that the `soci::is_contiguous_resizable_container` is specialized to have its `value` member yield `true`. This specialization is provided for `std::string` and `std::vector<T>` where `sizeof(T) == sizeof(char)`.

Fixes #1173