### PR TITLE
Allow specifying odbc_option_driver_complete as part of the DSN

### DIFF
--- a/docs/backends/odbc.md
+++ b/docs/backends/odbc.md
@@ -40,7 +40,7 @@ or simply:
 session sql(odbc, "filedsn=c:\\my.dsn");
 ```
 
-The set of parameters used in the connection string for ODBC is the same as accepted by the [SQLDriverConnect](https://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbcsql/od_odbc_d_4x4k.asp) function from the ODBC library.
+The set of parameters used in the connection string for ODBC is the same as accepted by the [SQLDriverConnect](https://msdn.microsoft.com/library/default.asp?url=/library/en-us/odbcsql/od_odbc_d_4x4k.asp) function from the ODBC library with the addition of SOCI-specific `odbc.driver_complete` option described in the [configuration options](#configuration-options) section below.
 
 Once you have created a `session` object as shown above, you can use it to access the database, for example:
 
@@ -179,10 +179,18 @@ that returns fully expanded connection string as returned by the `SQLDriverConne
 
 ## Configuration options
 
-This backend supports `odbc_option_driver_complete` option which can be passed to it via `connection_parameters` class. The value of this option is passed to `SQLDriverConnect()` function as "driver completion" parameter and so must be one of `SQL_DRIVER_XXX` values, in the string form. The default value of this option is `SQL_DRIVER_PROMPT` meaning that the driver will query the user for the user name and/or the password if they are not stored together with the connection. If this is undesirable for some reason, you can use `SQL_DRIVER_NOPROMPT` value for this option to suppress showing the message box:
+This backend supports `odbc_option_driver_complete` option which can be passed to it via `connection_parameters` class. The value of this option is passed to `SQLDriverConnect()` function as "driver completion" parameter and so must be one of `SQL_DRIVER_XXX` values, in the string form. The default value of this option is `SQL_DRIVER_PROMPT` meaning that the driver will query the user for the user name and/or the password if they are not stored together with the connection. If this is undesirable, e.g. because the program is running in non-interactive environment such as CI job context, you can use `SQL_DRIVER_NOPROMPT` value for this option to suppress showing the message box:
 
 ```cpp
 connection_parameters parameters("odbc", "DSN=mydb");
 parameters.set_option(odbc_option_driver_complete, "0" /* SQL_DRIVER_NOPROMPT */);
 session sql(parameters);
 ```
+
+For extra convenience, this option can also be specified as part of the connection string itself, e.g.
+
+```cpp
+session sql("odbc", "DSN=mydb;odbc.driver_complete=0");
+```
+
+has the same effect as the snippet above.

--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -19,6 +19,64 @@ using namespace soci::details;
 
 char const * soci::odbc_option_driver_complete = "odbc.driver_complete";
 
+namespace
+{
+
+// Helper function checking of odbc_option_driver_complete is specified in the
+// connection string and returning its value while removing this SOCI-specific
+// option from the connection string.
+//
+// Returns empty string if the option is not specified in the connection string.
+std::string extract_driver_complete_option(std::string& connectString)
+{
+    auto start = connectString.find(soci::odbc_option_driver_complete);
+    if (start == std::string::npos)
+    {
+        // Not found at all.
+        return {};
+    }
+
+    // Must be followed by the equal sign, remember its position before
+    // modifying start below.
+    auto const posEq = start + strlen(soci::odbc_option_driver_complete);
+
+    if (start != 0)
+    {
+        if (connectString[start - 1] != ';')
+        {
+            // Not preceded by the semicolon (and not at the very beginning),
+            // so not a valid option.
+            return {};
+        }
+
+        start--;
+    }
+
+    if (posEq >= connectString.size() || connectString[posEq] != '=')
+    {
+        // Not followed by the equal sign, so not a valid option.
+        return {};
+    }
+
+    // It looks like we have the option, extract its value and remove it.
+    std::string value;
+    auto const end = connectString.find(';', posEq + 1);
+    if (end == std::string::npos)
+    {
+        value = connectString.substr(posEq + 1);
+        connectString.erase(start);
+    }
+    else
+    {
+        value = connectString.substr(posEq + 1, end - posEq - 1);
+        connectString.erase(start, end - start);
+    }
+
+    return value;
+}
+
+} // anonymous namespace
+
 odbc_session_backend::odbc_session_backend(
     connection_parameters const & parameters)
     : henv_(0), hdbc_(0), product_(prod_uninitialized)
@@ -50,8 +108,10 @@ odbc_session_backend::odbc_session_backend(
     SQLCHAR outConnString[1024];
     SQLSMALLINT strLength = 0;
 
+    std::string connectString = parameters.get_connect_string();
+
     // Prompt the user for any missing information (typically UID/PWD) in the
-    // connection string by default but allow overriding this using "prompt"
+    // connection string by default but allow overriding this using a special
     // option and also suppress prompts when reconnecting, see the comment in
     // soci::session::reconnect().
     SQLHWND hwnd_for_prompt = NULL;
@@ -64,7 +124,14 @@ odbc_session_backend::odbc_session_backend(
     else
     {
       std::string completionString;
-      if (parameters.get_option(odbc_option_driver_complete, completionString))
+      if (!parameters.get_option(odbc_option_driver_complete, completionString))
+      {
+        // For convenience, also allow specifying this option as part of the
+        // connection string itself.
+        completionString = extract_driver_complete_option(connectString);
+      }
+
+      if (!completionString.empty())
       {
         // The value of the option is supposed to be just the integer value of
         // one of SQL_DRIVER_XXX constants but don't check for the exact value in
@@ -82,8 +149,6 @@ odbc_session_backend::odbc_session_backend(
     if (completion != SQL_DRIVER_NOPROMPT)
       hwnd_for_prompt = ::GetDesktopWindow();
 #endif // _WIN32
-
-    std::string const & connectString = parameters.get_connect_string();
 
     // This "infinite" loop can be executed at most twice.
     std::string errContext;


### PR DESCRIPTION
It is convenient to allow specifying this option as part of the connection string itself rather than requiring setting it using set_option(), e.g. like this it can be used in the connection string used by the CI service without requiring any changes in the code, so support giving it in this way.