### PR TITLE
Remove SOCI_INT64_T_IS_LONG and the test for it in CMake

### DIFF
--- a/include/soci/exchange-traits.h
+++ b/include/soci/exchange-traits.h
@@ -100,31 +100,15 @@ struct exchange_traits<uint64_t>
     enum { x_type = x_uint64 };
 };
 
-// If "long" itself is the same type as int64_t, "long long" must be a
-// different type and we need to specialize exchange_traits for it, otherwise
-// it must be same as "long long" and we need to define specialization for
-// "long" instead (whether it's 32 or 64 bits).
-#if defined(SOCI_INT64_T_IS_LONG)
 template <>
-struct exchange_traits<long long> : exchange_traits<int64_t>
+struct exchange_traits<soci_l_or_ll_t> : exchange_traits<soci_l_or_ll_int_t>
 {
 };
 
 template <>
-struct exchange_traits<unsigned long long> : exchange_traits<uint64_t>
+struct exchange_traits<soci_ul_or_ull_t> : exchange_traits<soci_ul_or_ull_int_t>
 {
 };
-#else
-template <>
-struct exchange_traits<long> : exchange_traits<soci_long_t>
-{
-};
-
-template <>
-struct exchange_traits<unsigned long> : exchange_traits<soci_ulong_t>
-{
-};
-#endif
 
 template <>
 struct exchange_traits<double>

--- a/include/soci/fixed-size-ints.h
+++ b/include/soci/fixed-size-ints.h
@@ -16,12 +16,10 @@ namespace soci
 // long and long long. With the following type_conversion specializations,
 // this becomes possible.
 
-// See comment before the similar test in exchange-traits.h for explanations.
-#if defined(SOCI_INT64_T_IS_LONG)
 template <>
-struct type_conversion<long long>
+struct type_conversion<soci_l_or_ll_t>
 {
-    typedef int64_t base_type;
+    typedef soci_l_or_ll_int_t base_type;
 
     static void from_base(base_type const & in, indicator ind, long long & out)
     {
@@ -41,9 +39,9 @@ struct type_conversion<long long>
 };
 
 template <>
-struct type_conversion<unsigned long long>
+struct type_conversion<soci_ul_or_ull_t>
 {
-    typedef uint64_t base_type;
+    typedef soci_ul_or_ull_int_t base_type;
 
     static void from_base(base_type const & in, indicator ind, unsigned long long & out)
     {
@@ -61,51 +59,6 @@ struct type_conversion<unsigned long long>
         ind = i_ok;
     }
 };
-#else
-template <>
-struct type_conversion<long>
-{
-    typedef soci_long_t base_type;
-
-    static void from_base(base_type const & in, indicator ind, long & out)
-    {
-        if (ind == i_null)
-        {
-            throw soci_error("Null value not allowed for this type.");
-        }
-
-        out = static_cast<long>(in);
-    }
-
-    static void to_base(long const & in, base_type & out, indicator & ind)
-    {
-        out = static_cast<base_type>(in);
-        ind = i_ok;
-    }
-};
-
-template <>
-struct type_conversion<unsigned long>
-{
-    typedef soci_ulong_t base_type;
-
-    static void from_base(base_type const & in, indicator ind, unsigned long & out)
-    {
-        if (ind == i_null)
-        {
-            throw soci_error("Null value not allowed for this type.");
-        }
-
-        out = static_cast<unsigned long>(in);
-    }
-
-    static void to_base(unsigned long const & in, base_type & out, indicator & ind)
-    {
-        out = static_cast<base_type>(in);
-        ind = i_ok;
-    }
-};
-#endif
 
 } // namespace soci
 

--- a/include/soci/soci-types.h
+++ b/include/soci/soci-types.h
@@ -4,9 +4,35 @@
 #include <cstdint>
 #include <type_traits>
 
