### PR TITLE
Use debuginfod in Ubuntu CI jobs if it is available

### DIFF
--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -28,15 +28,25 @@ case "$(uname)" in
         # progress" errors.
         for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
 
-        codename=$(lsb_release --codename --short)
-        # Enable the `-dbgsym` repositories.
-        echo "deb http://ddebs.ubuntu.com ${codename} main restricted universe multiverse
-        deb http://ddebs.ubuntu.com ${codename}-updates main restricted universe multiverse" | \
-        sudo tee --append /etc/apt/sources.list.d/ddebs.list >/dev/null
+        # If debuginfod is available, use it as this is faster and more robust.
+        if apt-cache show debuginfod >/dev/null 2>&1; then
+            packages_to_install="$packages_to_install debuginfod"
+            # Set this variable to use debuginfod when running tests.
+            echo "DEBUGINFOD_URLS=https://debuginfod.ubuntu.com" >> "$GITHUB_ENV"
+            # Also set it in this CI step, so that install_xxx.sh files could
+            # check it and only install -dbgsym packages if it's not set.
+            export DEBUGINFOD_URLS=https://debuginfod.ubuntu.com
+        else
+            codename=$(lsb_release --codename --short)
+            # Enable the `-dbgsym` repositories.
+            echo "deb http://ddebs.ubuntu.com ${codename} main restricted universe multiverse
+            deb http://ddebs.ubuntu.com ${codename}-updates main restricted universe multiverse" | \
+            sudo tee --append /etc/apt/sources.list.d/ddebs.list >/dev/null
 
-        # Import the debug symbol archive signing key from the Ubuntu server.
-        # Note that this command works only on Ubuntu 18.04 LTS and newer.
-        run_apt install ubuntu-dbgsym-keyring
+            # Import the debug symbol archive signing key from the Ubuntu server.
+            # Note that this command works only on Ubuntu 18.04 LTS and newer.
+            run_apt install ubuntu-dbgsym-keyring
+        fi
 
         run_apt update
         run_apt install ${packages_to_install}

--- a/scripts/ci/install_odbc.sh
+++ b/scripts/ci/install_odbc.sh
@@ -11,10 +11,13 @@ run_apt remove \
     libodbc1 odbcinst1debian2 \
     unixodbc unixodbc-dev
 
-run_apt install \
-    tar bzip2 \
-    unixodbc unixodbc-dbgsym unixodbc-dev \
-    odbc-postgresql odbc-postgresql-dbgsym postgresql
+packages_to_install="tar bzip2 unixodbc unixodbc-dev odbc-postgresql postgresql"
+
+if [ -z "$DEBUGINFOD_URLS" ]; then
+    packages_to_install="$packages_to_install unixodbc-dbgsym odbc-postgresql-dbgsym"
+fi
+
+run_apt install ${packages_to_install}
 
 # Use full path to the driver library to avoid errors like
 # [01000][unixODBC][Driver Manager]Can't open lib 'psqlodbca.so' : file not found


### PR DESCRIPTION
This avoids problems with dbgsym packages that regularly get out of sync and should also be faster, as the debug symbols will only be retrieved if necessary instead of being done every time the job runs.

This commit is best viewed ignoring whitespace-only changes.