### PR TITLE
Reuse `soci_mutex_t` and clean up `connection_pool` implementation

### DIFF
--- a/include/private/soci-mutex.h
+++ b/include/private/soci-mutex.h
@@ -44,6 +44,9 @@ public:
     void lock() { pthread_mutex_lock(&m_); }
     void unlock() { pthread_mutex_unlock(&m_); }
 
+    // This should be only used with pthread_cond_[timed]wait().
+    pthread_mutex_t * native_handle() { return &m_; }
+
 private:
     pthread_mutex_t m_;
 };

--- a/include/private/soci-mutex.h
+++ b/include/private/soci-mutex.h
@@ -1,0 +1,66 @@
+//
+// Copyright (C) 2025 Vadim Zeitlin
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// https://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_PRIVATE_SOCI_MUTEX_H_INCLUDED
+#define SOCI_PRIVATE_SOCI_MUTEX_H_INCLUDED
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+class soci_mutex_t
+{
+public:
+    soci_mutex_t() { ::InitializeCriticalSection(&cs_); }
+    ~soci_mutex_t() { ::DeleteCriticalSection(&cs_); }
+
+    void lock() { ::EnterCriticalSection(&cs_); }
+    void unlock() { ::LeaveCriticalSection(&cs_); }
+
+    soci_mutex_t(soci_mutex_t const &) = delete;
+    soci_mutex_t& operator=(soci_mutex_t const &) = delete;
+
+private:
+    CRITICAL_SECTION cs_;
+};
+
+#else // Assume POSIX
+
+#include <pthread.h>
+
+class soci_mutex_t
+{
+public:
+    soci_mutex_t() { pthread_mutex_init(&m_, NULL); }
+    soci_mutex_t(soci_mutex_t const &) = delete;
+    soci_mutex_t& operator=(soci_mutex_t const &) = delete;
+
+    ~soci_mutex_t() { pthread_mutex_destroy(&m_); }
+
+    void lock() { pthread_mutex_lock(&m_); }
+    void unlock() { pthread_mutex_unlock(&m_); }
+
+private:
+    pthread_mutex_t m_;
+};
+
+#endif // _WIN32/POSIX
+
+class soci_scoped_lock
+{
+public:
+    explicit soci_scoped_lock(soci_mutex_t * m) : m_(m) { m_->lock(); };
+    ~soci_scoped_lock() { m_->unlock(); };
+
+    soci_scoped_lock(soci_scoped_lock const &) = delete;
+    soci_scoped_lock& operator=(soci_scoped_lock const &) = delete;
+
+private:
+    soci_mutex_t * const m_;
+};
+
+#endif // SOCI_PRIVATE_SOCI_MUTEX_H_INCLUDED

--- a/include/soci/connection-pool.h
+++ b/include/soci/connection-pool.h
@@ -11,6 +11,7 @@
 #include "soci/soci-platform.h"
 // std
 #include <cstddef>
+#include <memory>
 
 namespace soci
 {
@@ -31,7 +32,7 @@ public:
 
 private:
     struct connection_pool_impl;
-    connection_pool_impl * pimpl_;
+    std::unique_ptr<connection_pool_impl> pimpl_;
 
     SOCI_NOT_COPYABLE(connection_pool)
 };

--- a/src/core/connection-pool.cpp
+++ b/src/core/connection-pool.cpp
@@ -15,13 +15,10 @@
 
 using namespace soci;
 
