### PR TITLE
Drop not working into() overload taking buffer size

### DIFF
--- a/include/soci/into.h
+++ b/include/soci/into.h
@@ -60,13 +60,6 @@ details::into_container<T, Indicator>
     into(T &t, Indicator &ind)
 { return details::into_container<T, Indicator>(t, ind); }
 
-// for char buffer with run-time size information
-template <typename T>
-details::into_type_ptr into(T & t, std::size_t bufSize)
-{
-    return details::into_type_ptr(new details::into_type<T>(t, bufSize));
-}
-
 // vectors with index ranges
 
 template <typename T>


### PR DESCRIPTION
This was supposed to allow reading into char[N] but either was never implemented or got broken a long time ago and doesn't seem really useful compared to using std::string with into(), so simply remove this overload.

Closes #1332.