### PR TITLE
add MariaDB to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Backend specific client libraries for:
 
 * DB2
 * Firebird
-* MySQL
+* MySQL / MariaDB
 * ODBC with specific database driver
 * Oracle
 * PostgreSQL


### PR DESCRIPTION
Following up my question https://github.com/SOCI/soci/issues/1150, I suggest adding a mention of MariaDB to README considering [MariaDB is being tested for](https://github.com/SOCI/soci/commit/8b2cc353bc380543984b1111fdeecdbbab2703a6) (MariaDB also mentioned [here](https://github.com/SOCI/soci/actions/runs/14606844172/job/40977457744))). Do I understand correctly, does this make sense? 

The README says "Backend specific client libraries for", so I guess it needs to say "MySQL/MariaDB" and not "MariaDB" on its own row?