### PR TITLE
Introduce Safe String Copy Utility (soci_strncpy_safe) for ODBC Backend

### DIFF
--- a/src/backends/odbc/CMakeLists.txt
+++ b/src/backends/odbc/CMakeLists.txt
@@ -25,7 +25,6 @@ soci_define_backend_target(
     "common.cpp"
   HEADER_FILES
     "${PROJECT_SOURCE_DIR}/include/soci/odbc/soci-odbc.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/common.h"
   MISSING_DEPENDENCY_BEHAVIOR "${DEPENDENCY_MODE}"
 )
 

--- a/src/backends/odbc/CMakeLists.txt
+++ b/src/backends/odbc/CMakeLists.txt
@@ -22,8 +22,10 @@ soci_define_backend_target(
     "statement.cpp"
     "vector-into-type.cpp"
     "vector-use-type.cpp"
+    "common.cpp"
   HEADER_FILES
     "${PROJECT_SOURCE_DIR}/include/soci/odbc/soci-odbc.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/common.h"
   MISSING_DEPENDENCY_BEHAVIOR "${DEPENDENCY_MODE}"
 )
 

--- a/src/backends/odbc/CMakeLists.txt
+++ b/src/backends/odbc/CMakeLists.txt
@@ -25,6 +25,7 @@ soci_define_backend_target(
     "common.cpp"
   HEADER_FILES
     "${PROJECT_SOURCE_DIR}/include/soci/odbc/soci-odbc.h"
+    "${PROJECT_SOURCE_DIR}/include/soci/odbc/common.h"
   MISSING_DEPENDENCY_BEHAVIOR "${DEPENDENCY_MODE}"
 )
 

--- a/src/backends/odbc/common.cpp
+++ b/src/backends/odbc/common.cpp
@@ -1,0 +1,24 @@
+#include "soci/odbc/common.h"
+
+namespace soci
+{
+    namespace details
+    {
+        namespace odbc
+        {
+
+            char* soci_strncpy_safe(char* dest, const char* src, std::size_t n)
+            {
+                if (n == 0) return dest;
+                std::size_t i = 0;
+                for (; i < n - 1 && src[i] != '\0'; ++i)
+                {
+                    dest[i] = src[i];
+                }
+                dest[i] = '\0';
+                return dest;
+            }
+
+        } // namespace odbc
+    } // namespace details
+} // namespace soci

--- a/src/backends/odbc/common.h
+++ b/src/backends/odbc/common.h
@@ -1,0 +1,19 @@
+// Copyright (C) 2024 Your Name or Project
+// Distributed under the Boost Software License, Version 1.0.
+
+#pragma once
+#include <cstddef>
+
+namespace soci
+{
+    namespace details
+    {
+        namespace odbc
+        {
+
+            // Safe string copy: copies up to n-1 chars, always null-terminates if n > 0.
+            char* soci_strncpy_safe(char* dest, const char* src, std::size_t n);
+
+        } // namespace odbc
+    } // namespace details
+} // namespace soci


### PR DESCRIPTION
This pull request introduces a custom, safer string copy function, soci_strncpy_safe, to the ODBC backend alongside the necessary common.cpp class for further utilities