### PR TITLE
Test building SOCI with multiple enabled backends in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,10 @@ jobs:
             cxxstd: 17
             name: SQLite3 Cxx17
           - lib_type: shared
-            backend: Empty
+            backend: All
             runner: ubuntu-24.04
             test_release_package: true
-            name: Release package
+            name: Release with all backends
           - lib_type: shared
             backend: Empty
             runner: ubuntu-24.04

--- a/scripts/ci/build_all.sh
+++ b/scripts/ci/build_all.sh
@@ -6,8 +6,75 @@
 source ${SOCI_SOURCE_DIR}/scripts/ci/common.sh
 
 # We don't use the default options here, as we don't want to turn off all the
-# backends.
-cmake ${SOCI_COMMON_CMAKE_OPTIONS} \
-    ..
+# backends, but rather enable all of those for which install_all.sh installs
+# the dependencies -- which doesn't include DB2 and Oracle, so these two are
+# explicitly disabled.
+#
+# Note that the backends are enabled explicitly, and not left at their default
+# "AUTO" value, in order to fail if any of them can't be built instead of just
+# silently skipping it.
+#
+# Also note that ASAN has to be disabled because of the problems with it when
+# using ODBC, see https://github.com/SOCI/soci/issues/1008.
+#
+# Finally, we don't run the tests for most of the backends here, as doing it
+# would require setting up all the database servers, so we don't even build
+# them, with the exception of the SQLite3 tests which don't need any server at
+# all and so allow us to check that the library actually works.
+run_cmake_for_all()
+{
+    cmake ${SOCI_COMMON_CMAKE_OPTIONS} \
+        -DSOCI_ASAN=OFF \
+        -DSOCI_DB2=OFF \
+        -DSOCI_EMPTY=OFF \
+        -DSOCI_FIREBIRD=ON \
+        -DSOCI_FIREBIRD_SKIP_TESTS=ON \
+        -DSOCI_MYSQL=ON \
+        -DSOCI_MYSQL_SKIP_TESTS=ON \
+        -DSOCI_ODBC=ON \
+        -DSOCI_ODBC_SKIP_TESTS=ON \
+        -DSOCI_ORACLE=OFF \
+        -DSOCI_POSTGRESQL=ON \
+        -DSOCI_POSTGRESQL_SKIP_TESTS=ON \
+        -DSOCI_SQLITE3=ON \
+        ..
+}
 
+run_cmake_for_all
 run_make
+
+# Test release branch packaging and building from the package
+if [[ "$TEST_RELEASE_PACKAGE" == "YES" ]] && [[ "$SOCI_CI_BRANCH" =~ ^release/[3-9]\.[0-9]$ ]]; then
+    ME=`basename "$0"`
+
+    run_apt update
+    run_apt install python3-venv
+
+    SOCI_VERSION=$(cat "$SOCI_SOURCE_DIR/include/soci/version.h" | grep -Po "(.*#define\s+SOCI_LIB_VERSION\s+.+)\K([3-9]_[0-9]_[0-9])" | sed "s/_/\./g")
+    if [[ ! "$SOCI_VERSION" =~ ^[4-9]\.[0-9]\.[0-9]$ ]]; then
+        echo "${ME} ERROR: Invalid format of SOCI version '$SOCI_VERSION'. Aborting."
+        exit 1
+    else
+        echo "${ME} INFO: Creating source package 'soci-${SOCI_VERSION}.tar.gz' from '$SOCI_CI_BRANCH' branch"
+    fi
+
+    cd $SOCI_SOURCE_DIR
+    $SOCI_SOURCE_DIR/scripts/release.sh --use-local-branch $SOCI_CI_BRANCH
+
+    if [[ ! -f "soci-${SOCI_VERSION}.tar.gz" ]]; then
+        echo "${ME} ERROR: Archive file 'soci-${SOCI_VERSION}.tar.gz' not found. Aborting."
+        exit 1
+    fi
+
+    echo "${ME} INFO: Unpacking source package 'soci-${SOCI_VERSION}.tar.gz'"
+    tar -xzf soci-${SOCI_VERSION}.tar.gz
+
+    echo "${ME} INFO: Building SOCI from source package 'soci-${SOCI_VERSION}.tar.gz'"
+    cd soci-${SOCI_VERSION}
+    mkdir _build
+    echo $PWD
+
+    run_cmake_for_all
+    run_make
+    run_test
+fi

