### PR TITLE
Turn SOCI::soci into an IMPORTED target

### DIFF
--- a/soci-config.cmake.in
+++ b/soci-config.cmake.in
@@ -157,13 +157,11 @@ unset(__dep_dep_targets)
 check_required_components(SOCI)
 
 if (NOT DEFINED SOCI_FOUND OR SOCI_FOUND)
-  add_library(soci_interface INTERFACE)
+  add_library(SOCI::soci INTERFACE IMPORTED)
 
   foreach (__comp IN LISTS SOCI_FIND_COMPONENTS)
-      target_link_libraries(soci_interface INTERFACE SOCI::${__comp})
+      target_link_libraries(SOCI::soci INTERFACE SOCI::${__comp})
   endforeach()
-
-  add_library(SOCI::soci ALIAS soci_interface)
 
   if (NOT SOCI_FIND_QUIETLY)
       list(JOIN SOCI_FIND_COMPONENTS ", " __components)


### PR DESCRIPTION
Turning it into an imported interface target makes it disappear from the command line when linking (which doesn't do anything anyway).

Furthermore, this is beneficial for detecting missing find_package calls at configuration time rather than at link time.