### PR TITLE
Remove rowset_iterator post-increment operator

### DIFF
--- a/include/soci/rowset.h
+++ b/include/soci/rowset.h
@@ -58,7 +58,8 @@ public:
         return &(operator*());
     }
 
-    // Iteration operators
+    // Iteration operator: as this is an input operator, it only supports
+    // pre-increment
 
     rowset_iterator & operator++()
     {
@@ -72,13 +73,6 @@ public:
         }
 
         return (*this);
-    }
-
-    rowset_iterator operator++(int)
-    {
-        rowset_iterator tmp(*this);
-        ++(*this);
-        return tmp;
     }
 
     // Comparison operators


### PR DESCRIPTION
It doesn't make sense for an input iterator and didn't work correctly.

Closes #1327.