### PR TITLE
Fixed an incorrect soci::use function overload

### DIFF
--- a/include/soci/use.h
+++ b/include/soci/use.h
@@ -71,9 +71,9 @@ details::use_container<const T, indicator> use(T const &t, indicator & ind, std:
 
 // vector containers
 template <typename T>
-details::use_container<T, std::vector<indicator> >
-    use(T &t, std::vector<indicator> & ind, const std::string &name = std::string())
-{ return details::use_container<T, std::vector<indicator> >(t, ind, name); }
+details::use_container<std::vector<T>, std::vector<indicator> >
+    use(std::vector<T> &t, std::vector<indicator> & ind, const std::string &name = std::string())
+{ return details::use_container<std::vector<T>, std::vector<indicator> >(t, ind, name); }
 
 template <typename T>
 details::use_container<std::vector<T>, details::no_indicator >


### PR DESCRIPTION
Previously an overload of the `soci::use` function accepted a value of type `T` and a vector of indicators. This function worked when `T` was `std::vector<U>`, but would fail if `T` was any other type. Judging by the comment, the original intent was to have an overload for `std::vector<T>`.

closes #1334 