### PR TITLE
Allow multiple find_package calls

### DIFF
--- a/soci-config.cmake.in
+++ b/soci-config.cmake.in
@@ -157,17 +157,23 @@ unset(__dep_dep_targets)
 check_required_components(SOCI)
 
 if (NOT DEFINED SOCI_FOUND OR SOCI_FOUND)
-  add_library(SOCI::SOCI INTERFACE IMPORTED)
+  if (NOT TARGET SOCI::SOCI)
+    add_library(SOCI::SOCI INTERFACE IMPORTED)
+  endif()
 
   foreach (__comp IN LISTS SOCI_FIND_COMPONENTS)
       target_link_libraries(SOCI::SOCI INTERFACE SOCI::${__comp})
   endforeach()
 
   # Shall be removed in SOCI v5
-  add_library(soci_interface_deprecated INTERFACE)
+  if (NOT TARGET soci_interface_deprecated)
+    add_library(soci_interface_deprecated INTERFACE)
+  endif()
   target_link_libraries(soci_interface_deprecated INTERFACE SOCI::SOCI)
   set_target_properties(soci_interface_deprecated PROPERTIES DEPRECATION "Use SOCI::SOCI (all-uppercase) instead of SOCI::soci")
-  add_library(SOCI::soci ALIAS soci_interface_deprecated)
+  if (NOT TARGET SOCI::soci)
+    add_library(SOCI::soci ALIAS soci_interface_deprecated)
+  endif()
 
   if (NOT SOCI_FIND_QUIETLY)
       list(JOIN SOCI_FIND_COMPONENTS ", " __components)


### PR DESCRIPTION
We now only define our targets if they don't exist yet.

Note that multiple calls to find_package(SOCI) that specify different components will cause all call-sides to use the superset of all requested components as targets are global (and hence also their link dependencies).

Fixes #1344