### PR TITLE
Simplify Boost dependency

### DIFF
--- a/cmake/soci_define_backend_target.cmake
+++ b/cmake/soci_define_backend_target.cmake
@@ -105,7 +105,7 @@ function(soci_define_backend_target)
         endif()
       endforeach()
       list(APPEND PUBLIC_DEP_CALL_ARGS
-        "NAME ${CURRENT_DEP} DEP_TARGETS ${CURRENT_DEP_TARGETS} TARGET SOCI::${DEFINE_BACKEND_ALIAS_NAME} REQUIRED"
+        "NAME ${CURRENT_DEP} DEP_TARGETS ${CURRENT_DEP_TARGETS} TARGET SOCI::${DEFINE_BACKEND_ALIAS_NAME}"
       )
     endif()
   endforeach()

--- a/cmake/soci_define_backend_target.cmake
+++ b/cmake/soci_define_backend_target.cmake
@@ -13,11 +13,9 @@ include(soci_utils)
 # TARGET_NAME <target>                     Name of the CMake target that shall be created for this backend
 # DEPENDENCIES <spec1> [... <specN>]       List of dependency specifications. Each specification has to be a single
 #                                          argument (single string) following the syntax
-#                                          <find_spec> YIELDS <targets> [DEFINES <macros>]
+#                                          <find_spec> YIELDS <targets>
 #                                          where <find_spec> will be passed to find_package to find the dependency. Upon
-#                                          success, all targets defined in <targets> are expected to exist. If provided,
-#                                          all defines specified in <macros> will be added as public compile definitions
-#                                          to the backend library if the dependency has been found.
+#                                          success, all targets defined in <targets> are expected to exist.
 #                                          For now, all dependencies are expected to be public and required.
 # FIND_PACKAGE_FILES <file1> [... <fileN>] List of files used by find_package to locate one of the dependencies. Specified
 #                                          files will be installed alongside SOCI in order to be usable from the install tree.
@@ -69,12 +67,11 @@ function(soci_define_backend_target)
   set(PUBLIC_DEP_CALL_ARGS "")
 
   foreach(CURRENT_DEP_SPEC IN LISTS DEFINE_BACKEND_DEPENDENCIES)
-    if (NOT "${CURRENT_DEP_SPEC}" MATCHES "^([a-zA-Z0-9_:-;]+) YIELDS ([a-zA-Z0-9_:-;]+)( DEFINES [a-zA-Z0-9_;])?$")
+    if (NOT "${CURRENT_DEP_SPEC}" MATCHES "^([a-zA-Z0-9_:-;]+) YIELDS ([a-zA-Z0-9_:-;]+)$")
       message(FATAL_ERROR "Invalid format for dependency specification in '${CURRENT_DEP_SPEC}'")
     endif()
     set(CURRENT_DEP_SEARCH ${CMAKE_MATCH_1})
     set(CURRENT_DEP_TARGETS ${CMAKE_MATCH_2})
-    set(CURRENT_DEP_DEFINES ${CMAKE_MATCH_3})
 
     list(GET CURRENT_DEP_SEARCH 0 CURRENT_DEP)
 
@@ -107,11 +104,8 @@ function(soci_define_backend_target)
           message(FATAL_ERROR "Expected successful find_package call with '${CURRENT_DEP_SEARCH}' to define target '${CURRENT}'")
         endif()
       endforeach()
-      if (CURRENT_DEP_DEFINES)
-        set(MACRO_NAMES_ARG "MACRO_NAMES ${CURRENT_DEP_DEFINES}")
-      endif()
       list(APPEND PUBLIC_DEP_CALL_ARGS
-        "NAME ${CURRENT_DEP} DEP_TARGETS ${CURRENT_DEP_TARGETS} TARGET SOCI::${DEFINE_BACKEND_ALIAS_NAME} ${MACRO_NAMES_ARG} REQUIRED"
+        "NAME ${CURRENT_DEP} DEP_TARGETS ${CURRENT_DEP_TARGETS} TARGET SOCI::${DEFINE_BACKEND_ALIAS_NAME} REQUIRED"
       )
     endif()
   endforeach()

--- a/cmake/soci_utils.cmake
+++ b/cmake/soci_utils.cmake
@@ -56,7 +56,6 @@ set(SOCI_DEPENDENCY_VARIABLES
   "SOCI_DEPENDENCY_SOCI_COMPONENTS"
   "SOCI_DEPENDENCY_NAMES"
   "SOCI_DEPENDENCY_TARGETS"
-  "SOCI_DEPENDENCY_REQUIRED"
 )
 if (NOT DEFINED SOCI_UTILS_ALREADY_INCLUDED)
   foreach(VAR_NAME IN LISTS SOCI_DEPENDENCY_VARIABLES)
