### PR TITLE
Use range-based loops when possible

### DIFF
--- a/include/soci/bind-values.h
+++ b/include/soci/bind-values.h
@@ -33,9 +33,8 @@ class use_type_vector: public std::vector<use_type_base *>
 public:
     ~use_type_vector()
     {
-        for(iterator iter = begin(), _end = end();
-            iter != _end; iter++)
-            delete *iter;
+        for(auto & iter : *this)
+            delete iter;
     }
 
     void exchange(use_type_ptr const& u) { push_back(u.get()); u.release(); }
@@ -129,9 +128,8 @@ class into_type_vector: public std::vector<details::into_type_base *>
 public:
     ~into_type_vector()
     {
-        for(iterator iter = begin(), _end = end();
-            iter != _end; iter++)
-            delete *iter;
+        for(auto & iter : *this)
+            delete iter;
     }
 
     void exchange(into_type_ptr const& i) { push_back(i.get()); i.release(); }

--- a/include/soci/statement.h
+++ b/include/soci/statement.h
@@ -122,10 +122,8 @@ private:
         intos_.exchange(i);
 
         int definePosition = 1;
-        for(into_type_vector::iterator iter = intos_.begin(),
-                                       end = intos_.end();
-            iter != end; iter++)
-        { (*iter)->define(*this, definePosition); }
+        for(auto & into : intos_)
+        { into->define(*this, definePosition); }
         definePositionForRow_ = definePosition;
     }
 

--- a/include/soci/values.h
+++ b/include/soci/values.h
@@ -332,16 +332,15 @@ private:
         // delete any uses and indicators which were created  by set() but
         // were not bound by the Statement
         // (bound uses and indicators are deleted in Statement::clean_up())
-        for (std::map<details::use_type_base *, indicator *>::iterator pos =
-            unused_.begin(); pos != unused_.end(); ++pos)
+        for (auto & pos : unused_)
         {
-            delete pos->first;
-            delete pos->second;
+            delete pos.first;
+            delete pos.second;
         }
 
-        for (std::size_t i = 0; i != deepCopies_.size(); ++i)
+        for (auto & deepCopie : deepCopies_)
         {
-            delete deepCopies_[i];
+            delete deepCopie;
         }
     }
 };

