### PR TITLE
Use default memory database for SOCI tests in the CI

### DIFF
--- a/scripts/ci/build_sqlite3.sh
+++ b/scripts/ci/build_sqlite3.sh
@@ -7,7 +7,6 @@ source ${SOCI_SOURCE_DIR}/scripts/ci/common.sh
 
 cmake ${SOCI_DEFAULT_CMAKE_OPTIONS} \
     -DSOCI_SQLITE3=ON \
-    -DSOCI_SQLITE3_TEST_CONNSTR:STRING="soci_test.db" \
     ..
 
 run_make


### PR DESCRIPTION
There doesn't seem to be any reason to override the default and doing this disables FK support which is enabled by default since 2a8abbe4 (Turn foreign keys on by default for SQLite tests, 2025-01-21).