@@ -72,7 +71,6 @@ endif()
 #      NAME <name>
 #      DEP_TARGETS <dep target> ...
 #      TARGET <target>
-#      [REQUIRED]
 #   )
 # where
 # - <name> is the name of the dependency (used for lookup via find_package)
@@ -80,7 +78,6 @@ endif()
 #                successful find_package call
 # - <target> is the name of the ALIAS target to link the found dependency to
 function(soci_public_dependency)
-  set(FLAGS "REQUIRED")
   set(ONE_VAL_OPTIONS "TARGET" "NAME")
   set(MULTI_VAL_OPTIONS "DEP_TARGETS")
 
@@ -107,7 +104,6 @@ function(soci_public_dependency)
   list(APPEND SOCI_DEPENDENCY_NAMES "${PUBLIC_DEP_NAME}")
   list(JOIN PUBLIC_DEP_DEP_TARGETS "|" STORED_TARGETS)
   list(APPEND SOCI_DEPENDENCY_TARGETS "${STORED_TARGETS}")
-  list(APPEND SOCI_DEPENDENCY_REQUIRED "${PUBLIC_DEP_REQUIRED}")
 
   foreach(VAR_NAME IN LISTS SOCI_DEPENDENCY_VARIABLES)
     set("${VAR_NAME}" "${${VAR_NAME}}" CACHE INTERNAL "")
@@ -115,12 +111,6 @@ function(soci_public_dependency)
 
 
   # Search for the package now
-  if (PUBLIC_DEP_REQUIRED)
-    set(REQUIRED "REQUIRED")
-  else()
-    set(REQUIRED "")
-  endif()
-
   set(SKIP_SEARCH ON)
   foreach (TGT IN LISTS PUBLIC_DEP_DEP_TARGETS)
     if (NOT TARGET "${TGT}")
@@ -129,7 +119,7 @@ function(soci_public_dependency)
   endforeach()
 
   if (NOT SKIP_SEARCH)
-    find_package("${PUBLIC_DEP_NAME}" ${REQUIRED})
+    find_package("${PUBLIC_DEP_NAME}" REQUIRED)
   endif()
 
   set(FOUND_ONE OFF)

--- a/cmake/soci_utils.cmake
+++ b/cmake/soci_utils.cmake
@@ -72,7 +72,7 @@ endif()
 # Use as
 #   soci_public_dependency(
 #      NAME <name>
-#      DEP_TARGET <dep target>
+#      DEP_TARGETS <dep target> ...
 #      TARGET <target>
 #      [MACRO_NAMES <macro name> ...]
 #      [REQUIRED]

--- a/soci-config.cmake.in
+++ b/soci-config.cmake.in
@@ -6,8 +6,6 @@ set(__dep_soci_comps  "@SOCI_DEPENDENCY_SOCI_COMPONENTS@")
 set(__dep_names       "@SOCI_DEPENDENCY_NAMES@")
 set(__dep_dep_targets "@SOCI_DEPENDENCY_TARGETS@")
 set(__dep_required    "@SOCI_DEPENDENCY_REQUIRED@")
-set(__dep_macro_names "@SOCI_DEPENDENCY_MACRO_NAMES@")
-set(__dep_components  "@SOCI_DEPENDENCY_COMPONENTS@")
 
 
 set(__prev_module_path "${CMAKE_MODULE_PATH}")
@@ -27,7 +25,7 @@ list(INSERT SOCI_FIND_COMPONENTS 0 Core)
 
 
 list(LENGTH __dep_soci_comps __list_size)
-foreach (__item IN ITEMS __dep_names __dep_dep_targets __dep_required __dep_macro_names __dep_components)
+foreach (__item IN ITEMS __dep_names __dep_dep_targets __dep_required)
     list(LENGTH ${__item} __current_size)
     if (NOT (__list_size EQUAL __current_size))
         message(FATAL_ERROR "SociConfig is invalid -> dependency lists have different sizes")
@@ -46,7 +44,6 @@ foreach(__comp IN LISTS SOCI_FIND_COMPONENTS)
 
   # Handle component-specific dependencies
   set(__link_targets)
-  set(__define_macros)
   set(__skip_dependency FALSE)
   foreach (__i RANGE ${__list_size})
     list(GET __dep_soci_comps ${__i} __dep_comp)