-namespace
-{
-
 // Common base class for both POSIX and Windows implementations.
-struct connection_pool_base_impl
+struct soci_connection_pool_base_impl
 {
-    explicit connection_pool_base_impl(std::size_t size)
+    explicit soci_connection_pool_base_impl(std::size_t size)
     {
         if (size == 0)
         {
@@ -35,7 +32,7 @@ struct connection_pool_base_impl
         }
     }
 
-    ~connection_pool_base_impl() = default;
+    ~soci_connection_pool_base_impl() = default;
 
     bool find_free(std::size_t & pos)
     {
@@ -56,8 +53,6 @@ struct connection_pool_base_impl
     std::vector<std::pair<bool, std::unique_ptr<session>> > sessions_;
 };
 
-} // anonymous namespace
-
 #ifndef _WIN32
 // POSIX implementation
 
@@ -65,10 +60,10 @@ struct connection_pool_base_impl
 #include <sys/time.h>
 #include <errno.h>
 
-struct connection_pool::connection_pool_impl : connection_pool_base_impl
+struct connection_pool::connection_pool_impl : soci_connection_pool_base_impl
 {
     explicit connection_pool_impl(std::size_t size)
-        : connection_pool_base_impl(size)
+        : soci_connection_pool_base_impl(size)
     {
         if (pthread_cond_init(&cond_, NULL) != 0)
         {
@@ -185,10 +180,10 @@ void connection_pool::give_back(std::size_t pos)
 
 #include <windows.h>
 
-struct connection_pool::connection_pool_impl : connection_pool_base_impl
+struct connection_pool::connection_pool_impl : soci_connection_pool_base_impl
 {
     explicit connection_pool_impl(std::size_t size)
-        : connection_pool_base_impl(size)
+        : soci_connection_pool_base_impl(size)
     {
         // initially all entries are available
         sem_ = CreateSemaphore(NULL,

--- a/src/core/connection-pool.cpp
+++ b/src/core/connection-pool.cpp
@@ -98,16 +98,6 @@ struct connection_pool::connection_pool_impl : connection_pool_base_impl
     pthread_cond_t cond_;
 };
 
-connection_pool::connection_pool(std::size_t size)
-{
-    pimpl_ = new connection_pool_impl(size);
-}
-
-connection_pool::~connection_pool()
-{
-    delete pimpl_;
-}
-
 bool connection_pool::try_lease(std::size_t & pos, int timeout)
 {
     struct timespec tm;
@@ -242,16 +232,6 @@ struct connection_pool::connection_pool_impl : connection_pool_base_impl
     HANDLE sem_;
 };
 
-connection_pool::connection_pool(std::size_t size)
-{
-    pimpl_ = new connection_pool_impl(size);
-}
-
-connection_pool::~connection_pool()
-{
-    delete pimpl_;
-}
-
 bool connection_pool::try_lease(std::size_t & pos, int timeout)
 {
     DWORD cc = WaitForSingleObject(pimpl_->sem_,
@@ -307,6 +287,13 @@ void connection_pool::give_back(std::size_t pos)
 }
 
 #endif // _WIN32
+
+connection_pool::connection_pool(std::size_t size)
+               : pimpl_(std::make_unique<connection_pool_impl>(size))
+{
+}
+
+connection_pool::~connection_pool() = default;
 
 session & connection_pool::at(std::size_t pos)
 {

--- a/src/core/connection-pool.cpp
+++ b/src/core/connection-pool.cpp
@@ -29,17 +29,11 @@ struct connection_pool_base_impl
         sessions_.resize(size);
         for (std::size_t i = 0; i != size; ++i)
         {
-            sessions_[i] = std::make_pair(true, new session());
+            sessions_[i] = std::make_pair(true, std::make_unique<session>());
         }
     }
 
-    ~connection_pool_base_impl()
-    {
-        for (std::size_t i = 0; i != sessions_.size(); ++i)
-        {
-            delete sessions_[i].second;
-        }
-    }
+    ~connection_pool_base_impl() = default;
 
     bool find_free(std::size_t & pos)
     {
@@ -57,7 +51,7 @@ struct connection_pool_base_impl
 
 
     // by convention, first == true means the entry is free (not used)
-    std::vector<std::pair<bool, session *> > sessions_;
+    std::vector<std::pair<bool, std::unique_ptr<session>> > sessions_;
 };
 
 } // anonymous namespace


### PR DESCRIPTION
This is mostly done to make `soci_mutex_t` available in other places.