### PR TITLE
Replaced the potentially unsafe `strcpy` function with `strcpy_s`

### DIFF
--- a/src/backends/odbc/error.cpp
+++ b/src/backends/odbc/error.cpp
@@ -82,10 +82,10 @@ odbc_soci_error::interpret_odbc_error(SQLSMALLINT htype,
     if (socierror)
     {
         // Use our own error message if we failed to retrieve the ODBC one.
-        strcpy(reinterpret_cast<char*>(message_), socierror);
+        strcpy_s(reinterpret_cast<char*>(message_), sizeof(message_), socierror);
 
         // Use "General warning" SQLSTATE code.
-        strcpy(reinterpret_cast<char*>(sqlstate_), "01000");
+        strcpy_s(reinterpret_cast<char*>(sqlstate_), sizeof(sqlstate_), "01000");
 
         sqlcode_ = 0;
     }


### PR DESCRIPTION
in soci\src\backends\odbc\error.cpp`

Replaced the deprecated and potentially unsafe `strcpy` function with `strcpy_s` in `error.cpp`. This change improves security by preventing buffer overflows, as `strcpy_s` requires a buffer size argument, ensuring that the destination buffer is not written past its allocated size.

The change is small but improves security 