### PR TITLE
WIP: PSQL backend UB then using `execute(false)` -> `fetch()` into a `soci::row` of a query that does not return data

### DIFF
--- a/tests/postgresql/test-postgresql.cpp
+++ b/tests/postgresql/test-postgresql.cpp
@@ -1432,15 +1432,41 @@ TEST_CASE("execute_fetch_insert_noreturn",
 
         sql << "INSERT INTO soci_test(\"flag\") VALUES (TRUE), (FALSE)";
 
-        soci::row r;
-        soci::statement st = (sql.prepare << "UPDATE soci_test SET flag=TRUE", soci::into(r));
-        CHECK(!st.execute(false));
+        const auto fetch_all = [&sql] (const std::string& query, auto& out) {
+            soci::statement st = (sql.prepare << query, soci::into(out));
 
-        std::size_t count = 0;
-        while (st.fetch()) {
-            ++count;
-        }
-        CHECK(count == 0);
+            st.execute(false);
+            std::size_t count = 0;
+            while (st.fetch()) {
+                ++count;
+            }
+            return count;
+        }; // <-- fetch_all
+
+        soci::row row;
+        int       flag;
+
+        // Reads several rows - fine
+        CHECK(fetch_all("SELECT * FROM soci_test", flag) == 2);
+        // Reads zero rows - fine
+        CHECK(fetch_all("SELECT * FROM soci_test WHERE flag = NOT flag", flag) == 0);
+        // UPDATE causes a sanitizer error
+        CHECK(fetch_all("UPDATE soci_test SET flag=TRUE", flag) == 0);
+        // INSERT causes a sanitizer error
+        CHECK(fetch_all("INSERT INTO soci_test(flag) VALUES (FALSE)", flag) == 0);
+        // DELETE causes a sanitizer error
+        CHECK(fetch_all("DELETE FROM soci_test WHERE NOT flag", flag) == 0);
+
+        // Reads several rows - fine
+        CHECK(fetch_all("SELECT * FROM soci_test", row) == 2);
+        // Reads zero rows - fine
+        CHECK(fetch_all("SELECT * FROM soci_test WHERE flag = NOT flag", row) == 0);
+        // UPDATE causes a sanitizer error
+        CHECK(fetch_all("UPDATE soci_test SET flag=TRUE", row) == 0);
+        // INSERT causes a sanitizer error
+        CHECK(fetch_all("INSERT INTO soci_test(flag) VALUES (FALSE)", row) == 0);
+        // DELETE causes a sanitizer error
+        CHECK(fetch_all("DELETE FROM soci_test WHERE NOT flag", row) == 0);
     }
 }
 


### PR DESCRIPTION
I've reproduced the integer overflows in a simple test. The behavior is not observed if no `soci::into(row)` is performed.

<details><summary>The test itself runs fine on my machine with a regular build</summary>

```
$ rm -rf ./* && cmake -GNinja .. && ninja && ./bin/soci_postgresql_test 'host=localhost port=5432 dbname=test user=postgres password='
zsh: sure you want to delete all 14 files in /media/ssd/projects/cpp/soci/psql-statement-ub/build/. [yn]? y
-- The C compiler identification is GNU 15.2.1
-- The CXX compiler identification is GNU 15.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using system fmt library 12.1.0
-- Found Boost: v1.89.0 in /usr/include (with date_time component)
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Could NOT find DB2 (missing: DB2_INCLUDE_DIRS DB2_LIBRARIES)
-- Disabling SOCI backend 'DB2' due to unsatisfied dependency on 'DB2'
-- Could NOT find Firebird (missing: Firebird_LIBRARIES Firebird_INCLUDE_DIRS)
-- Disabling SOCI backend 'Firebird' due to unsatisfied dependency on 'Firebird'
-- Found MySQL: mariadb (found version "3.4.8")
-- Found ODBC: /usr/lib/libodbc.so
-- Could NOT find Oracle (missing: Oracle_LIBRARIES Oracle_INCLUDE_DIRS)
-- None of the supported Oracle versions (21;20;19;18;12;11;10) could be found, consider updating Oracle_VERSIONS if the version you use is not among them.
-- Disabling SOCI backend 'Oracle' due to unsatisfied dependency on 'Oracle'
-- Found PostgreSQL: /usr/lib/libpq.so (found version "18.1")
-- Found SQLite3: /usr/lib/libsqlite3.so (found version "3.51.2")
-- SOCI 4.2.0 will be built as SHARED library in Release configuration.
-- Enabled SOCI backends are: Empty;MySQL;ODBC;PostgreSQL;SQLite3
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: /media/ssd/projects/cpp/soci/psql-statement-ub/build
[109/109] Linking CXX executable bin/soci_mysql_test

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
soci_postgresql_test is a Catch v2.13.10 host application.
Run with -? for options

-------------------------------------------------------------------------------
PostgreSQL ROWID
-------------------------------------------------------------------------------
/media/ssd/projects/cpp/soci/psql-statement-ub/tests/postgresql/test-postgresql.cpp:154
...............................................................................

/media/ssd/projects/cpp/soci/psql-statement-ub/tests/postgresql/test-postgresql.cpp:162: warning:
  Skipping test because OIDs are no longer supported in PostgreSQL 180001

NOTICE:  table "soci_test" does not exist, skipping
NOTICE:  table "soci_test" does not exist, skipping
===============================================================================
All tests passed (2426 assertions in 96 test cases)
```
</details>

