### PR TITLE
Initialize statement_impl::definePositionForRow_

### DIFF
--- a/include/soci/statement.h
+++ b/include/soci/statement.h
@@ -109,7 +109,7 @@ private:
     std::string query_;
 
     into_type_vector intosForRow_;
-    int definePositionForRow_;
+    int definePositionForRow_ = 1;
 
     template <typename Into>
     void exchange_for_rowset_(Into const &i)

--- a/src/core/statement.cpp
+++ b/src/core/statement.cpp
@@ -235,7 +235,7 @@ void statement_impl::define_and_bind()
         intos_[i]->define(*this, definePosition);
     }
 
-    // if there are some implicite into elements
+    // if there are some implicit into elements
     // injected by the row description process,
     // they should be defined in the later phase,
     // starting at the position where the above loop finished


### PR DESCRIPTION
It was not obvious that this member variable couldn't be used without being initialized, so do initialize it to ensure that it always has a valid value.

Also fix a typo in a related comment.