### PR TITLE
Restore ABI version use in Windows DLL names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,22 @@ else()
   set(SOCI_LIB_TYPE "STATIC")
 endif()
 
+# When using shared libraries, use version-dependent suffix in their names.
+if (SOCI_SHARED)
+  if (WIN32)
+    # Use the full version number as ABI version on Windows and define
+    # ABI_SUFFIX which is used to add it to the DLL name manually because this
+    # is just a convention and so is not done automatically by CMake.
+    set(ABI_VERSION "${PROJECT_VERSION_MAJOR}_${PROJECT_VERSION_MINOR}")
+    set(ABI_SUFFIX "_${ABI_VERSION}")
+  elseif(UNIX)
+    # Use same value as for SOVERSION, which is only the major version (and is
+    # used automatically to construct the shared libraries names, so there is
+    # no need for ABI_SUFFIX).
+    set(ABI_VERSION "${PROJECT_VERSION_MAJOR}")
+  endif()
+endif()
+
 
 include(soci_compiler_options)
 include(soci_install_dirs)

--- a/cmake/soci_define_backend_target.cmake
+++ b/cmake/soci_define_backend_target.cmake
@@ -137,6 +137,13 @@ function(soci_define_backend_target)
       EXPORT_NAME ${DEFINE_BACKEND_NAME}
   )
 
+  if (DEFINED ABI_SUFFIX)
+    set_target_properties(${DEFINE_BACKEND_TARGET_NAME}
+      PROPERTIES
+        OUTPUT_NAME "${DEFINE_BACKEND_TARGET_NAME}${ABI_SUFFIX}"
+    )
+  endif()
+
   if (DEFINE_BACKEND_HEADER_FILES)
     target_sources(${DEFINE_BACKEND_TARGET_NAME}
       PUBLIC

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -164,11 +164,11 @@ target_link_libraries(soci_core
     ${CMAKE_DL_LIBS}
 )
 
-if (WIN32)
-  set(ABI_VERSION "${PROJECT_VERSION_MAJOR}_${PROJECT_VERSION_MINOR}")
-elseif(UNIX)
-  # Use SOVERSION, which is only the major version
-  set(ABI_VERSION "${PROJECT_VERSION_MAJOR}")
+if (DEFINED ABI_SUFFIX)
+  set_target_properties(soci_core
+    PROPERTIES
+      OUTPUT_NAME "soci_core${ABI_SUFFIX}"
+  )
 endif()
 
 cmake_path(

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -40,3 +40,9 @@ target_include_directories(soci_tests_common
     "${PROJECT_SOURCE_DIR}/include/private"
     "${PROJECT_SOURCE_DIR}/tests"
 )
+
+if (SOCI_SHARED)
+  # We have a test checking for loading backend dynamically which can only be
+  # done when using shared libraries, so define a symbol to guard it.
+  target_compile_definitions(soci_tests_common PRIVATE SOCI_DYNAMIC_BACKEND)
+endif()

--- a/tests/common/test-connparams.cpp
+++ b/tests/common/test-connparams.cpp
@@ -149,6 +149,15 @@ TEST_CASE("connection_parameters::build_string_from_options", "[core][connstring
     CHECK(params.build_string_from_options('\'') == "bar=baz foo='' quux='1 2'");
 }
 
+// Test loading backend dynamically if possible (this symbol is defined by
+// the build system if shared libraries are used).
+#ifdef SOCI_DYNAMIC_BACKEND
+TEST_CASE_METHOD(common_tests, "backend::load_by_name", "[backend][dynamic]")
+{
+    CHECK_NOTHROW(soci::session(tc_.get_backend_name(), tc_.get_connect_string()));
+}
+#endif // SOCI_DYNAMIC_BACKEND
+
 } // namespace tests
 
 } // namespace soci

--- a/tests/db2/test-db2.cpp
+++ b/tests/db2/test-db2.cpp
@@ -74,6 +74,11 @@ public:
         return "DSN=SAMPLE;Uid=db2inst1;Pwd=db2inst1;autocommit=off";
     }
 
+    std::string get_backend_name() const override
+    {
+        return "db2";
+    }
+
     table_creator_base* table_creator_1(soci::session & pr_s) const override
     {
         pr_s << "SET CURRENT SCHEMA = 'DB2INST1'";

--- a/tests/empty/test-empty.cpp
+++ b/tests/empty/test-empty.cpp
@@ -153,6 +153,11 @@ public:
         return "connect_string_for_empty_backend";
     }
 
+    std::string get_backend_name() const override
+    {
+        return "empty";
+    }
+
     // As we don't use common tests with this pseudo-backend, we don't actually
     // need to implement these functions -- but they still must be defined.
     std::string to_date_time(std::string const&) const override

