### PR TITLE
Include cstdint for uint32_t

### DIFF
--- a/src/core/unicode.cpp
+++ b/src/core/unicode.cpp
@@ -7,6 +7,7 @@
 
 #define SOCI_SOURCE
 #include "soci/soci-unicode.h"
+#include <cstdint>
 
 namespace soci
 {


### PR DESCRIPTION
With recent versions of GNU C++ compilers (for instance on Fedora Rawhide), we need to `#include <cstdint>` in order for `uint32_t` to be defined