### PR TITLE
Disable MSVC "unreachable code" warnings at CMake level

### DIFF
--- a/cmake/soci_compiler_options.cmake
+++ b/cmake/soci_compiler_options.cmake
@@ -34,6 +34,7 @@ if (MSVC)
     INTERFACE
       "$<${soci_cxx_source}:/W4>"
       "$<${soci_cxx_source}:/we4266>"
+      "$<${soci_cxx_source}:/wd4702>"  # we get many bogus "unreachable code"
   )
 
   if (SOCI_ENABLE_WERROR)

--- a/include/soci/row.h
+++ b/include/soci/row.h
@@ -72,12 +72,6 @@ public:
     column_properties const& get_properties(std::size_t pos) const;
     column_properties const& get_properties(std::string const& name) const;
 
-#ifdef _MSC_VER
-// MSVC complains about "unreachable code" in case get<base_type> can
-// be determined at compile time to throw.
-#pragma warning(push)
-#pragma warning(disable:4702)
-#endif
     template <typename T>
     T get(std::size_t pos) const
     {
@@ -110,9 +104,6 @@ public:
 
         return ret;
     }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
     template <typename T>
     T get(std::size_t pos, T const &nullValue) const

--- a/include/soci/type-holder.h
+++ b/include/soci/type-holder.h
@@ -364,12 +364,6 @@ public:
         }
     }
 
-#ifdef _MSC_VER
-// MSVC complains about "unreachable code" even though all
-// code here can be reached.
-#pragma warning(push)
-#pragma warning(disable:4702)
-#endif
     template <typename T>
     T get(value_cast_tag)
     {
@@ -443,9 +437,6 @@ public:
 
         throw std::bad_cast();
     }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 private:
     holder(db_type dt, void* val) : dt_(dt)

--- a/src/backends/sqlite3/vector-into-type.cpp
+++ b/src/backends/sqlite3/vector-into-type.cpp
@@ -45,23 +45,12 @@ void sqlite3_vector_into_type_backend::pre_fetch()
 namespace // anonymous
 {
 
-// MSVS 2015 (only) gives a bogus warning about unreachable code here, suppress
-// it to allow compilation with /WX in the CI builds.
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4702) // unreachable code
-#endif
-
 template <typename T>
 void set_in_vector(void* p, int indx, T const& val)
 {
     std::vector<T> &v = *static_cast<std::vector<T>*>(p);
     v[indx] = val;
 }
-
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 
 template <typename T>
 T parse_number_from_string(const char* str)


### PR DESCRIPTION
Not only the compiler seems to give this warning for just a simple unconditional "throw", but it also has started giving it in a previously warning-free code, probably due to a micro version update on GitHub CI.

Fighting against is becoming really ridiculous, so just suppress the warning globally and remove the local suppressions for it which are not needed any more.