### PR TITLE
Use built-in SQLite if system library not found

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rdparty/sqlite3"]
+	path = 3rdparty/sqlite3
+	url = https://github.com/vadz/sqlite-amalgamation.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ project(SOCI
   VERSION ${SOCI_VERSION}
   DESCRIPTION "C++ database access library"
   HOMEPAGE_URL "https://soci.sourceforge.net/"
-  LANGUAGES CXX
+  LANGUAGES C CXX
 )
 
 include(soci_utils)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,13 +72,11 @@ install:
         $env:SOCI_ODBC_SKIP_TESTS = $env:SOCI_ODBC_SKIP_TESTS + '|soci_odbc_test_postgresql'
       }
       Write-Output "To be skipped ODBC tests: $env:SOCI_ODBC_SKIP_TESTS"
-  - git clone https://github.com/snikulov/sqlite.cmake.build.git C:\projects\sqlite\src
     # Ensure we have a recent cmake version available
   - choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
   - refreshenv
 
 before_build:
-  - set SQLITE_ROOT=C:\projects\sqlite\sqlite
   # dirty little hack - remove sh from Git to make generator happy
   - ps: |
       if ($env:G -eq "MinGW Makefiles")
@@ -91,12 +89,10 @@ before_build:
             Remove-Item $shellPath
           }
         }
-        $env:SQLITE3_LIBRARY = $env:SQLITE_ROOT + '/lib/libsqlite3-static.a'
         $env:BUILD_TOOL_OPTIONS = '-j3'
       }
       else
       {
-        $env:SQLITE3_LIBRARY = $env:SQLITE_ROOT + '/lib/sqlite3-static.lib'
         $env:BUILD_TOOL_OPTIONS = ''
         # Set up Visual Studio environment (MSVC compiler etc.)
         # Works by calling the respective bat script and then copying over the env vars
@@ -108,9 +104,6 @@ before_build:
                 }
             }
       }
-  - cd C:\projects\sqlite\src
-  - mkdir build
-  - cd build
   - set PATH=%MINGW_BIN%;%POSTGRESQL_ROOT%\bin;%MYSQL_DIR%\bin;%MYSQL_DIR%\lib;%PATH%
   - echo %PATH%
   - cmake --version
@@ -121,14 +114,12 @@ before_build:
   - set USER=root
   - mysql -e "create database soci_test;" --user=root
   - sqlcmd -U sa -P Password12! -S (local)\SQL%MSSQL_VER% -i C:\projects\soci\scripts\windows\mssql_db_create.sql
-  - cmake .. -G"%G%" -DSQLITE_BUILD_SHARED=OFF -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX=%SQLITE_ROOT% -DCMAKE_UNITY_BUILD=ON
-  - cmake --build . --config %CONFIGURATION% --target install
 
 build_script:
   - cd C:\projects\soci
   - mkdir build
   - cd build
-  - cmake .. -G"%G%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_VERBOSE_MAKEFILE=ON -DSOCI_ENABLE_WERROR=ON -DCMAKE_PREFIX_PATH=%SQLITE_ROOT% -DSQLite3_LIBRARY=%SQLITE3_LIBRARY% -DCMAKE_UNITY_BUILD=ON
+  - cmake .. -G"%G%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_VERBOSE_MAKEFILE=ON -DSOCI_ENABLE_WERROR=ON -DCMAKE_UNITY_BUILD=ON
   - cmake --build . --config %CONFIGURATION% -- %BUILD_TOOL_OPTIONS%
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,6 +75,7 @@ install:
     # Ensure we have a recent cmake version available
   - choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
   - refreshenv
+  - git submodule update --init
 
 before_build:
   # dirty little hack - remove sh from Git to make generator happy

--- a/docs/backends/sqlite3.md
+++ b/docs/backends/sqlite3.md
@@ -6,32 +6,11 @@ SOCI backend for accessing SQLite 3 database.
 
 ### Supported Versions
 
