### PR TITLE
Add unit test to ensure Sqlite3 db can be created using the database name

### DIFF
--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -44,6 +44,7 @@ TEST_CASE("SQLite connection string", "[sqlite][connstring]")
     params.set_option("nocreate", "1");
     CHECK_THROWS_WITH(soci::session(params),
                       Catch::Contains("Cannot establish connection"));
+    CHECK_NOTHROW(soci::session("sqlite3", "dbname=:memory: nocreate"));
 
     // Finally allow testing arbitrary connection strings by specifying them in
     // the environment variables.


### PR DESCRIPTION
This test attempts to open a Sqlite3 database by name ("sqlite3") rather than by specifying soci::factory_sqlite3(). It demonstrates a regression in recent versions where the name of the sqlite3 DLL on Windows is incorrectly generated to include the version, which then causes a crash because the build system no longer creates a DLL with the version included.

See https://github.com/SOCI/soci/pull/1248 for a proposed solution.