--- a/tests/firebird/test-firebird.cpp
+++ b/tests/firebird/test-firebird.cpp
@@ -1196,6 +1196,11 @@ class test_context : public tests::test_context_common
             return "service=/usr/local/firebird/db/test.fdb user=SYSDBA password=masterkey";
         }
 
+        std::string get_backend_name() const override
+        {
+            return "firebird";
+        }
+
         tests::table_creator_base* table_creator_1(soci::session& s) const override
         {
             return new TableCreator1(s);

--- a/tests/mysql/test-mysql.h
+++ b/tests/mysql/test-mysql.h
@@ -73,6 +73,11 @@ public:
         return "dbname=test user=root password=\'Ala ma kota\'";
     }
 
+    std::string get_backend_name() const override
+    {
+        return "mysql";
+    }
+
     table_creator_base* table_creator_1(soci::session& s) const override
     {
         return new table_creator_one(s);

--- a/tests/odbc/test-odbc-access.cpp
+++ b/tests/odbc/test-odbc-access.cpp
@@ -79,6 +79,11 @@ public:
         return "FILEDSN=./test-access.dsn";
     }
 
+    std::string get_backend_name() const override
+    {
+        return "odbc";
+    }
+
     table_creator_base * table_creator_1(soci::session& s) const
     {
         return new table_creator_one(s);

--- a/tests/odbc/test-odbc-db2.cpp
+++ b/tests/odbc/test-odbc-db2.cpp
@@ -74,6 +74,11 @@ public:
         return "DSN=<db>;Uid=<user>;Pwd=<password>";
     }
 
+    std::string get_backend_name() const override
+    {
+        return "odbc";
+    }
+
     table_creator_base * table_creator_1(soci::session& s) const
     {
         return new table_creator_one(s);

--- a/tests/odbc/test-odbc-mssql.cpp
+++ b/tests/odbc/test-odbc-mssql.cpp
@@ -275,6 +275,11 @@ public:
         return "FILEDSN=./test-mssql.dsn";
     }
 
+    std::string get_backend_name() const override
+    {
+        return "odbc";
+    }
+
     table_creator_base* table_creator_1(soci::session& s) const override
     {
         return new table_creator_one(s);

--- a/tests/odbc/test-odbc-mysql.cpp
+++ b/tests/odbc/test-odbc-mysql.cpp
@@ -29,6 +29,11 @@ public:
         return "FILEDSN=./test-mysql.dsn";
     }
 
+    std::string get_backend_name() const override
+    {
+        return "odbc";
+    }
+
     bool truncates_uint64_to_int64() const override
     {
         // The ODBC driver of MySQL truncates values bigger then INT64_MAX.

--- a/tests/odbc/test-odbc-postgresql.cpp
+++ b/tests/odbc/test-odbc-postgresql.cpp
@@ -174,6 +174,11 @@ public:
         return "FILEDSN=./test-postgresql.dsn";
     }
 
+    std::string get_backend_name() const override
+    {
+        return "odbc";
+    }
+
     table_creator_base * table_creator_1(soci::session& s) const override
     {
         return new table_creator_one(s);

--- a/tests/oracle/test-oracle.cpp
+++ b/tests/oracle/test-oracle.cpp
@@ -1553,6 +1553,11 @@ public:
         return test_context_base::start_testing();
     }
 
+    std::string get_backend_name() const override
+    {
+        return "oracle";
+    }
+
     table_creator_base* table_creator_1(soci::session& s) const override
     {
         return new table_creator_one(s);

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -1498,6 +1498,11 @@ public:
         return "host=localhost port=5432 dbname=test user=postgres password=postgres";
     }
 
+    std::string get_backend_name() const override
+    {
+        return "postgresql";
+    }
+
     table_creator_base* table_creator_1(soci::session& s) const override
     {
         return new table_creator_one(s);

--- a/tests/sqlite3/test-sqlite3.cpp
+++ b/tests/sqlite3/test-sqlite3.cpp
@@ -1030,6 +1030,11 @@ public:
         return test_context_base::initialize_connect_string(argFromCommandLine);
     }
 
+    std::string get_backend_name() const override
+    {
+        return "sqlite3";
+    }
+
     table_creator_base* table_creator_1(soci::session& s) const override
     {
         return new table_creator_one(s);

--- a/tests/test-context.h
+++ b/tests/test-context.h
@@ -143,6 +143,9 @@ public:
         return connectString_;
     }
 
+    // Return the name of the backend as used in the dynamic library name.
+    virtual std::string get_backend_name() const = 0;
+
     virtual std::string to_date_time(std::string const &dateTime) const = 0;
 
     virtual table_creator_base* table_creator_1(session&) const = 0;


### PR DESCRIPTION
This was lost during CMake rewrite, but it makes sense to keep doing it, as it's a common convention under Windows due to the absence of SOVERSION equivalent, and it broke dynamic backend loading by name.

See #1248.