### PR TITLE
Add possibility to specify "builtin" SQLite3 source file path

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -149,7 +149,7 @@ Furthermore, the `MYSQL_DIR` _environment variable_ can be set to the MySQL inst
 
 #### SQLite 3
 
-* `SOCI_SQLITE3` - Enabler - Enables the [SQLite3](backends/sqlite3.md) backend. Note that, unlike with all the other backends, if SQLite3 library is not found, built-in version of SQLite3 is used instead of the backend being disabled. `SOCI_SQLITE3_BUILTIN` can be set to `OFF` to prevent this from happening, i.e. force using system version only, or, on the contrary, set to `ON` to always use the built-in version, even if SQLite3 library is available on the system.
+* `SOCI_SQLITE3` - Enabler - Enables the [SQLite3](backends/sqlite3.md) backend. Note that, unlike with all the other backends, if SQLite3 library is not found, built-in version of SQLite3 is used instead of the backend being disabled. `SOCI_SQLITE3_BUILTIN` can be set to `OFF` to prevent this from happening, i.e. force using system version only, or, on the contrary, set to `ON` to always use the built-in version, even if SQLite3 library is available on the system. In the latter case you may additionally set `SOCI_SQLITE3_DIRECTORY` to specify the directory containing `sqlite3.c` file which will be used during the build or `SOCI_SQLITE3_SOURCE_FILE` to specify the path to the `sqlite3.c` file directly.
 * `SOCI_SQLITE3_TEST_CONNSTR` - string - Connection string is simply a file path where SQLite3 test database will be created (e.g. /home/john/soci_test.db). Check [SQLite3 backend reference](backends/sqlite3.md) for details. Example: `-DSOCI_SQLITE3_TEST_CONNSTR="my.db"` or `-DSOCI_SQLITE3_TEST_CONNSTR=":memory:"`.
 * `SOCI_SQLITE3_SKIP_TESTS` - boolean - Skips testing this backend.
 

--- a/src/backends/sqlite3/CMakeLists.txt
+++ b/src/backends/sqlite3/CMakeLists.txt
@@ -39,13 +39,17 @@ endif()
 
 # If SQLite3 was found, this target must have been created.
 if (NOT TARGET SQLite::SQLite3)
-  set(SQLITE3_DIRECTORY "${PROJECT_SOURCE_DIR}/3rdparty/sqlite3")
-  set(SQLITE3_SOURCE_FILE "${SQLITE3_DIRECTORY}/sqlite3.c")
+  set(SOCI_SQLITE3_DIRECTORY "${PROJECT_SOURCE_DIR}/3rdparty/sqlite3" CACHE
+    STRING "Directory where the built-in SQLite3 source code is located"
+  )
+  set(SOCI_SQLITE3_SOURCE_FILE "${SOCI_SQLITE3_DIRECTORY}/sqlite3.c" CACHE
+    STRING "Source file for the built-in SQLite3 library"
+  )
 
   # But if it wasn't, use our built-in version, after checking that it is
   # available, and if we're allowed to use it.
   if (NOT "${SOCI_SQLITE3_BUILTIN}" STREQUAL "OFF")
-    if (NOT EXISTS ${SQLITE3_SOURCE_FILE})
+    if (NOT EXISTS ${SOCI_SQLITE3_SOURCE_FILE})
       message(WARNING "SQLite3 not found and built-in version not available, have you cloned SOCI repository with --recurse-submodules?")
     else()
       set(SOCI_SQLITE3_USE_BUILTIN ON)
@@ -59,17 +63,17 @@ if (NOT TARGET SQLite::SQLite3)
   endif()
 
   if ("${SOCI_SQLITE3_BUILTIN}" STREQUAL "ON")
-    message(STATUS "Using built-in version of SQLite3")
+    message(STATUS "Using built-in version of SQLite3 in ${SOCI_SQLITE3_SOURCE_FILE}")
   else()
     message(STATUS "Falling back on built-in version of SQLite3")
   endif()
 
   target_sources(soci_sqlite3
     PRIVATE
-      ${SQLITE3_SOURCE_FILE}
+      ${SOCI_SQLITE3_SOURCE_FILE}
   )
   target_include_directories(soci_sqlite3
     PRIVATE
-      ${SQLITE3_DIRECTORY}
+      ${SOCI_SQLITE3_DIRECTORY}
   )
 endif()


### PR DESCRIPTION
This can be useful if a superproject wants to force the use of its own SQLite3 version.

Just prefix the existing variables with "SOCI_" and make them cache variables to allow pre-setting them before calling add_subdirectory() from the superproject.