### PR TITLE
Fix exception with multiple batch operations in SQLite3 backend

### DIFF
--- a/src/backends/sqlite3/statement.cpp
+++ b/src/backends/sqlite3/statement.cpp
@@ -334,6 +334,10 @@ sqlite3_statement_backend::bind_and_execute(int number)
         rowsAffectedBulk_ += sqlite3_changes(session_.conn_);
     }
 
+    // Don't leave invalid (out of range) value in current_row_, this can't be
+    // useful and can cause problems when using multiple batch inserts.
+    current_row_ = -1;
+
     return retVal;
 }
 


### PR DESCRIPTION
Don't leave current_row_ with an invalid value after finishing a batch operation, it could be reused, resulting in an exception due to the index being invalid, when the statement is executed again.

Note that this was already done for the other backends using current_row_ in their overridden get_row_to_dump() in a similar way (Firebird and PostgreSQL), so they were not affected by this bug.

Closes #1308.