### PR TITLE
Drop MSVS 2015 support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,12 @@ This file contains the history of changes in the SOCI library.
 Please read at least the following section when upgrading from
 a previous version of the library.
 
+INCOMPATIBLE CHANGES IN SOCI 4.2 SINCE 4.1
+==========================================
+
+- SOCI 4.2 requires MSVS 2017 or later.
+
+
 INCOMPATIBLE CHANGES IN SOCI 4.1 SINCE 4.0
 ==========================================
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ SOCI library is distributed under the terms of the [Boost Software License](http
 
 Core:
 
-* Compiler with C++14 support (please use 4.0 series for C++98 support) or MSVS 2015 or later.
+* Compiler with C++14 support (please use 4.0 series for C++98 support) or MSVS 2017 or later.
 * CMake 3.23 or later.
 * Optionally: Boost C++ Libraries (header-only and Boost.DateTime).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,18 +6,18 @@ skip_commits:
 
 environment:
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       G: "MinGW Makefiles"
       CONFIGURATION: Release
       MINGW_BIN: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin
       MSSQL_VER: 2014
       BOOST_ROOT: C:\Libraries\boost_1_60_0
-      POSTGRESQL_ROOT: C:\Program Files\PostgreSQL\9.4
-      POSTGRESQL_VER: 9.4
+      POSTGRESQL_ROOT: C:\Program Files\PostgreSQL\9.5
+      POSTGRESQL_VER: 9.5
       MYSQL_VER: 57
       MYSQL_DIR: C:\Program Files\MySql\MySQL Server 5.7
-      VCVARS_SCRIPT: "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      VCVARS_SCRIPT: "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       G: "Ninja"
       CONFIGURATION: Debug
       BOOST_ROOT: C:\Libraries\boost_1_60_0
@@ -26,7 +26,7 @@ environment:
       POSTGRESQL_VER: 11
       MYSQL_VER: 57
       MYSQL_DIR: C:\Program Files\MySql\MySQL Server 5.7
-      VCVARS_SCRIPT: "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC"
+      VCVARS_SCRIPT: "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       G: "Ninja"
       CONFIGURATION: Release

--- a/docs/backends/postgresql.md
+++ b/docs/backends/postgresql.md
@@ -17,8 +17,7 @@ The SOCI PostgreSQL backend is supported for use with PostgreSQL >= 9.0, althoug
 | 13|Windows Server 2019|MSVS 2022|
 | 12|Windows Server 2019|MSVS 2019|
 | 11|Windows Server 2016|MSVS 2017|
-| 10|Windows Server 2012 R2|MSVS 2015|
-|9.4|Windows Server 2012 R2|MinGW-w64/GCC 8.1|
+|9.5|Windows Server 2016|MSVS 2017|
 
 ### Required Client Libraries
 

--- a/include/private/soci-ssize.h
+++ b/include/private/soci-ssize.h
@@ -52,16 +52,7 @@ constexpr ssize_t ssize(T (&)[N]) noexcept
     Cast size_t to integer safely, raising exception if the value is out of
     range.
  */
-#ifdef _MSC_VER
-    #if _MSC_VER < 1910
-        // MSVS 2015 can't compile "if" and "throw" in constexpr functions.
-        #define SOCI_NO_ICAST_CONSTEXPR
-    #endif
-#endif
-
-#ifndef SOCI_NO_ICAST_CONSTEXPR
 constexpr
-#endif
 inline int icast(size_t n)
 {
     if ( n >= INT_MAX )

--- a/include/soci/soci-platform.h
+++ b/include/soci/soci-platform.h
@@ -41,7 +41,7 @@ namespace std {
 
 #ifdef _WIN32
 # ifndef _WIN32_WINNT
-#   define _WIN32_WINNT 0x0502 //_WIN32_WINNT_WS03, VS2015 support: https://msdn.microsoft.com/de-de/library/6sehtctf.aspx
+#   define _WIN32_WINNT 0x0A00 // _WIN32_WINNT_WIN10
 # endif
 // SOCI_DLL should be defined when SOCI is used as a DLL/DSO
 # ifdef SOCI_DLL
@@ -77,8 +77,8 @@ namespace std {
 // (see https://msdn.microsoft.com/en-us/library/hh567368.aspx).
 
 #ifdef _MSC_VER
-    #if _MSC_VER < 1900
-        #error This version of SOCI requires MSVS 2015 or later.
+    #if _MSC_VER < 1910
+        #error This version of SOCI requires MSVS 2017 or later.
     #endif
     #if _MSVC_LANG >= 201703L
         #define SOCI_HAVE_CXX17

--- a/include/soci/type-conversion-traits.h
+++ b/include/soci/type-conversion-traits.h
@@ -73,11 +73,6 @@ private:
 namespace details
 {
 
-#if !defined(_MSC_VER) || (_MSC_VER >= 1910)
-    // MSVC 2015 and earlier don't support SFINAE on return types
-    #define SOCI_HAS_RET_TYPE_SFINAE
-#endif
-
 template<typename T>
 using from_base_check_t = decltype(T::from_base_check::value);
 template<typename T>
@@ -87,8 +82,6 @@ template<typename T>
 using supports_from_base_check = is_detected<from_base_check_t, T>;
 template<typename T>
 using supports_move_from_base_check = is_detected<move_from_base_check_t, T>;
-
-#ifdef SOCI_HAS_RET_TYPE_SFINAE
 
 template<typename Trait>
 constexpr auto can_use_from_base()
@@ -120,27 +113,6 @@ constexpr auto can_use_move_from_base()
     // move_from_base implementation
     return false;
 }
-
-#undef SOCI_HAS_RET_TYPE_SFINAE
-
-#else
-
-// Always return true - if it doesn't work the user will get a cryptic compiler error but at least
-// it will compile properly for cases in which things do indeed work
-
-template<typename Trait>
-constexpr auto can_use_from_base()
-{
-    return true;
-}
-
-template<typename Trait>
-constexpr auto can_use_move_from_base()
-{
-    return true;
-}
-
-#endif
 
 }
 


### PR DESCRIPTION
It's not worth keeping supporting any more and this will make using fmt library simpler.