### PR TITLE
Make multiple find_package calls possible

### DIFF
--- a/soci-config.cmake.in
+++ b/soci-config.cmake.in
@@ -157,13 +157,14 @@ unset(__dep_dep_targets)
 check_required_components(SOCI)
 
 if (NOT DEFINED SOCI_FOUND OR SOCI_FOUND)
-  add_library(soci_interface INTERFACE)
+  if (NOT TARGET soci_interface)
+    add_library(soci_interface INTERFACE)
+    add_library(SOCI::soci ALIAS soci_interface)
+  endif()
 
   foreach (__comp IN LISTS SOCI_FIND_COMPONENTS)
       target_link_libraries(soci_interface INTERFACE SOCI::${__comp})
   endforeach()
-
-  add_library(SOCI::soci ALIAS soci_interface)
 
   if (NOT SOCI_FIND_QUIETLY)
       list(JOIN SOCI_FIND_COMPONENTS ", " __components)


### PR DESCRIPTION
In cases in which find_package(SOCI) was performed multiple times in a single configure run (e.g. because two independent dependencies both depend on SOCI), CMake would error due to the attempted re-definition of the soci_interface (and SOCI::soci) targets created in SOCI's config file.

This commit adds a check for the existence of these targets and only creates them if they don't exist yet. Hence, multiple find_package calls no longer lead to errors.