### PR TITLE
SQLite: Ensure timeout setting first

### DIFF
--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -14,6 +14,7 @@
 
 #include <functional>
 #include <memory>
+#include <sqlite3.h>
 #include <sstream>
 #include <string>
 
@@ -172,6 +173,10 @@ sqlite3_session_backend::sqlite3_session_backend(
         }
     );
 
+    //Set the timeout first to have effect on the following queries.
+    res = sqlite3_busy_timeout(conn_, timeout * 1000);
+    check_sqlite_err(conn_, res, "Failed to set busy timeout for connection. ");
+
     if (!synchronous.empty())
     {
         std::string const query("pragma synchronous=" + synchronous);
@@ -193,9 +198,6 @@ sqlite3_session_backend::sqlite3_session_backend(
             }
         );
     }
-
-    res = sqlite3_busy_timeout(conn_, timeout * 1000);
-    check_sqlite_err(conn_, res, "Failed to set busy timeout for connection. ");
 }
 
 sqlite3_session_backend::~sqlite3_session_backend()


### PR DESCRIPTION
The timeout setting is set first for SQLite as setting other settings might fail with a locked database and no timeout.