### PR TITLE
Make SQLite overwrite exchange type for integers

### DIFF
--- a/docs/backends/sqlite3.md
+++ b/docs/backends/sqlite3.md
@@ -102,6 +102,12 @@ For the SQLite3 backend, this type mapping is complicated by the fact the SQLite
 | *text*, *char*, *character*, *clob*, *native character*, *nchar*, *nvarchar*, *varchar*, *varying character* | db_string                    | std::string                   |
 | *date*, *time*, *datetime*                                                                                   | db_date                      | std::tm                       |
 
+Another consequence of SQLite's lack of type checking is that it is possible to store arbitrarily large integers in a column, even if the type it has
+been created with wouldn't allow for that. Thus, it is possible that a column of type `integer` (which should correspond to the possible values of a
+32-bit signed integer type) contains a value that overflows a 32-bit integer. In such cases, trying to query the data via `row::get<T>`, with `T` being
+the type as given in the table above, will throw an exception as the selected value would overflow the provided type. You may instead use a `T` that
+can holder a wider range (e.g. a 64-bit integer) in order to avoid this exception.
+
 [INTEGER_PRIMARY_KEY] : There is one case where SQLite3 enforces type. If a column is declared as "integer primary key", then SQLite3 uses that as an alias to the internal ROWID column that exists for every table.  Only integers are allowed in this column.
 
 (See the [dynamic resultset binding](../types.md#dynamic-binding) documentation for general information on using the `row` class.)

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -294,6 +294,8 @@ public:
     virtual vector_into_type_backend* make_vector_into_type_backend() = 0;
     virtual vector_use_type_backend* make_vector_use_type_backend() = 0;
 
+    virtual db_type exchange_dbtype_for(db_type type) const { return type; }
+
     // These are set when the corresponding make_xxx_backend() above is called
     // by statement_impl. This goes against encapsulation but allows to avoid
     // having to set them in all backends implementations of these functions.

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -294,6 +294,14 @@ public:
     virtual vector_into_type_backend* make_vector_into_type_backend() = 0;
     virtual vector_use_type_backend* make_vector_use_type_backend() = 0;
 
+    // Converts the given (deduced) DB type and converts it into the data type
+    // that should be used for fetching the corresponding data.
+    // Normally, the deduced DB type should be exactly what should be used but
+    // we need to give backends the possibility to overwrite this to e.g. account
+    // for known shortcomings in the DB type deduction (e.g. for SQLite).
+    // This function is only relevant in cases where we are not dealing with a
+    // user-provided exchange type but instead have to set one up ourselves. Most
+    // notably this is the case for dynamic (i.e. row-based) binding.
     virtual db_type exchange_dbtype_for(db_type type) const { return type; }
 
     // These are set when the corresponding make_xxx_backend() above is called

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -235,6 +235,8 @@ struct SOCI_SQLITE3_DECL sqlite3_statement_backend : details::statement_backend
     sqlite3_vector_into_type_backend * make_vector_into_type_backend() override;
     sqlite3_vector_use_type_backend * make_vector_use_type_backend() override;
 
+    db_type exchange_dbtype_for(db_type type) const override;
+
     sqlite3_session_backend &session_;
     sqlite_api::sqlite3_stmt *stmt_;
     sqlite3_recordset dataCache_;

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -614,7 +614,7 @@ sqlite3_statement_backend::make_vector_use_type_backend()
 db_type sqlite3_statement_backend::exchange_dbtype_for(db_type type) const
 {
     // Due to SQLite not really having a type system, any integer type may hold
-    // values that should be way outside of its range.
+    // values that could be way outside of its range.
     // Hence, we have to be prepared to get a huge number, even if the determined
     // db_type is e.g. db_int8.
     // In order to do that, we ensure that we'll always select into an (u)int64,

--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -610,3 +610,28 @@ sqlite3_statement_backend::make_vector_use_type_backend()
 {
     return new sqlite3_vector_use_type_backend(*this);
 }
+
+db_type sqlite3_statement_backend::exchange_dbtype_for(db_type type) const
+{
+    // Due to SQLite not really having a type system, any integer type may hold
+    // values that should be way outside of its range.
+    // Hence, we have to be prepared to get a huge number, even if the determined
+    // db_type is e.g. db_int8.
+    // In order to do that, we ensure that we'll always select into an (u)int64,
+    // in cases where we have to select the exchange type ourselves (e.g. in rows).
+    switch (type)
+    {
+        case db_int8:
+        case db_int16:
+        case db_int32:
+        case db_int64:
+            return db_int64;
+        case db_uint8:
+        case db_uint16:
+        case db_uint32:
+        case db_uint64:
+            return db_uint64;
+        default:
+            return type;
+    }
+}

--- a/src/core/statement.cpp
+++ b/src/core/statement.cpp
@@ -770,7 +770,7 @@ void statement_impl::describe()
         props.set_db_type(dbtype);
         props.set_data_type(backEnd_->to_data_type(dbtype));
 
-        switch (dbtype)
+        switch (backEnd_->exchange_dbtype_for(dbtype))
         {
         case db_string:
         case db_xml:

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -894,6 +894,9 @@ TEST_CASE("SQLite row int64", "[sqlite][row][int64]")
     // small for the queried value, leading to a silent integer overflow and hence unexpected
     // query results.
     // This test case effectively ensures that this no longer happens.
+    //
+    // Note that this test is SQLite-specific because with the other backends we'd
+    // fail to insert the value in the first place.
     soci::session sql(backEnd, connectString);
     integer_table_creator creator(sql);
 


### PR DESCRIPTION
Since SQLite doesn't have a type system, we have to always be prepared to select huge numbers, even if the "type" is e.g. int8. To do that, we overwrite the exchange type (e.g. in row based APIs) to always be (u)int64 for integers to avoid over-/underflows.

Fixes #1190