### PR TITLE
Move external symbol declaration into global namepace

### DIFF
--- a/src/core/backend-loader.cpp
+++ b/src/core/backend-loader.cpp
@@ -23,6 +23,8 @@ using namespace soci::dynamic_backends;
 
 #include <windows.h>
 
+extern "C" IMAGE_DOS_HEADER __ImageBase;
+
 namespace
 {
 
@@ -43,8 +45,6 @@ private:
 };
 
 typedef HMODULE soci_dynlib_handle_t;
-
-extern "C" IMAGE_DOS_HEADER __ImageBase;
 
 std::string get_this_dynlib_path()
 {


### PR DESCRIPTION
Even though symbols with C linkage don't really have a namespace, declaring an 'extern "C"' symbol inside of a C++ namespace causes the symbol to be inside that namespace, with the exception that the symbol name must still be globally unique. This can cause issues where this external symbol is linked to an actual C library.

See also https://stackoverflow.com/q/28996944

Fixes #1266