### PR TITLE
Add session::get_database_engine()

### DIFF
--- a/docs/api/backend.md
+++ b/docs/api/backend.md
@@ -294,6 +294,7 @@ public:
     virtual bool get_next_sequence_value(session&, std::string const&, long long&);
     virtual bool get_last_insert_id(session&, std::string const&, long long&);
 
+    virtual database_engine get_database_engine() const = 0;
     virtual std::string get_backend_name() const = 0;
 
     virtual statement_backend * make_statement_backend() = 0;
@@ -306,6 +307,7 @@ The object of the class derived from `session_backend` implements the internals 
 
 * `begin`, `commit`, `rollback` - Forward-called when the same functions of `session` are called by user.
 * `get_next_sequence_value`, `get_last_insert_id` - Called to retrieve sequences or auto-generated values and every backend should define at least one of them to allow the code using auto-generated values to work.
+* `get_database_engine`, `get_backend_name` - Must be overridden to return information about the database being used. Note that some backends may support multiple database engines, e.g. ODBC backend may be used with any engine.
 * `make_statement_backend`, `make_rowid_backend`, `make_blob_backend` - Called to create respective implementations for the `statement`, `rowid` and `blob` classes.
 
 ```cpp

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -87,6 +87,8 @@ public:
     std::string get_dummy_from_table() const;
     std::string get_dummy_from_clause() const;
 
+    database_engine get_database_engine() const;
+
     details::session_backend * get_backend();
 
     std::string get_backend_name() const;
@@ -135,6 +137,7 @@ sql << "drop table persons";
 * `get_last_query` retrieves the text of the last used query.
 * `uppercase_column_names` allows to force all column names to uppercase in dynamic row description; this function is particularly useful for portability, since various database servers report column names differently (some preserve case, some change it).
 * `get_dummy_from_table` and `get_dummy_from_clause()`: helpers for writing portable DML statements, see [DML helpers](../utilities.md#dml) for more details.
+* `get_database_engine` returns the database engine type of the current session, which can be useful if database-specific SQL dialect needs to be used. Avoid this function if possible to keep the code portable across different database engines.
 * `get_backend` returns the internal pointer to the concrete backend implementation of the session. This is provided for advanced users that need access to the functionality that is not otherwise available.
 * `get_backend_name` is a convenience forwarder to the same function of the backend object.
 

--- a/include/soci/db2/soci-db2.h
+++ b/include/soci/db2/soci-db2.h
@@ -256,6 +256,8 @@ struct SOCI_DB2_DECL db2_session_backend : details::session_backend
 
     std::string get_dummy_from_table() const override { return "sysibm.sysdummy1"; }
 
+    database_engine get_database_engine() const override { return database_engine::db2; }
+
     std::string get_backend_name() const override { return "DB2"; }
 
     void clean_up();

--- a/include/soci/empty/soci-empty.h
+++ b/include/soci/empty/soci-empty.h
@@ -165,6 +165,8 @@ struct SOCI_EMPTY_DECL empty_session_backend : details::session_backend
 
     std::string get_dummy_from_table() const override { return std::string(); }
 
+    database_engine get_database_engine() const override { return database_engine::unknown; }
+
     std::string get_backend_name() const override { return "empty"; }
 
     void clean_up();

--- a/include/soci/firebird/soci-firebird.h
+++ b/include/soci/firebird/soci-firebird.h
@@ -315,6 +315,8 @@ struct SOCI_FIREBIRD_DECL firebird_session_backend : details::session_backend
 
     std::string get_dummy_from_table() const override { return "rdb$database"; }
 
+    database_engine get_database_engine() const override { return database_engine::firebird; }
+
     std::string get_backend_name() const override { return "firebird"; }
 
     void cleanUp();

--- a/include/soci/mysql/soci-mysql.h
+++ b/include/soci/mysql/soci-mysql.h
@@ -246,6 +246,8 @@ struct SOCI_MYSQL_DECL mysql_session_backend : details::session_backend
     // syntaxes, but there doesn't seem to be any reason to use the longer one.
     std::string get_dummy_from_table() const override { return std::string(); }
 
+    database_engine get_database_engine() const override { return database_engine::mysql; }
+
     std::string get_backend_name() const override { return "mysql"; }
 
     void clean_up();

--- a/include/soci/odbc/soci-odbc.h
+++ b/include/soci/odbc/soci-odbc.h
@@ -353,6 +353,8 @@ struct SOCI_ODBC_DECL odbc_session_backend : details::session_backend
 
     std::string get_dummy_from_table() const override;
 
+    database_engine get_database_engine() const override;
+
     std::string get_backend_name() const override { return "odbc"; }
 
     void configure_connection();

--- a/include/soci/oracle/soci-oracle.h
+++ b/include/soci/oracle/soci-oracle.h
@@ -446,6 +446,8 @@ struct SOCI_ORACLE_DECL oracle_session_backend : details::session_backend
 
     std::string get_dummy_from_table() const override { return "dual"; }
 
+    database_engine get_database_engine() const override { return database_engine::oracle; }
+
     std::string get_backend_name() const override { return "oracle"; }
 
     void clean_up();

--- a/include/soci/postgresql/soci-postgresql.h
+++ b/include/soci/postgresql/soci-postgresql.h
@@ -423,6 +423,8 @@ struct SOCI_POSTGRESQL_DECL postgresql_session_backend : details::session_backen
 
     std::string get_dummy_from_table() const override { return std::string(); }
 
+    database_engine get_database_engine() const override { return database_engine::postgresql; }
+
     std::string get_backend_name() const override { return "postgresql"; }
 
     void clean_up();

--- a/include/soci/session.h
+++ b/include/soci/session.h
@@ -9,6 +9,7 @@
 #define SOCI_SESSION_H_INCLUDED
 
 #include "soci/soci-platform.h"
+#include "soci/soci-defs.h"
 #include "soci/once-temp-type.h"
 #include "soci/query_transformation.h"
 #include "soci/connection-parameters.h"
@@ -212,6 +213,11 @@ public:
 
     // Sets the failover callback object.
     void set_failover_callback(failover_callback & callback);
+
+
+    // This function should be avoided if possible, but may sometimes be useful
+    // for writing database-specific code not covered by the existing SOCI API.
+    database_engine get_database_engine() const;
 
     // for diagnostics and advanced users
     // (downcast it to expected back-end session class)

--- a/include/soci/soci-backend.h
+++ b/include/soci/soci-backend.h
@@ -9,6 +9,7 @@
 #define SOCI_BACKEND_H_INCLUDED
 
 #include "soci/soci-platform.h"
+#include "soci/soci-defs.h"
 #include "soci/error.h"
 // std
 #include <cstddef>
@@ -554,6 +555,8 @@ public:
         failoverCallback_ = &callback;
         session_ = &sql;
     }
+
+    virtual database_engine get_database_engine() const = 0;
 
     virtual std::string get_backend_name() const = 0;
 

--- a/include/soci/soci-defs.h
+++ b/include/soci/soci-defs.h
@@ -1,0 +1,31 @@
+//
+// Copyright (C) 2026 Vadim Zeitlin
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// https://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef SOCI_DEFS_H_INCLUDED
+#define SOCI_DEFS_H_INCLUDED
+
+// This header contains miscellaneous simple definitions used by SOCI.
+
+namespace soci
+{
+
+// Type of the database engine used by SOCI session.
+enum class database_engine
+{
+    unknown = 0,
+    db2,
+    firebird,
+    mssql,
+    mysql,
+    oracle,
+    postgresql,
+    sqlite3,
+};
+
+} // namespace soci
+
+#endif // SOCI_DEFS_H_INCLUDED

--- a/include/soci/sqlite3/soci-sqlite3.h
+++ b/include/soci/sqlite3/soci-sqlite3.h
@@ -320,6 +320,8 @@ struct SOCI_SQLITE3_DECL sqlite3_session_backend : details::session_backend
 
     std::string get_dummy_from_table() const override { return std::string(); }
 
+    database_engine get_database_engine() const override { return database_engine::sqlite3; }
+
     std::string get_backend_name() const override { return "sqlite3"; }
 
     void clean_up();

--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -568,6 +568,41 @@ std::string odbc_session_backend::get_dummy_from_table() const
     return table;
 }
 
+database_engine odbc_session_backend::get_database_engine() const
+{
+    switch ( get_database_product() )
+    {
+        case prod_db2:
+            return database_engine::db2;
+
+        case prod_firebird:
+            return database_engine::firebird;
+
+        case prod_mssql:
+            return database_engine::mssql;
+
+        case prod_mysql:
+            return database_engine::mysql;
+
+        case prod_oracle:
+            return database_engine::oracle;
+
+        case prod_postgresql:
+            return database_engine::postgresql;
+
+        case prod_sqlite:
+            return database_engine::sqlite3;
+
+            // These cases are here just to make the switch exhaustive, we
+            // can't really do anything about them anyhow.
+        case prod_unknown:
+        case prod_uninitialized:
+            break;
+    }
+
+    return database_engine::unknown;
+}
+
 void odbc_session_backend::reset_transaction()
 {
     SQLRETURN rc = SQLSetConnectAttr( hdbc_, SQL_ATTR_AUTOCOMMIT,

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -91,6 +91,7 @@ target_sources(soci_core
       "${PROJECT_SOURCE_DIR}/include/soci/rowset.h"
       "${PROJECT_SOURCE_DIR}/include/soci/session.h"
       "${PROJECT_SOURCE_DIR}/include/soci/soci-backend.h"
+      "${PROJECT_SOURCE_DIR}/include/soci/soci-defs.h"
       "${PROJECT_SOURCE_DIR}/include/soci/soci-platform.h"
       "${PROJECT_SOURCE_DIR}/include/soci/soci-simple.h"
       "${PROJECT_SOURCE_DIR}/include/soci/soci-types.h"

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -730,6 +730,13 @@ void session::set_failover_callback(failover_callback & callback)
     backEnd_->set_failover_callback(callback, *this);
 }
 
+database_engine session::get_database_engine() const
+{
+    ensureConnected(backEnd_);
+
+    return backEnd_->get_database_engine();
+}
+
 std::string session::get_backend_name() const
 {
     ensureConnected(backEnd_);


### PR DESCRIPTION
The use of this function is discouraged but it may sometimes be necessary and get_backend_name() is insufficient to determine the database being used because ODBC backend can be used with any of them.