### PR TITLE
Fix Firebird and ODBC session backend classes dtors definition

### DIFF
--- a/src/backends/firebird/session.cpp
+++ b/src/backends/firebird/session.cpp
@@ -97,7 +97,7 @@ void firebird_session_backend::begin()
     }
 }
 
-firebird_session_backend::~firebird_session_backend()
+firebird_session_backend::~firebird_session_backend() noexcept(false)
 {
     cleanUp();
 }

--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -373,7 +373,7 @@ void odbc_session_backend::configure_connection()
     }
 }
 
-odbc_session_backend::~odbc_session_backend()
+odbc_session_backend::~odbc_session_backend() noexcept(false)
 {
     clean_up();
 }


### PR DESCRIPTION
Add missing "noexcept(false)" to them -- definition must match the declaration, but didn't (and yet this somehow compiled fine).