--- a/scripts/ci/build_empty.sh
+++ b/scripts/ci/build_empty.sh
@@ -32,39 +32,3 @@ if [[ "$BUILD_EXAMPLES" == "YES" ]]; then
   # This example simulates SOCI being installed on the target system
   build_example connect
 fi
-
-# Test release branch packaging and building from the package
-if [[ "$TEST_RELEASE_PACKAGE" == "YES" ]] && [[ "$SOCI_CI_BRANCH" =~ ^release/[3-9]\.[0-9]$ ]]; then
-    ME=`basename "$0"`
-
-    run_apt update
-    run_apt install python3-venv
-
-    SOCI_VERSION=$(cat "$SOCI_SOURCE_DIR/include/soci/version.h" | grep -Po "(.*#define\s+SOCI_LIB_VERSION\s+.+)\K([3-9]_[0-9]_[0-9])" | sed "s/_/\./g")
-    if [[ ! "$SOCI_VERSION" =~ ^[4-9]\.[0-9]\.[0-9]$ ]]; then
-        echo "${ME} ERROR: Invalid format of SOCI version '$SOCI_VERSION'. Aborting."
-        exit 1
-    else
-        echo "${ME} INFO: Creating source package 'soci-${SOCI_VERSION}.tar.gz' from '$SOCI_CI_BRANCH' branch"
-    fi
-
-    cd $SOCI_SOURCE_DIR
-    $SOCI_SOURCE_DIR/scripts/release.sh --use-local-branch $SOCI_CI_BRANCH
-
-    if [[ ! -f "soci-${SOCI_VERSION}.tar.gz" ]]; then
-        echo "${ME} ERROR: Archive file 'soci-${SOCI_VERSION}.tar.gz' not found. Aborting."
-        exit 1
-    fi
-
-    echo "${ME} INFO: Unpacking source package 'soci-${SOCI_VERSION}.tar.gz'"
-    tar -xzf soci-${SOCI_VERSION}.tar.gz
-
-    echo "${ME} INFO: Building SOCI from source package 'soci-${SOCI_VERSION}.tar.gz'"
-    cd soci-${SOCI_VERSION}
-    mkdir _build
-    echo $PWD
-
-    run_cmake_for_empty
-    run_make
-    run_test
-fi

--- a/scripts/ci/install_all.sh
+++ b/scripts/ci/install_all.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Install the dependencies of all the backends built by build_all.sh
+#
+# Copyright (c) 2026 Vadim Zeitlin <vz-soci@zeitlins.org>
+#
+source ${SOCI_SOURCE_DIR}/scripts/ci/common.sh
+
+# Note that we only need the client libraries here, and not the database
+# servers themselves, as this build doesn't run any tests using them.
+#
+# Oracle is not installed because we'd need the server just to get the client
+# headers and libraries.
+
+# Remove buggy versions of the ODBC packages from Microsoft repositories as
+# well as their dependencies, just as install_odbc.sh does.
+run_apt remove \
+    libodbc1 odbcinst1debian2 \
+    unixodbc unixodbc-dev
+
+run_apt install \
+    firebird-dev \
+    libmysqlclient-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    unixodbc-dev


### PR DESCRIPTION
CI jobs always tested building SOCI with a single backend enabled, so we would never detect any potential problems due to using multiple backends at once. We also had a completely unused scripts/ci/build_all.sh which was confusing.

Solve both problems at once by starting to use this script instead of using "empty" backend for the job testing release packaging. This is more realistic too.

Most of the changes here just move the release packaging fragment from build_empty.sh to build_all.sh, so it is recommended to view this commit with Git --color-moved option.