### PR TITLE
Don't terminate the application on errors during disconnection

### DIFF
--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -104,6 +104,7 @@ session sql("postgresql://dbname=mydb");
 ```
 
 * The constructors that take backend name as string load the shared library (if not yet loaded) with name computed as `libsoci_ABC.so` (or `libsoci_ABC.dll` on Windows) where `ABC` is the given backend name.
+* Destructor closes the connection if it is open. Note that any errors occurring during the destruction are silently ignored, please call `close`, which may throw, explicitly before destroying the session object if you need to handle such errors.
 * `open`, `close` and `reconnect` functions for   reusing the same session object many times; the `reconnect` function attempts to establish the connection with the same parameters as most recently used with constructor or `open`. The arguments for `open` are treated in the same way as for constructors. `is_connected` can be used to check if there is an existing usable connection.
 * `begin`, `commit` and `rollback` functions for transaction control.
 * `once` member, which is used for performing *instant* queries that do not need to be separately prepared. Example:

--- a/include/soci/firebird/soci-firebird.h
+++ b/include/soci/firebird/soci-firebird.h
@@ -302,7 +302,7 @@ struct SOCI_FIREBIRD_DECL firebird_session_backend : details::session_backend
 {
     firebird_session_backend(connection_parameters const & parameters);
 
-    ~firebird_session_backend() override;
+    ~firebird_session_backend() noexcept(false) override;
 
     bool is_connected() override;
 

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -334,7 +334,7 @@ struct SOCI_ODBC_DECL odbc_session_backend : details::session_backend
 {
     odbc_session_backend(connection_parameters const & parameters);
 
-    ~odbc_session_backend() override;
+    ~odbc_session_backend() noexcept(false) override;
 
     bool is_connected() override;
 

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -362,7 +362,7 @@ class session_backend
 {
 public:
     session_backend() : failoverCallback_(NULL), session_(NULL) {}
-    virtual ~session_backend() {}
+    virtual ~session_backend() noexcept(false) {}
 
     virtual bool is_connected() = 0;
 

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -234,13 +234,22 @@ schema_table_name& session::alloc_schema_table_name(const std::string & tableNam
 
 session::~session()
 {
-    if (isFromPool_)
+    try
     {
-        pool_->give_back(poolPosition_);
+        if (isFromPool_)
+        {
+            pool_->give_back(poolPosition_);
+        }
+        else
+        {
+            delete backEnd_;
+        }
     }
-    else
+    catch (...)
     {
-        delete backEnd_;
+        // Do not throw from a destructor and just ignore the exception
+        // because, while not ideal, it's still preferable to immediately
+        // terminating the program.
     }
 }
 


### PR DESCRIPTION
Make sure no exceptions can escape from session class dtor as this would result in an immediate application termination due to throwing from a (implicitly) noexcept function.

Let exceptions escape from the backend session classes dtors for those of them that throw from them: as these classes are private, this shouldn't affect any existing code and allows these exceptions to still be reported if they happen when session::close() is called.

Also document that close() may throw and should be called by the application if handling errors during clean up is important for it.

Closes #1313.