### PR TITLE
Don't include libpq-fe.h from soci/postgresql/soci-postgresql.h

### DIFF
--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -19,9 +19,12 @@
 
 #include <soci/soci-backend.h>
 #include "soci/connection-parameters.h"
-#include <libpq-fe.h>
+
 #include <vector>
 #include <unordered_map>
+
+typedef struct pg_conn PGconn;
+typedef struct pg_result PGresult;
 
 namespace soci
 {
@@ -104,12 +107,8 @@ private:
         result_ = result;
     }
 
-    void clear()
-    {
-        // Notice that it is safe to call PQclear() with NULL pointer, it
-        // simply does nothing in this case.
-        PQclear(result_);
-    }
+    // This is implemented in src/backends/postgresql/session.cpp.
+    void clear();
 
     postgresql_session_backend & sessionBackend_;
     PGresult* result_;

--- a/src/backends/postgresql/blob.cpp
+++ b/src/backends/postgresql/blob.cpp
@@ -7,7 +7,10 @@
 
 #define SOCI_POSTGRESQL_SOURCE
 #include "soci/postgresql/soci-postgresql.h"
+
+#include <libpq-fe.h>
 #include <libpq/libpq-fs.h> // libpq
+
 #include <cctype>
 #include <cstdint>
 #include <cstdio>
@@ -15,10 +18,6 @@
 #include <ctime>
 #include <sstream>
 #include <limits>
-
-#ifdef _MSC_VER
-#pragma warning(disable:4355)
-#endif
 
 using namespace soci;
 using namespace soci::details;

--- a/src/backends/postgresql/error.cpp
+++ b/src/backends/postgresql/error.cpp
@@ -9,6 +9,9 @@
 #include "soci/postgresql/soci-postgresql.h"
 #include "soci/callbacks.h"
 #include "soci/connection-parameters.h"
+
+#include <libpq-fe.h>
+
 #include <cstring>
 
 using namespace soci;

--- a/src/backends/postgresql/factory.cpp
+++ b/src/backends/postgresql/factory.cpp
@@ -9,11 +9,6 @@
 #include "soci/postgresql/soci-postgresql.h"
 #include "soci/connection-parameters.h"
 #include "soci/backend-loader.h"
-#include <libpq/libpq-fs.h> // libpq
-
-#ifdef _MSC_VER
-#pragma warning(disable:4355)
-#endif
 
 using namespace soci;
 using namespace soci::details;

--- a/src/backends/postgresql/row-id.cpp
+++ b/src/backends/postgresql/row-id.cpp
@@ -7,16 +7,6 @@
 
 #define SOCI_POSTGRESQL_SOURCE
 #include "soci/postgresql/soci-postgresql.h"
-#include <libpq/libpq-fs.h> // libpq
-#include <cctype>
-#include <cstdio>
-#include <cstring>
-#include <ctime>
-#include <sstream>
-
-#ifdef _MSC_VER
-#pragma warning(disable:4355)
-#endif
 
 using namespace soci;
 using namespace soci::details;

--- a/src/backends/postgresql/session.cpp
+++ b/src/backends/postgresql/session.cpp
@@ -10,7 +10,9 @@
 #include "soci/postgresql/soci-postgresql.h"
 #include "soci/session.h"
 #include "soci-compiler.h"
-#include <libpq/libpq-fs.h> // libpq
+
+#include <libpq-fe.h>
+
 #include <cctype>
 #include <cstdio>
 #include <cstring>
@@ -19,6 +21,15 @@
 
 using namespace soci;
 using namespace soci::details;
+
+// Implement this postgresql_result member function here to avoid adding a
+// separate source file just for it.
+void postgresql_result::clear()
+{
+    // Notice that it is safe to call PQclear() with NULL pointer, it
+    // simply does nothing in this case.
+    PQclear(result_);
+}
 
 namespace // unnamed
 {

--- a/src/backends/postgresql/standard-into-type.cpp
+++ b/src/backends/postgresql/standard-into-type.cpp
@@ -15,7 +15,10 @@
 #include "soci/blob.h"
 #include "soci/type-wrappers.h"
 #include "soci-exchange-cast.h"
+
+#include <libpq-fe.h>
 #include <libpq/libpq-fs.h> // libpq
+
 #include <cctype>
 #include <cstdint>
 #include <cstdio>

--- a/src/backends/postgresql/standard-use-type.cpp
+++ b/src/backends/postgresql/standard-use-type.cpp
@@ -14,7 +14,9 @@
 #include "soci-dtocstr.h"
 #include "soci-exchange-cast.h"
 #include "soci-mktime.h"
-#include <libpq/libpq-fs.h> // libpq
+
+#include <libpq-fe.h>
+
 #include <cctype>
 #include <cstdint>
 #include <cstdio>

--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -10,7 +10,9 @@
 #include "soci/soci-platform.h"
 #include "soci-cstrtoi.h"
 #include "soci-ssize.h"
-#include <libpq/libpq-fs.h> // libpq
+
+#include <libpq-fe.h>
+
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>

--- a/src/backends/postgresql/vector-into-type.cpp
+++ b/src/backends/postgresql/vector-into-type.cpp
@@ -12,7 +12,9 @@
 #include "soci-mktime.h"
 #include "common.h"
 #include "soci/type-wrappers.h"
-#include <libpq/libpq-fs.h> // libpq
+
+#include <libpq-fe.h>
+
 #include <cctype>
 #include <cstdint>
 #include <cstdio>

--- a/src/backends/postgresql/vector-use-type.cpp
+++ b/src/backends/postgresql/vector-use-type.cpp
@@ -12,7 +12,9 @@
 #include "soci-mktime.h"
 #include "common.h"
 #include "soci/type-wrappers.h"
-#include <libpq/libpq-fs.h> // libpq
+
+#include <libpq-fe.h>
+
 #include <cctype>
 #include <cstdint>
 #include <cstdio>


### PR DESCRIPTION
This allows including this file from the code including the library even if that code doesn't set up its include paths to find libpq headers.

Also remove some more apparently unneeded headers and don't bother disabling MSVC warning 4355 which is never given in these files.