### PR TITLE
Fix possible crashes on unloading dynamically loaded SOCI library

### DIFF
--- a/docs/connections.md
+++ b/docs/connections.md
@@ -33,6 +33,8 @@ The usage is similar to the above, but instead of providing the factory object, 
 session sql("postgresql", "dbname=mydb");
 ```
 
+Note: a dynamic/shared library corresponding to the backend name will be loaded and remain loaded until the application exit. If you want to unload it earlier, you can call `unload("postgresql")` or `unload_all()` functions, both of which are found in `soci::dynamic_backends` namespace. Also note that if you are loading the SOCI core library itself dynamically, using `dlopen()` (which also includes the case of using SOCI in a normal way from a shared library which is itself loaded dynamically, i.e. any kind of plugin) or `LoadLibrary()`, you need to ensure that no SOCI objects remain alive and call `unload_all()` before unloading the SOCI core library itself, otherwise both this library and any dynamically loaded backends will remain in memory.
+
 For convenience, the URL-like form that combines both the backend name with connection parameters is supported as well:
 
 ```cpp

--- a/src/core/backend-loader.cpp
+++ b/src/core/backend-loader.cpp
@@ -133,9 +133,13 @@ std::string get_this_dynlib_path()
 
     std::string path = di.dli_fname;
 
+    // Note that if the path contains just the file name, it can't be used as a
+    // search path, so use the current directory in this case instead.
     auto const last_sep = path.rfind('/');
     if ( last_sep != std::string::npos )
         path.erase(last_sep);
+    else
+        path = ".";
 
     return path;
 }
@@ -250,17 +254,6 @@ std::vector<std::string>& get_default_search_paths()
 
     return paths;
 }
-
-// used to automatically initialize the global state
-struct static_state_mgr
-{
-    static_state_mgr() = default;
-
-    ~static_state_mgr()
-    {
-        unload_all();
-    }
-} static_state_mgr_;
 
 // non-synchronized helpers for the other functions
 factory_map::iterator do_unload(factory_map::iterator i)


### PR DESCRIPTION
There were multiple problems with calling unload_all() from the static object destructor:

1. Under Windows, this is explicitly disallowed when the destructor is executed under the global loader lock, which is the case when SOCI is built as a shared library, so never do it there.

2. Under Unix, this could result in unloading the core library itself, containing unload_all() code, if SOCI core was dynamically loaded using dlopen() or was linked in a usual way into another shared library which was loading with dlopen(), i.e. any kind of plugin.

Fix this by simply not trying to unload the backends automatically from a global object destructor and document that unload_all() must be called if it is really important to unload them.

Also mention unload(), which previously didn't appear in the documentation at all, just like unload_all().