<details><summary>But building and running with sanitizers throws an overflow error</summary>

```
$ rm -rf ./* && cmake -GNinja .. -DCMAKE_CXX_FLAGS='-fsanitize=address,undefined' && ninja && ./bin/soci_postgresql_test 'host=localhost port=5432 dbname=test user=postgres password='
zsh: sure you want to delete all 15 files in /media/ssd/projects/cpp/soci/psql-statement-ub/build-sanitize/. [yn]? y
-- The C compiler identification is GNU 15.2.1
-- The CXX compiler identification is GNU 15.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using system fmt library 12.1.0
-- Found Boost: v1.89.0 in /usr/include (with date_time component)
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Could NOT find DB2 (missing: DB2_INCLUDE_DIRS DB2_LIBRARIES)
-- Disabling SOCI backend 'DB2' due to unsatisfied dependency on 'DB2'
-- Could NOT find Firebird (missing: Firebird_LIBRARIES Firebird_INCLUDE_DIRS)
-- Disabling SOCI backend 'Firebird' due to unsatisfied dependency on 'Firebird'
-- Found MySQL: mariadb (found version "3.4.8")
-- Found ODBC: /usr/lib/libodbc.so
-- Could NOT find Oracle (missing: Oracle_LIBRARIES Oracle_INCLUDE_DIRS)
-- None of the supported Oracle versions (21;20;19;18;12;11;10) could be found, consider updating Oracle_VERSIONS if the version you use is not among them.
-- Disabling SOCI backend 'Oracle' due to unsatisfied dependency on 'Oracle'
-- Found PostgreSQL: /usr/lib/libpq.so (found version "18.1")
-- Found SQLite3: /usr/lib/libsqlite3.so (found version "3.51.2")
-- SOCI 4.2.0 will be built as SHARED library in Release configuration.
-- Enabled SOCI backends are: Empty;MySQL;ODBC;PostgreSQL;SQLite3
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: /media/ssd/projects/cpp/soci/psql-statement-ub/build-sanitize
[109/109] Linking CXX executable bin/soci_sqlite3_test

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
soci_postgresql_test is a Catch v2.13.10 host application.
Run with -? for options

-------------------------------------------------------------------------------
PostgreSQL ROWID
-------------------------------------------------------------------------------
/media/ssd/projects/cpp/soci/psql-statement-ub/tests/postgresql/test-postgresql.cpp:154
...............................................................................

/media/ssd/projects/cpp/soci/psql-statement-ub/tests/postgresql/test-postgresql.cpp:162: warning:
  Skipping test because OIDs are no longer supported in PostgreSQL 180001

NOTICE:  table "soci_test" does not exist, skipping
NOTICE:  table "soci_test" does not exist, skipping
/media/ssd/projects/cpp/soci/psql-statement-ub/src/backends/postgresql/statement.cpp:568:17: runtime error: signed integer overflow: -1094795586 + -1094795586 cannot be represented in type 'int'
===============================================================================
All tests passed (2426 assertions in 96 test cases)
```
</details>

I'll add more tests if I find a better case to reproduce, hopefully one that fires even without sanitizer detection.