@@ -55,13 +52,9 @@ foreach(__comp IN LISTS SOCI_FIND_COMPONENTS)
       list(GET __dep_names ${__i} __dep)
       list(GET __dep_dep_targets ${__i} __targets)
       list(GET __dep_required ${__i} __required)
-      list(GET __dep_macro_names ${__i} __macros)
-      list(GET __dep_components ${__i} __components)
 
       # Split list-valued entries to become actual lists
       string(REPLACE "|" ";" __targets "${__targets}")
-      string(REPLACE "|" ";" __macros "${__macros}")
-      string(REPLACE "|" ";" __components "${__components}")
 
       set(__already_found)
       foreach (__tgt IN LISTS __targets)
@@ -77,10 +70,6 @@ foreach(__comp IN LISTS SOCI_FIND_COMPONENTS)
         continue()
       endif()
 
-      if (__components)
-        set(__components COMPONENTS ${__components})
-      endif()
-
       if (${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
         set(__quiet "QUIET")
       else()
@@ -89,7 +78,6 @@ foreach(__comp IN LISTS SOCI_FIND_COMPONENTS)
 
       find_package(
         ${__dep}
-        ${__components}
         ${__quiet}
       )
 
@@ -103,7 +91,6 @@ foreach(__comp IN LISTS SOCI_FIND_COMPONENTS)
       endif()
 
       list(APPEND __link_targets  ${__targets})
-      list(APPEND __define_macros ${__macros})
     endif()
   endforeach()
   unset(__i)
@@ -119,14 +106,6 @@ foreach(__comp IN LISTS SOCI_FIND_COMPONENTS)
     APPEND
     PROPERTY INTERFACE_LINK_LIBRARIES "${__link_targets}"
   )
-  if (__define_macros)
-    set_property(
-      TARGET SOCI::${__comp}
-      APPEND
-      PROPERTY INTERFACE_COMPILE_DEFINITIONS "${__define_macros}"
-    )
-  endif()
-
   set(${CMAKE_FIND_PACKAGE_NAME}_${__comp}_FOUND ON)
 endforeach()
 unset(__comp)
@@ -136,8 +115,6 @@ unset(__dep_soci_comps)
 unset(__dep_names)
 unset(__dep_dep_targets)
 unset(__dep_required)
-unset(__dep_macro_names)
-unset(__dep_components)
 
 
 check_required_components(SOCI)

--- a/soci-config.cmake.in
+++ b/soci-config.cmake.in
@@ -32,8 +32,6 @@ foreach (__item IN ITEMS __dep_names __dep_dep_targets)
 endforeach()
 unset(__current_size)
 
-math(EXPR __list_size "${__list_size} - 1")
-
 foreach(__comp IN LISTS SOCI_FIND_COMPONENTS)
   if (NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/SOCI${__comp}Targets.cmake")
     set(SOCI_FOUND FALSE)
@@ -45,6 +43,12 @@ foreach(__comp IN LISTS SOCI_FIND_COMPONENTS)
   set(__link_targets)
   set(__skip_dependency FALSE)
   foreach (__i RANGE ${__list_size})
+    # We want to iterate up to and excluding __list_size, but CMake RANGE
+    # doesn't allow this, so do it manually here.
+    if (${__i} EQUAL ${__list_size})
+      break()
+    endif()
+
     list(GET __dep_soci_comps ${__i} __dep_comp)
     if (__dep_comp MATCHES "::${__comp}$")
       # This entry matches the current component

--- a/soci-config.cmake.in
+++ b/soci-config.cmake.in
@@ -5,7 +5,6 @@
 set(__dep_soci_comps  "@SOCI_DEPENDENCY_SOCI_COMPONENTS@")
 set(__dep_names       "@SOCI_DEPENDENCY_NAMES@")
 set(__dep_dep_targets "@SOCI_DEPENDENCY_TARGETS@")
-set(__dep_required    "@SOCI_DEPENDENCY_REQUIRED@")
 
 
 set(__prev_module_path "${CMAKE_MODULE_PATH}")
@@ -25,7 +24,7 @@ list(INSERT SOCI_FIND_COMPONENTS 0 Core)
 
 
 list(LENGTH __dep_soci_comps __list_size)
-foreach (__item IN ITEMS __dep_names __dep_dep_targets __dep_required)
+foreach (__item IN ITEMS __dep_names __dep_dep_targets)
     list(LENGTH ${__item} __current_size)
     if (NOT (__list_size EQUAL __current_size))
         message(FATAL_ERROR "SociConfig is invalid -> dependency lists have different sizes")
@@ -51,7 +50,6 @@ foreach(__comp IN LISTS SOCI_FIND_COMPONENTS)
       # This entry matches the current component
       list(GET __dep_names ${__i} __dep)
       list(GET __dep_dep_targets ${__i} __targets)
-      list(GET __dep_required ${__i} __required)
 
       # Split list-valued entries to become actual lists
       string(REPLACE "|" ";" __targets "${__targets}")
@@ -82,12 +80,9 @@ foreach(__comp IN LISTS SOCI_FIND_COMPONENTS)
       )
 
       if (NOT ${__dep}_FOUND)
-        if (__required)
-          set(SOCI_FOUND FALSE)
-          set(SOCI_NOT_FOUND_MESSAGE "Unmet dependency '${__dep}' for SOCI component '${__comp}'")
-          set(__skip_dependency TRUE)
-        endif()
-        continue()
+        set(SOCI_FOUND FALSE)
+        set(SOCI_NOT_FOUND_MESSAGE "Unmet dependency '${__dep}' for SOCI component '${__comp}'")
+        set(__skip_dependency TRUE)
       endif()
 
       list(APPEND __link_targets  ${__targets})
@@ -114,7 +109,6 @@ unset(__comp)
 unset(__dep_soci_comps)
 unset(__dep_names)
 unset(__dep_dep_targets)
-unset(__dep_required)
 
 
 check_required_components(SOCI)

--- a/soci-config.cmake.in
+++ b/soci-config.cmake.in
@@ -10,6 +10,12 @@ set(__dep_dep_targets "@SOCI_DEPENDENCY_TARGETS@")
 set(__prev_module_path "${CMAKE_MODULE_PATH}")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/find_package_files/")
 
+if (${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
+  set(__quiet "QUIET")
+else()
+  set(__quiet "")
+endif()
+
 
 if (NOT DEFINED SOCI_FIND_COMPONENTS OR SOCI_FIND_COMPONENTS STREQUAL "")
     # Use all available SOCI components
@@ -72,12 +78,6 @@ foreach(__comp IN LISTS SOCI_FIND_COMPONENTS)
         continue()
       endif()
 
-      if (${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
-        set(__quiet "QUIET")
-      else()
-        set(__quiet "")
-      endif()
-
       find_package(
         ${__dep}
         ${__quiet}
@@ -131,6 +131,8 @@ if (NOT DEFINED SOCI_FOUND OR SOCI_FOUND)
       message(STATUS "Found SOCI: ${CMAKE_CURRENT_LIST_FILE} (found version \"@PROJECT_VERSION@\") found components: ${__components}")
   endif()
 endif()
+
+unset(__quiet)
 
 set(CMAKE_MODULE_PATH "${__prev_module_path}")
 unset(__prev_module_path)

--- a/soci-config.cmake.in
+++ b/soci-config.cmake.in
@@ -6,6 +6,8 @@ set(__dep_soci_comps  "@SOCI_DEPENDENCY_SOCI_COMPONENTS@")
 set(__dep_names       "@SOCI_DEPENDENCY_NAMES@")
 set(__dep_dep_targets "@SOCI_DEPENDENCY_TARGETS@")
 
+set(__dep_soci_boost "@SOCI_DEPENDENCY_BOOST@")
+set(__dep_soci_boost_components "@SOCI_DEPENDENCY_BOOST_COMPONENTS@")
 
 set(__prev_module_path "${CMAKE_MODULE_PATH}")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/find_package_files/")
@@ -28,6 +30,28 @@ endif()
 list(REMOVE_ITEM SOCI_FIND_COMPONENTS Core)
 list(INSERT SOCI_FIND_COMPONENTS 0 Core)
 
+# Check (optional) Core dependency on Boost.
+if (${__dep_soci_boost})
+  if (NOT "${__dep_soci_boost_components}" STREQUAL "")
+    set(SOCI_BOOST_COMPONENTS COMPONENTS ${__dep_soci_boost_components})
+  endif()
+
+  # Don't use REQUIRED to be able to give a better error message below.
+  find_package(Boost ${SOCI_BOOST_COMPONENTS} ${__quiet})
+
+  if (NOT Boost_FOUND)
+    set(SOCI_FOUND FALSE)
+    set(SOCI_NOT_FOUND_MESSAGE "Unmet dependency 'Boost' for SOCI component 'Core'")
+  else()
+    # Check for all the components too
+    foreach (__soci_boost_component IN LISTS __dep_soci_boost_components)
+      if (NOT TARGET Boost::${__soci_boost_component})
+        set(SOCI_FOUND FALSE)
+        set(SOCI_NOT_FOUND_MESSAGE "Unmet dependency 'Boost::${__soci_boost_component}' for SOCI component 'Core'")
+      endif()
+    endforeach()
+  endif()
+endif()
 
 list(LENGTH __dep_soci_comps __list_size)
 foreach (__item IN ITEMS __dep_names __dep_dep_targets)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -72,29 +72,33 @@ if (SOCI_SHARED)
 endif()
 
 if (WITH_BOOST)
-  if (WITH_BOOST STREQUAL "REQUIRED")
-    set(SOCI_BOOST_REQUIRED REQUIRED)
+  # Try and find Boost with the date_time component.
+  find_package(Boost COMPONENTS date_time QUIET)
+
+  # Note that we shouldn't check Boost_FOUND here as it will be true even if
+  # we found only Boost headers, but not the date_time library.
+  if (TARGET Boost::date_time)
+    set(SOCI_BOOST_DATE_TIME_MESSAGE " (with date_time component)")
+
+    target_link_libraries(soci_core PUBLIC Boost::date_time)
+    target_compile_definitions(soci_core PUBLIC SOCI_HAVE_BOOST_DATE_TIME)
+  else()
+    # If we couldn't find Boost::date_time, retry searching for Boost headers
+    # only and use only them, if found.
+    if (WITH_BOOST STREQUAL "REQUIRED")
+      find_package(Boost REQUIRED)
+    else()
+      find_package(Boost)
+    endif()
   endif()
 
-  # First try and find Boost with the date_time component. If it succeeds, the second search doesn't have any
-  # effect. If it failed, retry searching only for Boost without the date_time component and use that, if found.
-  soci_public_dependency(
-    NAME Boost
-    DEP_TARGETS Boost::boost Boost::date_time Boost::disable_autolinking
-    COMPONENTS date_time
-    MACRO_NAMES SOCI_HAVE_BOOST SOCI_HAVE_BOOST_DATE_TIME
-    ${SOCI_BOOST_REQUIRED}
-    TARGET SOCI::Core
-  )
+  # Here Boost_FOUND is true either if we had found date_time in the first
+  # find_package() call or just Boost headers in the second one.
+  if (Boost_FOUND)
+    message(STATUS "Found Boost: v${Boost_VERSION_STRING} in ${Boost_INCLUDE_DIRS}${SOCI_BOOST_DATE_TIME_MESSAGE}")
 
-  # If the search above was required to succeed, we know that it did, so don't bother trying to find Boost again.
-  if (NOT SOCI_BOOST_REQUIRED)
-    soci_public_dependency(
-      NAME Boost
-      DEP_TARGETS Boost::boost Boost::disable_autolinking
-      MACRO_NAMES SOCI_HAVE_BOOST
-      TARGET SOCI::Core
-    )
+    target_link_libraries(soci_core PUBLIC Boost::boost Boost::disable_autolinking)
+    target_compile_definitions(soci_core PUBLIC SOCI_HAVE_BOOST)
   endif()
 endif()
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -79,6 +79,7 @@ if (WITH_BOOST)
   # we found only Boost headers, but not the date_time library.
   if (TARGET Boost::date_time)
     set(SOCI_BOOST_DATE_TIME_MESSAGE " (with date_time component)")
+    set(SOCI_DEPENDENCY_BOOST_COMPONENTS "date_time" CACHE INTERNAL "Boost components used by SOCI")
 
     target_link_libraries(soci_core PUBLIC Boost::date_time)
     target_compile_definitions(soci_core PUBLIC SOCI_HAVE_BOOST_DATE_TIME)
@@ -96,6 +97,7 @@ if (WITH_BOOST)
   # find_package() call or just Boost headers in the second one.
   if (Boost_FOUND)
     message(STATUS "Found Boost: v${Boost_VERSION_STRING} in ${Boost_INCLUDE_DIRS}${SOCI_BOOST_DATE_TIME_MESSAGE}")
+    set(SOCI_DEPENDENCY_BOOST TRUE CACHE INTERNAL "Whether SOCI depends on Boost")
 
     target_link_libraries(soci_core PUBLIC Boost::boost Boost::disable_autolinking)
     target_compile_definitions(soci_core PUBLIC SOCI_HAVE_BOOST)


### PR DESCRIPTION
Don't use `soci_public_dependency()` for it to make things much simpler.

@Krzmbrzl I couldn't deal with the subtleties of this function and all the levels of indirection between its call in the sources and the use of macro names in the generated config file, so I've simply removed all of this because I really, really don't want to have to deal with all that complexity if this is at all avoidable. If we absolutely need to define Boost targets in the config file, I prefer to add something to `soci-config.cmake.in` to do it manually.