--- a/src/backends/firebird/statement.cpp
+++ b/src/backends/firebird/statement.cpp
@@ -88,48 +88,47 @@ void firebird_statement_backend::rewriteParameters(
     std::string name;
     int position = 0;
 
-    for (std::string::const_iterator it = src.begin(), end = src.end();
-        it != end; ++it)
+    for (char it : src)
     {
         switch (state)
         {
         case eNormal:
-            if (*it == '\'')
+            if (it == '\'')
             {
-                *dst_it++ = *it;
+                *dst_it++ = it;
                 state = eInQuotes;
             }
-            else if (*it == ':')
+            else if (it == ':')
             {
                 state = eInName;
             }
             else // regular character, stay in the same state
             {
-                *dst_it++ = *it;
+                *dst_it++ = it;
             }
             break;
         case eInQuotes:
-            if (*it == '\'')
+            if (it == '\'')
             {
-                *dst_it++ = *it;
+                *dst_it++ = it;
                 state = eNormal;
             }
             else // regular quoted character
             {
-                *dst_it++ = *it;
+                *dst_it++ = it;
             }
             break;
         case eInName:
-            if (std::isalnum(*it) || *it == '_')
+            if (std::isalnum(it) || it == '_')
             {
-                name += *it;
+                name += it;
             }
             else // end of name
             {
                 names_.insert(std::pair<std::string, int>(name, position++));
                 name.clear();
                 *dst_it++ = '?';
-                *dst_it++ = *it;
+                *dst_it++ = it;
                 state = eNormal;
             }
             break;

--- a/src/backends/sqlite3/session.cpp
+++ b/src/backends/sqlite3/session.cpp
@@ -248,11 +248,11 @@ static std::string sanitize_table_name(std::string const& table)
 {
     std::string ret;
     ret.reserve(table.length());
-    for (std::string::size_type pos = 0; pos < table.size(); ++pos)
+    for (char pos : table)
     {
-        if (isspace(table[pos]))
+        if (isspace(pos))
             throw soci_error("Table name must not contain whitespace");
-        const char c = table[pos];
+        const char c = pos;
         ret += c;
         if (c == '\'')
             ret += '\'';

--- a/tests/common/test-common.cpp
+++ b/tests/common/test-common.cpp
@@ -324,9 +324,9 @@ TEST_CASE_METHOD(common_tests, "Repeated and bulk fetch", "[core][bulk]")
             st.execute();
             while (st.fetch())
             {
-                for (std::size_t i = 0; i != vec.size(); ++i)
+                for (char i : vec)
                 {
-                    CHECK(c2 == vec[i]);
+                    CHECK(c2 == i);
                     ++c2;
                 }
 
@@ -394,11 +394,11 @@ TEST_CASE_METHOD(common_tests, "Repeated and bulk fetch", "[core][bulk]")
             st.execute();
             while (st.fetch())
             {
-                for (std::size_t j = 0; j != vec.size(); ++j)
+                for (const auto & j : vec)
                 {
                     std::ostringstream ss;
                     ss << "Hello_" << i;
-                    CHECK(ss.str() == vec[j]);
+                    CHECK(ss.str() == j);
                     ++i;
                 }
 
@@ -444,9 +444,9 @@ TEST_CASE_METHOD(common_tests, "Repeated and bulk fetch", "[core][bulk]")
             st.execute();
             while (st.fetch())
             {
-                for (std::size_t i = 0; i != vec.size(); ++i)
+                for (short i : vec)
                 {
-                    CHECK(sh2 == vec[i]);
+                    CHECK(sh2 == i);
                     ++sh2;
                 }
 
@@ -510,9 +510,9 @@ TEST_CASE_METHOD(common_tests, "Repeated and bulk fetch", "[core][bulk]")
             st.execute();
             while (st.fetch())
             {
-                for (std::size_t n = 0; n != vec.size(); ++n)
+                for (int n : vec)
                 {
-                    CHECK(i2 == vec[n]);
+                    CHECK(i2 == n);
                     ++i2;
                 }
 
@@ -558,9 +558,9 @@ TEST_CASE_METHOD(common_tests, "Repeated and bulk fetch", "[core][bulk]")
             st.execute();
             while (st.fetch())
             {
-                for (std::size_t i = 0; i != vec.size(); ++i)
+                for (unsigned int i : vec)
                 {
-                    CHECK(ul2 == vec[i]);
+                    CHECK(ul2 == i);
                     ++ul2;
                 }
 
@@ -606,9 +606,9 @@ TEST_CASE_METHOD(common_tests, "Repeated and bulk fetch", "[core][bulk]")
             st.execute();
             while (st.fetch())
             {
-                for (std::size_t i = 0; i != vec.size(); ++i)
+                for (unsigned long long i : vec)
                 {
-                    CHECK(ul2 == vec[i]);
+                    CHECK(ul2 == i);
                     ++ul2;
                 }
 
@@ -721,14 +721,14 @@ TEST_CASE_METHOD(common_tests, "Repeated and bulk fetch", "[core][bulk]")
             st.execute();
             while (st.fetch())
             {
-                for (std::size_t j = 0; j != vec.size(); ++j)
+                for (auto & j : vec)
                 {
-                    CHECK(vec[j].tm_year == 2000 - 1900 + i);
-                    CHECK(vec[j].tm_mon == i);
-                    CHECK(vec[j].tm_mday == 20 - i);
-                    CHECK(vec[j].tm_hour == 15 + i);
-                    CHECK(vec[j].tm_min == 50 - i);
-                    CHECK(vec[j].tm_sec == 40 + i);
+                    CHECK(j.tm_year == 2000 - 1900 + i);
+                    CHECK(j.tm_mon == i);
+                    CHECK(j.tm_mday == 20 - i);
+                    CHECK(j.tm_hour == 15 + i);
+                    CHECK(j.tm_min == 50 - i);
+                    CHECK(j.tm_sec == 40 + i);
 
                     ++i;
                 }

--- a/tests/odbc/test-odbc-postgresql.cpp
+++ b/tests/odbc/test-odbc-postgresql.cpp
@@ -256,12 +256,12 @@ public:
 
         std::string s2;
         s2.reserve(s.size());
-        for (std::size_t i = 0; i < s.size(); ++i)
+        for (char i : s)
         {
-            if (s[i] == '\r')
+            if (i == '\r')
                 continue;
 
-            s2 += s[i];
+            s2 += i;
         }
 
         return s2;

--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -542,12 +542,12 @@ TEST_CASE("PostgreSQL insert into ... returning", "[postgresql]")
     table_creator_for_test12 tableCreator(sql);
 
     std::vector<long> ids(10);
-    for (std::size_t i = 0; i != ids.size(); i++)
+    for (long & id : ids)
     {
         long sid(0);
         std::string txt("abc");
         sql << "insert into soci_test(txt) values(:txt) returning sid", use(txt, "txt"), into(sid);
-        ids[i] = sid;
+        id = sid;
     }
 
     std::vector<long> ids2(ids.size());


### PR DESCRIPTION
Run clang-tidy with modernize-loop-convert check to convert a few loops to a simpler and tidier form.