### PR TITLE
Implement get_next_sequence_value() for SQL Server in ODBC backend

### DIFF
--- a/src/backends/odbc/session.cpp
+++ b/src/backends/odbc/session.cpp
@@ -445,6 +445,9 @@ bool odbc_session_backend::get_next_sequence_value(
             break;
 
         case prod_mssql:
+            query = "select next value for " + sequence;
+            break;
+
         case prod_mysql:
         case prod_sqlite:
             // These RDBMS implement get_last_insert_id() instead.

--- a/tests/odbc/test-odbc-mssql.cpp
+++ b/tests/odbc/test-odbc-mssql.cpp
@@ -201,6 +201,28 @@ TEST_CASE("MS SQL table records count", "[odbc][mssql][count]")
     CHECK(hasTables);
 }
 
+struct table_creator_for_sequence : table_creator_base
+{
+    table_creator_for_sequence(soci::session & sql)
+        : table_creator_base(sql, "seqtest")
+    {
+        sql << "create sequence seqtest start with 101 increment by 1";
+    }
+};
+
+TEST_CASE("next sequence value", "[odbc][mssql][get_next_sequence_value()]")
+{
+    soci::session sql(backEnd, connectString);
+    table_creator_for_sequence tableCreator(sql);
+
+    long long val = -1;
+    CHECK(sql.get_next_sequence_value("seqtest", val));
+    CHECK(val == 101);
+
+    CHECK(sql.get_next_sequence_value("seqtest", val));
+    CHECK(val == 102);
+}
+
 // DDL Creation objects for common tests
 struct table_creator_one : public table_creator_base
 {


### PR DESCRIPTION
SQL Server supports sequences, so implement this function when using it.

Add a unit test checking that it works as expected.