### PR TITLE
Allow customizing SOCI shared libraries names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,9 +131,18 @@ install(
     DESTINATION "${SOCI_INSTALL_CMAKEDIR}"
 )
 
-# Final status
+# Give build summary at the end but only if it's the first time we're running,
+# as indicated by SOCI_SUMMARY not being cached yet, or if it has changed.
+set(SOCI_SUMMARY_NOW
+  "${SOCI_VERSION}-${SOCI_LIB_TYPE}-${SOCI_ENABLED_BACKENDS}-${CMAKE_BUILD_TYPE}"
+)
+if(NOT "${SOCI_SUMMARY_NOW}" STREQUAL "$CACHE{SOCI_SUMMARY}")
+set(SOCI_SUMMARY ${SOCI_SUMMARY_NOW} CACHE INTERNAL "SOCI internal build summary")
+
 if (CMAKE_BUILD_TYPE)
   set(SOCI_CONFIG_DESCRIPTION " in ${CMAKE_BUILD_TYPE} configuration")
 endif()
 message(STATUS "SOCI ${SOCI_VERSION} will be built as ${SOCI_LIB_TYPE} library${SOCI_CONFIG_DESCRIPTION}.")
 message(STATUS "Enabled SOCI backends are: ${SOCI_ENABLED_BACKENDS}")
+
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,19 +86,29 @@ endif()
 # When using shared libraries, use version-dependent suffix in their names.
 if (SOCI_SHARED)
   if (WIN32)
-    # Use the full version number as ABI version on Windows and define
-    # ABI_SUFFIX which is used to add it to the DLL name manually because this
-    # is just a convention and so is not done automatically by CMake.
+    # Use the full version number as ABI version on Windows, different minor
+    # versions are not ABI-compatible.
     set(ABI_VERSION "${PROJECT_VERSION_MAJOR}_${PROJECT_VERSION_MINOR}")
-    set(ABI_SUFFIX "_${ABI_VERSION}")
+
+    # Also use it in the library name by default to ensure that the DLLs of
+    # different versions are called differently as there is no SOVERSION on
+    # Windows to prevent this from happening.
+    set(soci_default_suffix "_${ABI_VERSION}")
   elseif(UNIX)
     # Use same value as for SOVERSION, which is only the major version (and is
     # used automatically to construct the shared libraries names, so there is
-    # no need for ABI_SUFFIX).
+    # no need for any suffix).
     set(ABI_VERSION "${PROJECT_VERSION_MAJOR}")
   endif()
 endif()
 
+set(SOCI_NAME_PREFIX "" CACHE STRING "Optional prefix to add before 'soci_' in library names")
+set(SOCI_NAME_SUFFIX "${soci_default_suffix}" CACHE STRING "Optional suffix to add to the library names")
+
+# Helper function appending prefix and suffix to the library name.
+function(soci_build_library_name result basename)
+  set(${result} "${SOCI_NAME_PREFIX}${basename}${SOCI_NAME_SUFFIX}" PARENT_SCOPE)
+endfunction()
 
 include(soci_compiler_options)
 include(soci_install_dirs)