-The SOCI SQLite3 backend is supported for use with SQLite3 >= 3.1
-
-### Tested Platforms
-
-|SQLite3|OS|Compiler|
-|--- |--- |--- |
-|3.12.1|Windows Server 2016|MSVC++ 14.1|
-|3.12.1|Windows Server 2012 R2|MSVC++ 14.0|
-|3.12.1|Windows Server 2012 R2|MSVC++ 12.0|
-|3.12.1|Windows Server 2012 R2|MSVC++ 11.0|
-|3.12.1|Windows Server 2012 R2|Mingw-w64/GCC 4.8|
-|3.7.9|Ubuntu 12.04|g++ 4.6.3|
-|3.4.0|Windows XP|(cygwin) g++ 3.4.4|
-|3.4.0|Windows XP|Visual C++ 2005 Express Edition|
-|3.3.8|Windows XP|Visual C++ 2005 Professional|
-|3.5.2|Mac OS X 10.5|g++ 4.0.1|
-|3.3.4|Ubuntu 5.1|g++ 4.0.2|
-|3.3.4|Windows XP|(cygwin) g++ 3.3.4|
-|3.3.4|Windows XP|Visual C++ 2005 Express Edition|
-|3.2.1|Linux i686 2.6.10-gentoo-r6|g++ 3.4.5|
-|3.1.3|Mac OS X 10.4|g++ 4.0.1|
-|3.24.0|macOS High Sierra 10.13.5|AppleClang 9.1.0.9020039|
+The oldest tested SQLite3 version that SOCI was tested with was 3.1.3 and the latest tested version is 3.49.1. Due to high degree of SQLite3 backwards compatibility, it is likely that newer versions can work as well.
 
 ### Required Client Libraries
 
-The SOCI SQLite3 backend requires SQLite3's `libsqlite3` client library.
+The SOCI SQLite3 backend uses `libsqlite3` client library if available or the built-in version of SQLite3 included in the SOCI source code if this library cannot be found.
 
 ### Connecting to the Database
 

--- a/docs/backends/sqlite3.md
+++ b/docs/backends/sqlite3.md
@@ -171,6 +171,10 @@ The SQLite3 backend provides the following concrete classes for navite API acces
 
 SQLite3 result code is provided via the backend specific `sqlite3_soci_error` class. Catching the backend specific error yields the value of SQLite3 result code via the `result()` method.
 
+### SQLite3 version information
+
+`sqlie3_session_backend` class, declared in `<soci/sqlite3/soci-sqlite3.h>`, provides static `libversion_number()` and `libversion()` functions which can be used to retrieve the SQLite3 version as a number (e.g. `3049001`) and as a string (e.g. `3.49.1`) respectively.
+
 ## Configuration options
 
 None

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ where X.Y.Z is the version number. Unpack the archive.
 You can always clone SOCI from the Git repository:
 
 ```console
-git clone git://github.com/SOCI/soci.git
+git clone --recurse-submodules git://github.com/SOCI/soci.git
 ```
 
 ## Building with CMake
@@ -145,7 +145,7 @@ Furthermore, the `MYSQL_DIR` _environment variable_ can be set to the MySQL inst
 
 #### SQLite 3
 
-* `SOCI_SQLITE3` - Enabler - Enables the [SQLite3](backends/sqlite3.md) backend.
+* `SOCI_SQLITE3` - Enabler - Enables the [SQLite3](backends/sqlite3.md) backend. Note that, unlike with all the other backends, if SQLite3 library is not found, built-in version of SQLite3 is used instead of the backend being disabled.
 * `SOCI_SQLITE3_TEST_CONNSTR` - string - Connection string is simply a file path where SQLite3 test database will be created (e.g. /home/john/soci_test.db). Check [SQLite3 backend reference](backends/sqlite3.md) for details. Example: `-DSOCI_SQLITE3_TEST_CONNSTR="my.db"` or `-DSOCI_SQLITE3_TEST_CONNSTR=":memory:"`.
 * `SOCI_SQLITE3_SKIP_TESTS` - boolean - Skips testing this backend.
 

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -31,7 +31,24 @@
 namespace sqlite_api
 {
 
-#include <sqlite3.h>
+// Don't include sqlite3.h from outside SOCI: this header might not be
+// available when using built-in SQLite3 as we don't install it in this case.
+#ifdef SOCI_SQLITE3_SOURCE
+    #include <sqlite3.h>
+#else // !SOCI_SQLITE3_SOURCE
+// We need just a couple of forward declarations to make this header itself
+// compile.
+struct sqlite3;
+struct sqlite3_stmt;
+
+#if defined(_MSC_VER)
+  typedef __int64 sqlite3_int64;
+  typedef unsigned __int64 sqlite3_uint64;
+#else
+  typedef long long int sqlite3_int64;
+  typedef unsigned long long int sqlite3_uint64;
+#endif
+#endif // SOCI_SQLITE3_SOURCE/!SOCI_SQLITE3_SOURCE
 
 } // namespace sqlite_api
 

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -353,6 +353,10 @@ struct SOCI_SQLITE3_DECL sqlite3_session_backend : details::session_backend
         }
     }
 
