### PR TITLE
Remove ABI_VERSION from Windows build to prevent including version in DLL name and subsequent crash

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -164,9 +164,7 @@ target_link_libraries(soci_core
     ${CMAKE_DL_LIBS}
 )
 
-if (WIN32)
-  set(ABI_VERSION "${PROJECT_VERSION_MAJOR}_${PROJECT_VERSION_MINOR}")
-elseif(UNIX)
+if(UNIX)
   # Use SOVERSION, which is only the major version
   set(ABI_VERSION "${PROJECT_VERSION_MAJOR}")
 endif()

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -44,6 +44,7 @@ TEST_CASE("SQLite connection string", "[sqlite][connstring]")
     params.set_option("nocreate", "1");
     CHECK_THROWS_WITH(soci::session(params),
                       Catch::Contains("Cannot establish connection"));
+    CHECK_NOTHROW(soci::session("sqlite3", "dbname=:memory: nocreate"));
 
     // Finally allow testing arbitrary connection strings by specifying them in
     // the environment variables.


### PR DESCRIPTION
The DLL name dynamically generated on Windows when loading a backend using a backend name (eg 'sqlite3') includes the version (eg soci-sqlite3_4_1.dll). The build system no longer uses version numbers so your application crashes at run time when the DLL cannot be found. 

This PR removes the version number. Tested on Windows and Linux for SQLite3 backend only and only opening via the backend name.

Note that soci_sqlite3_test.exe works before and after this PR because it doesn't load the SQLite3 dll via a backend name.