### PR TITLE
Fix incorrect SQLWCHAR buffer size calculation in ODBC backend

### DIFF
--- a/src/backends/odbc/standard-into-type.cpp
+++ b/src/backends/odbc/standard-into-type.cpp
@@ -56,7 +56,8 @@ void odbc_standard_into_type_backend::define_by_pos(
         // Do exactly the same thing here as for x_stdstring above.
         size = static_cast<SQLUINTEGER>(statement_.column_size(position_));
         size = (size >= ODBC_MAX_COL_SIZE || size == 0) ? odbc_max_buffer_length : size;
-        size += sizeof(SQLWCHAR);
+        size++;
+        size = size * sizeof(SQLWCHAR); // size in bytes
         buf_ = new char[size];
         data = buf_;
         break;

--- a/src/backends/odbc/vector-into-type.cpp
+++ b/src/backends/odbc/vector-into-type.cpp
@@ -140,12 +140,13 @@ void odbc_vector_into_type_backend::define_by_pos(
                 statement_.fetchVectorByRows_ = true;
             }
 
-            colSize_ += sizeof(SQLWCHAR);
+            colSize_++;
+            colSize_ = colSize_ * sizeof(SQLWCHAR); // size in bytes
 
             const std::size_t elementsCount
                 = statement_.fetchVectorByRows_ ? 1 : vectorSize;
 
-            buf_ = new char[colSize_ * elementsCount * sizeof(SQLWCHAR)];
+            buf_ = new char[colSize_ * elementsCount];
         }
         break;
     case x_stdtm:

--- a/tests/odbc/test-odbc-mssql.cpp
+++ b/tests/odbc/test-odbc-mssql.cpp
@@ -83,7 +83,7 @@ struct wide_text_table_creator : public table_creator_base
       : table_creator_base(sql)
   {
       sql << "create table soci_test ("
-                  "wide_text nvarchar(40) null"
+                  "wide_text nvarchar(17) null"
               ")";
   }
 };


### PR DESCRIPTION
This PR fixes an issue in the ODBC backend where the buffer size passed to SQLBindCol() for std::wstring (i.e. SQL_C_WCHAR) was incorrectly calculated.

ODBC's SQLDescribeCol() returns column size in characters, but SQLBindCol() expects the buffer size in bytes.
The existing code failed to multiply by sizeof(SQLWCHAR), which could result in buffer truncation, corrupted reads, or subtle bugs when binding to wide character types such as NVARCHAR.


Changes included:

- Fixed the buffer size calculation in both standard-into-type.cpp and vector-into-type.cpp, converting character count to bytes properly using size * sizeof(SQLWCHAR).

- Adjusted the test table definition in test-odbc-mssql.cpp:
One of the existing test cases compares input and output of std::wstring values using a wide_text column.
However, the test string length was no more than 17 characters (wchar_t[17]), while the column was defined as NVARCHAR(40),
which made the buffer miscalculation undetectable.
To address this, the column was changed to NVARCHAR(17) so that the test becomes sensitive to buffer size errors.

- As a result of this change, the test fails without the fix and passes with the fix, effectively reproducing the issue without requiring a new test case.

- No additional test was added — instead, the existing one was precisely tuned to make the bug observable and reliably verified.