+    // Get information about SQLite3 version used.
+    static const char* libversion();
+    static int libversion_number();
+
     sqlite_api::sqlite3 *conn_;
 
     // This flag is set to true if the internal sqlite_sequence table exists in

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -31,18 +31,9 @@
 namespace sqlite_api
 {
 
-#if SQLITE_VERSION_NUMBER < 3003010
-// The sqlite3_destructor_type typedef introduced in 3.3.10
-// https://www.sqlite.org/cvstrac/tktview?tn=2191
-typedef void (*sqlite3_destructor_type)(void*);
-#endif
-
 #include <sqlite3.h>
 
 } // namespace sqlite_api
-
-#undef SQLITE_STATIC
-#define SQLITE_STATIC ((sqlite_api::sqlite3_destructor_type)0)
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/src/backends/sqlite3/CMakeLists.txt
+++ b/src/backends/sqlite3/CMakeLists.txt
@@ -1,7 +1,9 @@
 include(soci_define_backend_target)
 
 if (SOCI_SQLITE3_AUTO)
-  set(DEPENDENCY_MODE "DISABLE")
+  # Unlike most other backends, we can fall back on using the built-in
+  # version of SQLite3 if the system version is not found.
+  set(DEPENDENCY_MODE "BUILTIN")
 else()
   set(DEPENDENCY_MODE "ERROR")
 endif()
@@ -31,4 +33,32 @@ soci_define_backend_target(
 
 if (NOT SOCI_SQLITE3)
   return()
+endif()
+
+# If SQLite3 was found, this target must have been created.
+if (NOT TARGET SQLite::SQLite3)
+  # But if it wasn't, use our built-in version, after checking that it is
+  # available.
+  if (NOT EXISTS "${PROJECT_SOURCE_DIR}/3rdparty/sqlite3/sqlite3.c")
+    message(WARNING "SQLite3 not found and built-in version not available, have you cloned SOCI repository with --recurse-submodules?")
+
+    get_property(DESCRIPTION CACHE SOCI_SQLITE3 PROPERTY HELPSTRING)
+    set(SOCI_SQLITE3 OFF CACHE STRING "${DESCRIPTION}" FORCE)
+    return()
+  endif()
+
+  add_library(soci_sqlite3_builtin)
+  target_sources(soci_sqlite3_builtin
+    PRIVATE
+      "${PROJECT_SOURCE_DIR}/3rdparty/sqlite3/sqlite3.c"
+  )
+  target_include_directories(soci_sqlite3_builtin
+    PUBLIC
+      "${PROJECT_SOURCE_DIR}/3rdparty/sqlite3"
+  )
+
+  target_link_libraries(soci_sqlite3
+    PRIVATE
+      soci_sqlite3_builtin
+  )
 endif()

--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -313,3 +313,15 @@ sqlite3_blob_backend * sqlite3_session_backend::make_blob_backend()
 {
     return new sqlite3_blob_backend(*this);
 }
+
+// static
+const char* sqlite3_session_backend::libversion()
+{
+    return sqlite3_libversion();
+}
+
+// static
+int sqlite3_session_backend::libversion_number()
+{
+    return sqlite3_libversion_number();
+}

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -404,11 +404,11 @@ TEST_CASE("SQLite long long", "[sqlite][longlong]")
 // Test the DDL and metadata functionality
 TEST_CASE("SQLite DDL with metadata", "[sqlite][ddl]")
 {
-    if (sqlite_api::sqlite3_libversion_number() < 3036000) {
-        if (sqlite_api::sqlite3_libversion_number() < 3014000) {
-            WARN("SQLite requires at least version 3.14.0 for column description, detected " << sqlite_api::sqlite3_libversion());
+    if (sqlite3_session_backend::libversion_number() < 3036000) {
+        if (sqlite3_session_backend::libversion_number() < 3014000) {
+            WARN("SQLite requires at least version 3.14.0 for column description, detected " << sqlite3_session_backend::libversion());
         }
-        WARN("SQLite requires at least version 3.36.0 for drop column, detected " << sqlite_api::sqlite3_libversion());
+        WARN("SQLite requires at least version 3.36.0 for drop column, detected " << sqlite3_session_backend::libversion());
         return;
     }
     soci::session sql(backEnd, connectString);

--- a/www/index.html
+++ b/www/index.html
@@ -107,7 +107,7 @@ organization where all Git repositories are available.</p>
 
 <p>The main Git repository with SOCI source code can be cloned with:</p>
 <pre>
-$ git clone git://github.com/SOCI/soci.git
+$ git clone --recurse-submodules git://github.com/SOCI/soci.git
 </pre>
 
 <p>The <a href="https://github.com/SOCI/soci/issues">Issues</a> tracker is open


### PR DESCRIPTION
In particular, this fixes AppVeyor CI build as it didn't work with CMake 4.0 any more.