-// Define typedefs for std::[u]intN_t type of the same size as [unsigned] long
-// assuming it can only be 32 or 64 bits.
-using soci_long_t = std::conditional<sizeof(long) == 8, int64_t, int32_t>::type;
-using soci_ulong_t = std::conditional<sizeof(long) == 8, uint64_t, uint32_t>::type;
+// In several places, we want to handle "long" or "long long" as the
+// corresponding fixed size integer types (knowing that the other type is
+// already handled by the specialization for either int32_t or int64_t).
+//
+// Define the type which is not handled by an existing specialization and the
+// type as which it should be handled.
+//
+// Note that this assumes that int64_t is always either "long long" or "long",
+// which is not, strictly speaking, guaranteed by the C++ standard, but is true
+// for all known compilers and platforms (however note that some LP64 platforms
+// still define int64_t as "long long" and not just "long", e.g. macOS does it).
+
+// This is the "other" type, i.e. the one which is not the same as int64_t.
+using soci_l_or_ll_t =
+    std::conditional<std::is_same<long long, int64_t>::value,
+                     long, long long>::type;
+
+// And this is the corresponding intN_t type of the same size.
+using soci_l_or_ll_int_t =
+    std::conditional<sizeof(soci_l_or_ll_t) == 4,
+                     int32_t, int64_t>::type;
+
+// Same as above but for unsigned types.
+using soci_ul_or_ull_t =
+    std::conditional<std::is_same<unsigned long long, uint64_t>::value,
+                     unsigned long, unsigned long long>::type;
+
+using soci_ul_or_ull_int_t =
+    std::conditional<sizeof(soci_ul_or_ull_t) == 4,
+                     uint32_t, uint64_t>::type;
 
 #endif // SOCI_TYPES_H_INCLUDED

--- a/include/soci/type-holder.h
+++ b/include/soci/type-holder.h
@@ -276,29 +276,15 @@ struct type_holder_trait<uint64_t>
     static const db_type type = db_uint64;
 };
 
-// See comment before the similar test in exchange-traits.h for explanations.
-#if defined(SOCI_INT64_T_IS_LONG)
 template <>
-struct type_holder_trait<long long> : type_holder_trait<int64_t>
+struct type_holder_trait<soci_l_or_ll_t> : type_holder_trait<soci_l_or_ll_int_t>
 {
 };
 
 template <>
-struct type_holder_trait<unsigned long long> : type_holder_trait<uint64_t>
+struct type_holder_trait<soci_ul_or_ull_t> : type_holder_trait<soci_ul_or_ull_int_t>
 {
 };
-#else
-
-template <>
-struct type_holder_trait<long> : type_holder_trait<soci_long_t>
-{
-};
-
-template <>
-struct type_holder_trait<unsigned long> : type_holder_trait<soci_ulong_t>
-{
-};
-#endif
 
 template <>
 struct type_holder_trait<double>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,6 @@ add_subdirectory(backends)
 # platform-dependent settings
 ###############################################################################
 
-soci_are_types_same(TYPES "int64_t" "long" OUTPUT_VARIABLE SOCI_INT64_T_IS_LONG)
 soci_are_types_same(TYPES "int8_t" "char" OUTPUT_VARIABLE SOCI_INT8_T_IS_CHAR)
 
 # Generate the soci-config.h file
@@ -28,7 +27,6 @@ set(CONFIG_VARS
   SOCI_ORACLE
   SOCI_POSTGRESQL
   SOCI_SQLITE3
-  SOCI_INT64_T_IS_LONG
   SOCI_INT8_T_IS_CHAR
 )
 set(CONFIG_MACROS
@@ -40,7 +38,6 @@ set(CONFIG_MACROS
   SOCI_HAVE_ORACLE
   SOCI_HAVE_POSTGRESQL
   SOCI_HAVE_SQLITE3
-  SOCI_INT64_T_IS_LONG
   SOCI_INT8_T_IS_CHAR
 )
 


### PR DESCRIPTION
We can replace preprocessor checks for SOCI_INT64_T_IS_LONG with simpler logic if we assume that int64_t is always either "long" or "long long", which seems to be true in practice, so do it and remove duplicated specializations for "long" and "long long" in several places.