--- a/cmake/soci_define_backend_target.cmake
+++ b/cmake/soci_define_backend_target.cmake
@@ -130,19 +130,15 @@ function(soci_define_backend_target)
   target_link_libraries(${DEFINE_BACKEND_TARGET_NAME} PUBLIC SOCI::Core)
   target_include_directories(${DEFINE_BACKEND_TARGET_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/include/private")
 
+  soci_build_library_name(full_backend_target_name "${DEFINE_BACKEND_TARGET_NAME}")
+
   set_target_properties(${DEFINE_BACKEND_TARGET_NAME}
     PROPERTIES
+      OUTPUT_NAME ${full_backend_target_name}
       SOVERSION ${PROJECT_VERSION_MAJOR}
       VERSION ${PROJECT_VERSION}
       EXPORT_NAME ${DEFINE_BACKEND_NAME}
   )
-
-  if (DEFINED ABI_SUFFIX)
-    set_target_properties(${DEFINE_BACKEND_TARGET_NAME}
-      PROPERTIES
-        OUTPUT_NAME "${DEFINE_BACKEND_TARGET_NAME}${ABI_SUFFIX}"
-    )
-  endif()
 
   if (DEFINE_BACKEND_HEADER_FILES)
     target_sources(${DEFINE_BACKEND_TARGET_NAME}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -85,6 +85,7 @@ Some other build options:
 * `SOCI_ASAN` - boolean - Build with address sanitizer (ASAN) support. Useful for finding problems when debugging, but shouldn't be used for the production builds due to extra overhead. Default is `OFF`.
 * `SOCI_UBSAN` - boolean - Build with undefined behaviour sanitizer (ASAN) support. Default is `OFF`.
 * `SOCI_LTO` - boolean - Build with link-time optimizations, if supported. This produces noticeably smaller libraries. Default is `OFF`, but turning it on is recommended for the production builds.
+* `SOCI_NAME_PREFIX` and `SOCI_NAME_SUFFIX` - strings - If specified, the former is prepended and the latter appended to the names of all SOCI libraries. Note that by default SOCI build system appends `_MAJOR_MINOR` suffix to the names of Windows DLLs (but not to the names of Unix shared libraries) to prevent mixing up ABI-incompatible builds from different SOCI versions. If you want to override this behaviour, you can set `SOCI_NAME_SUFFIX` to an empty string.
 
 When it comes to enabling specific backends, SOCI supports three distinct options that can be used as `Enabler` type as used below:
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,7 +1,5 @@
 include(GNUInstallDirs)
 
-set(SOCI_LIB_PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}soci_" CACHE STRING "Specifies prefix for the lib directory")
-set(SOCI_LIB_SUFFIX "${CMAKE_SHARED_LIBRARY_SUFFIX}" CACHE STRING "Specifies suffix for the lib directory")
 set(SOCI_DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}" CACHE STRING "Specifies suffix for the library file in debug mode")
 
 
@@ -33,8 +31,11 @@ add_library(soci_core
 
 add_library(SOCI::Core ALIAS soci_core)
 
+soci_build_library_name(soci_core_name "soci_core")
+
 set_target_properties(
   soci_core PROPERTIES
+  OUTPUT_NAME ${soci_core_name}
   SOVERSION ${PROJECT_VERSION_MAJOR}
   VERSION ${PROJECT_VERSION}
   EXPORT_NAME Core
@@ -169,13 +170,6 @@ if (NOT MSVC)
   )
 endif()
 
-if (DEFINED ABI_SUFFIX)
-  set_target_properties(soci_core
-    PROPERTIES
-      OUTPUT_NAME "soci_core${ABI_SUFFIX}"
-  )
-endif()
-
 cmake_path(
   ABSOLUTE_PATH SOCI_INSTALL_LIBDIR
   BASE_DIRECTORY "${CMAKE_INSTALL_PREFIX}"
@@ -185,17 +179,10 @@ cmake_path(
 target_compile_definitions(soci_core
   PRIVATE
     DEFAULT_BACKENDS_PATH="${SOCI_INSTALL_FULL_LIBDIR}"
-    SOCI_LIB_PREFIX="${SOCI_LIB_PREFIX}"
-    SOCI_LIB_SUFFIX="${SOCI_LIB_SUFFIX}"
+    SOCI_LIB_PREFIX="${CMAKE_SHARED_LIBRARY_PREFIX}${SOCI_NAME_PREFIX}soci_"
+    SOCI_LIB_SUFFIX="${SOCI_NAME_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}"
     SOCI_DEBUG_POSTFIX="${SOCI_DEBUG_POSTFIX}"
 )
-if (DEFINED ABI_VERSION)
-  target_compile_definitions(soci_core
-    PRIVATE
-      SOCI_ABI_VERSION="${ABI_VERSION}"
-  )
-endif()
-
 
 install(
   TARGETS soci_core

--- a/src/core/backend-loader.cpp
+++ b/src/core/backend-loader.cpp
@@ -77,15 +77,7 @@ std::string get_this_dynlib_path()
 #define DLCLOSE(x) FreeLibrary(x)
 #define DLSYM(x, y) GetProcAddress(x, y)
 
-#ifdef SOCI_ABI_VERSION
-  #ifndef NDEBUG
-    #define LIBNAME(x) (SOCI_LIB_PREFIX + x + "_" SOCI_ABI_VERSION SOCI_DEBUG_POSTFIX SOCI_LIB_SUFFIX)
-  #else
-    #define LIBNAME(x) (SOCI_LIB_PREFIX + x + "_" SOCI_ABI_VERSION SOCI_LIB_SUFFIX)
-  #endif
-#else
-#define LIBNAME(x) (SOCI_LIB_PREFIX + x + SOCI_LIB_SUFFIX)
-#endif // SOCI_ABI_VERSION
+#define LIBNAME(x) (SOCI_LIB_PREFIX + x + SOCI_DEBUG_POSTFIX SOCI_LIB_SUFFIX)
 
 // We need to disable showing message boxes from LoadLibrary() as we're
 // prepared to handle errors from them. Do this in ctor of this class and


### PR DESCRIPTION
Add SOCI_NAME_PREFIX and SOCI_NAME_SUFFIX build options to allow using custom prefix and/or suffix to distinguish custom SOCI builds.